### PR TITLE
Spec that OscillatorNode phase should be conserved when `type` is set.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3710,7 +3710,8 @@ to determine a <em>computedFrequency</em> value:
       type constant values except for "custom".  The <a
       href="#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave"><code>setPeriodicWave()</code></a> method can be
       used to set a custom waveform, which results in this attribute being set to
-      "custom".  The default value is "sine".
+      "custom".  The default value is "sine". When this attribute is set, the
+      phase of the oscillator MUST be conserved.
     </dd>
 
     <dt> readonly attribute AudioParam frequency </dt>


### PR DESCRIPTION
Fixes #136.
