### PR TITLE
Define oscillator phases for the predefined types.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3629,7 +3629,7 @@ This is a basic and well understood principle of audio DSP.
 
 <p>
 There are several practical approaches that an implementation may take to avoid this aliasing.
-But regardless of approach, the <em>idealized</em> discrete-time digital audio signal is well defined mathematically.
+But regardless of approach, the <a href="#oscillatorTypes-OscillatorNode"><em>idealized</em> discrete-time digital audio signal</a> is well defined mathematically.
 The trade-off for the implementation is a matter of implementation cost (in terms of CPU usage) versus fidelity to
 achieving this ideal.
 </p>
@@ -3749,25 +3749,25 @@ interface <dfn id="dfn-OscillatorNode">OscillatorNode</dfn> : AudioNode {
 
 <div id="oscillatorTypes-OscillatorNode-section" class="section">
 <h3 id="oscillatorTypes-OscillatorNode">4.23.3. Oscillator Types</h3>
-The mathematical waveforms for the various oscillator types are defined here. In summary,
+The idealized mathematical waveforms for the various oscillator types are defined here. In summary,
 all waveforms are defined mathematically to be an odd function with a positive slope at time
-0. 
+0. The actual waveforms produced by the oscillator may differ to prevent aliasing affects.
 <div id="oscillatorSin-OscillatorNode-section" class="section">
 <h4 id="oscillatorSin-OscillatorNode">4.23.3.1 "sine"</h3>
 The waveform for sine oscillator is sin(t).
 </div>        
 <div id="oscillatorSquare-OscillatorNode-section" class="section">
 <h4 id="oscillatorSquare-OscillatorNode">4.23.3.2 "square"</h3>
-The waveform for the square wave oscillator is 1 for 0<= t < &pi; and -1 for -&pi; < t < 0.
+The waveform for the square wave oscillator is 1 for 0&le; t &lt; &pi; and -1 for -&pi; &lt; t &lt; 0.
 </div>        
 <div id="oscillatorSawtooth-OscillatorNode-section" class="section">
 <h4 id="oscillatorSawTooth-OscillatorNode">4.23.3.2 "sawtooth"</h3>
-The waveform for the sawtooth oscillator is the ramp t/&pi; for -&pi; < t <= &pi;.
+The waveform for the sawtooth oscillator is the ramp t/&pi; for -&pi; &lt; t &le; &pi;.
 </div>        
 <div id="oscillatorTriangle-OscillatorNode-section" class="section">
 <h4 id="oscillatorTriangle-OscillatorNode">4.23.3.2 "triangle"</h3>
-The waveform for the triangle oscillator is 2/&pi;*t for 0 <= t <= &pi;/2 and
-1-2/&pi;*(t-&pi;/2) for &pi;/2 < t <= &pi;. This is extended to all t by using the fact
+The waveform for the triangle oscillator is 2/&pi;*t for 0 &le; t &le; &pi;/2 and
+1-2/&pi;*(t-&pi;/2) for &pi;/2 &lt; t &le; &pi;. This is extended to all t by using the fact
 that the waveform is an odd function with period 2&pi;.        
 </div>        
 </div>


### PR DESCRIPTION
Define the oscillator waveform (and hence the phase) for each of the predefined oscillator types.

HTML markup almost certainly needs reviewing in addition to the actual text.
