### PR TITLE
ConvolverNode.buffer supports 1, 2, or 4 channels or an error is thrown

### DIFF
--- a/index.html
+++ b/index.html
@@ -2844,9 +2844,9 @@ interface <dfn id="dfn-ConvolverNode">ConvolverNode</dfn> : AudioNode {
     <dd><p>A mono, stereo, or 4-channel <code>AudioBuffer</code> containing the
     (possibly multi-channel) impulse response used by the ConvolverNode.  The 
     <code>AudioBuffer</code> must have 1, 2, or 4 channels or a NOT_SUPPORTED_ERR 
-    exception must be thrown.
+    exception MUST be thrown.
     This <code>AudioBuffer</code> must be of the same sample-rate as the AudioContext
-    or an NOT_SUPPORTED_ERR exception MUST be thrown.  At the time when this
+    or a NOT_SUPPORTED_ERR exception MUST be thrown.  At the time when this
     attribute is set, the <em>buffer</em> and the state of the
     <em>normalize</em> attribute will be used to configure the ConvolverNode
     with this impulse response having the given normalization.  The initial


### PR DESCRIPTION
Fix for issue 305
