### PR TITLE
Throw errors for negative or non-finite time and/or duration values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1704,7 +1704,7 @@ of a <em>SetValueCurve</em> event at time T and duration D.</li>
       parameter will change to at the given time.</p>
       <p>The <dfn id="dfn-startTime_2">startTime</dfn> parameter is the time in the same time
       coordinate system as AudioContext.currentTime.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.
       </p>
       <p>
       If there are no more events after this <em>SetValue</em> event, then for t >= startTime,  v(t) = value.  In other words, the value will remain constant.
@@ -1728,7 +1728,7 @@ of a <em>SetValueCurve</em> event at time T and duration D.</li>
       <p>The <dfn id="dfn-value_3">value</dfn> parameter is the value the
       parameter will linearly ramp to at the given time.</p>
       <p>The <dfn id="dfn-endTime_3">endTime</dfn> parameter is the time in the same time coordinate system as AudioContext.currentTime.</p>
-      An INVALID_STATE_ERR exception MUST be thrown if <code>endTime</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>endTime</code> is negative or is not a finite number.
       <p>
       The value during the time interval T0 &lt;= t &lt; T1 (where T0 is the time of the previous event and T1 is the endTime parameter passed into this method)
       will be calculated as:
@@ -1756,7 +1756,7 @@ of a <em>SetValueCurve</em> event at time T and duration D.</li>
       parameter will exponentially ramp to at the given time.  A NOT_SUPPORTED_ERR exception MUST be thrown if this value is less than
       or equal to 0, or if the value at the time of the previous event is less than or equal to 0.</p>
       <p>The <dfn id="dfn-endTime_4">endTime</dfn> parameter is the time in the same time coordinate system as AudioContext.currentTime.</p>
-      An INVALID_STATE_ERR exception MUST be thrown if <code>endTime</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>endTime</code> is negative or is not a finite number.
       <p>
       The value during the time interval T0 &lt;= t &lt; T1 (where T0 is the time of the previous event and T1 is the endTime parameter passed into this method)
       will be calculated as:
@@ -1785,13 +1785,13 @@ of a <em>SetValueCurve</em> event at time T and duration D.</li>
       the parameter will <em>start</em> changing to at the given time.</p>
       <p>The <dfn id="dfn-startTime">startTime</dfn> parameter is the time in the same time
       coordinate system as AudioContext.currentTime.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>start</code> is negative or is not a finite number.                    
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>start</code> is negative or is not a finite number.                    
       </p>
       <p>The <dfn id="dfn-timeConstant">timeConstant</dfn> parameter is the
       time-constant value of first-order filter (exponential) approach to the
       target value. The larger this value is, the slower the transition will
       be.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>timeConstant</code> is negative or zero or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>timeConstant</code> is negative or zero or is not a finite number.
       </p>
       <p>
       More precisely, <em>timeConstant</em> is the time it takes a first-order linear continuous time-invariant system
@@ -1821,12 +1821,12 @@ of a <em>SetValueCurve</em> event at time T and duration D.</li>
       the given time and lasting for the given duration. </p>
       <p>The <dfn id="dfn-startTime_5">startTime</dfn> parameter is the time in the same time
       coordinate system as AudioContext.currentTime.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.
       </p>
       <p>The <dfn id="dfn-duration_5">duration</dfn> parameter is the
       amount of time in seconds (after the <em>time</em> parameter) where values will be calculated
       according to the <em>values</em> parameter.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>duration</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>duration</code> is negative or is not a finite number.
       </p>
       <p>
       During the time interval: <em>startTime</em> &lt;= t &lt; <em>startTime</em> + <em>duration</em>, values will be calculated:
@@ -2247,12 +2247,12 @@ Parameters</h3>
       this value or if the value is less than <b>currentTime</b>, then the
       sound will start playing immediately.  <code>start</code> may only be called one time
       and must be called before <code>stop</code> is called or an INVALID_STATE_ERR exception MUST be thrown.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>when</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>when</code> is negative or is not a finite number.
       </p>
       <p>The <dfn id="dfn-offset">offset</dfn> parameter describes
       the offset time in the buffer (in seconds) where playback will begin. If 0 is passed
       in for this value, then playback will start from the beginning of the buffer.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>offset</code> is negative or is not a finite
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>offset</code> is negative or is not a finite
       number.
       </p>
       <p>The <dfn id="dfn-duration">duration</dfn> parameter
@@ -2260,7 +2260,7 @@ Parameters</h3>
       the duration will be equal to the total duration of the AudioBuffer minus the <code>offset</code> parameter.
       Thus if neither <code>offset</code> nor <code>duration</code> are specified then the implied duration is
       the total duration of the AudioBuffer.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>duration</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>duration</code> is negative or is not a finite number.
       </p>
 
     </dd>
@@ -2275,7 +2275,7 @@ Parameters</h3>
       <b>currentTime</b>, then the sound will stop playing immediately.
       <code>stop</code> must only be called one time and only after a call to <code>start</code> or <code>stop</code>,
       or an INVALID_STATE_ERR exception MUST be thrown.
-      An INVALID_STATE_ERR exception MUST be thrown if <code>when</code> is negative or is not a finite number.
+      An INVALID_ACCESS_ERR exception MUST be thrown if <code>when</code> is negative or is not a finite number.
       </p>
     </dd>
 </dl>


### PR DESCRIPTION
Fix issue #354.
