### PR TITLE
Issue #114 - Spec argument range of createBuffer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -929,10 +929,9 @@ interface <dfn id="dfn-AudioContext">AudioContext</dfn> : EventTarget {
   <dt id="dfn-createBuffer">The <code>createBuffer</code> method</dt>
     <dd><p>Creates an AudioBuffer of the given size. The audio data in the
       buffer will be zero-initialized (silent).  An NOT_SUPPORTED_ERR exception MUST be thrown if
-      the <code>numberOfChannels</code> or <code>sampleRate</code> are out-of-bounds,
-      or if length is 0.</p>
+      any of the arguments is negative, zero, or outside its nominal range.</p>
       <p>The <dfn id="dfn-numberOfChannels">numberOfChannels</dfn> parameter
-      determines how many channels the buffer will have.  An implementation must support at least 32 channels. </p>
+      determines how many channels the buffer will have. An implementation must support at least 32 channels. </p>
       <p>The <dfn id="dfn-length">length</dfn> parameter determines the size of
       the buffer in sample-frames. </p>
       <p>The <dfn id="dfn-sampleRate_2">sampleRate</dfn> parameter describes


### PR DESCRIPTION
Issue #114: Those can only be non-null positive and inside their eventual nominal range.
INDEX_SIZE_ERR is thrown if this is not the case.
