### PR TITLE
Spec that subsample scheduling with AudioBufferSourceNode is impossible.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2017,8 +2017,17 @@ to the very end of the buffer.
 </p>
 
 <p>
-Please note that as a low-level implementation detail, the AudioBuffer is at a specific sample-rate (usually the same as the <a><code>AudioContext</code></a> sample-rate), and
-that the loop times (in seconds) must be converted to the appropriate sample-frame positions in the buffer according to this sample-rate.
+  Please note that as a low-level implementation detail, the AudioBuffer is at a
+  specific sample-rate (usually the same as the <a><code>AudioContext</code></a>
+  sample-rate), and that the loop times (in seconds) must be converted to the
+  appropriate sample-frame positions in the buffer according to this sample-rate.
+</p>
+<p>
+  When scheduling the beginning and the end of playback using the
+  <code>start()</code> and <code>stop()</code> methods, the resulting start or
+  stop time MUST be rounded to the nearest sample-frame in the sample rate of
+  the <a><code>AudioContext</code></a>. That is, no sub-sample scheduling is
+  possible.
 </p>
 
 </section>


### PR DESCRIPTION
This fixes #332.
