### PR TITLE
Propose additions to AnalyserNode for getting complex data

### DIFF
--- a/index.html
+++ b/index.html
@@ -3043,10 +3043,13 @@ interface <dfn id="dfn-AnalyserNode">AnalyserNode</dfn> : AudioNode {
 <dl>
   <dt id="dfn-getFloatFrequencyData">The <code>getFloatFrequencyData</code>
   method</dt>
-    <dd><p>Copies the current frequency data into the passed floating-point
-      array. If the array has fewer elements than the frequencyBinCount, the
-      excess elements will be dropped. If the array has more elements than
-      the frequencyBinCount, the excess elements will be ignored.</p>
+    <dd>
+      <p>Copies the magnitude (the square root of the sum of the
+      squared real and imaginary components ) of the current frequency
+      data into the passed floating-point array. If the array has
+      fewer elements than the frequencyBinCount, the excess elements
+      will be dropped. If the array has more elements than the
+      frequencyBinCount, the excess elements will be ignored.</p>
       <p>The <dfn id="dfn-array">array</dfn> parameter is where
       frequency-domain analysis data will be copied. </p>
     </dd>
@@ -3054,10 +3057,13 @@ interface <dfn id="dfn-AnalyserNode">AnalyserNode</dfn> : AudioNode {
 <dl>
   <dt id="dfn-getByteFrequencyData">The <code>getByteFrequencyData</code>
   method</dt>
-    <dd><p>Copies the current frequency data into the passed unsigned byte
-      array. If the array has fewer elements than the frequencyBinCount, the
-      excess elements will be dropped. If the array has more elements than
-      the frequencyBinCount, the excess elements will be ignored.</p>
+    <dd>
+      <p>Copies the magnitude (the square root of the sum of the
+      squared real and imaginary components ) of the current frequency
+      data into the passed unsigned byte array. If the array has fewer
+      elements than the frequencyBinCount, the excess elements will be
+      dropped. If the array has more elements than the
+      frequencyBinCount, the excess elements will be ignored.</p>
       <p>The <dfn id="dfn-array_2">array</dfn> parameter is where
       frequency-domain analysis data will be copied. </p>
     </dd>


### PR DESCRIPTION
This proposal, based on the feedback[1] on the public-audio mailing
list, adds two methods to get the complex (real and imaginary) values of
the frequency data calculated in the `AnalyserNode`.

[1] http://lists.w3.org/Archives/Public/public-audio/2013JulSep/1925.html
