### PR TITLE
Clarify that no clipping is applied to intermediate nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3888,8 +3888,8 @@ as other architectures. </p>
   </p>
 
   <p>
-    No clipping is applied a the input or outputs of the
-    <a><code>AudioNode</code></a>, to allow a maximum of dynamic range within
+    No clipping is applied at the inputs or outputs of the
+    <a><code>AudioNode</code></a> to allow a maximum of dynamic range within
     the audio graph.
   </p>
 </section>


### PR DESCRIPTION
This fixes #366.
