### PR TITLE
Add a detune attribute for the BiquadFilterNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3296,19 +3296,31 @@ in the following operation:
 <h2>The BiquadFilterNode Interface</h2>
 
 <p>
-  <a><code>BiquadFilterNode</code></a> is an <a><code>AudioNode</code></a> processor implementing very
-  common low-order filters.
+  <a><code>BiquadFilterNode</code></a> is an <a><code>AudioNode</code></a>
+  processor implementing very common low-order filters.
 </p>
 
 <p>
   Low-order filters are the building blocks of basic tone controls (bass, mid,
   treble), graphic equalizers, and more advanced filters. Multiple
-  <a><code>BiquadFilterNode</code></a> filters can be combined to form more complex filters. The
-  filter parameters such as "frequency" can be changed over time for filter
-  sweeps, etc. Each <a><code>BiquadFilterNode</code></a> can be configured as one of a number of
-  common filter types as shown in the IDL below.  The default filter type
-  is "lowpass".
+  <a><code>BiquadFilterNode</code></a> filters can be combined to form more
+  complex filters. The filter parameters such as <a><code>frequency</code></a>
+  can be changed over time for filter sweeps, etc. Each
+  <a><code>BiquadFilterNode</code></a> can be configured as one of a number of
+  common filter types as shown in the IDL below.  The default filter type is
+  <code>"lowpass"</code>.
 </p>
+
+<p>
+  Both <a><code>frequency</code></a> and <a><code>detune</code></a> are
+  <a>a-rate</a> parameters and are used together to determine a
+  <dfn id=computedFreq-biquad>computedFrequency</dfn> value:
+</p>
+
+<pre class=highlight>
+  computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
+</pre>
+
 <pre>
     numberOfInputs  : 1
     numberOfOutputs : 1
@@ -3499,7 +3511,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>k-rate</a>
     Nyquist frequency.
   </dd>
   <dt>readonly attribute AudioParam detune</dt>
-  <dd> A detune value, in cents, for the frequency</dd>
+  <dd> A detune value, in cents, for the frequency. Its default value is 0. </dd>
   <dt>readonly attribute AudioParam Q</dt>
   <dd>
     The <a href="http://en.wikipedia.org/wiki/Q_factor">Q</a> factor has a
@@ -3691,8 +3703,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>k-rate</a>
     <a>AudioContext</a>.</li>
     <li>Let <math
     title="f0"><mrow><msub><mi>f</mi><mn>0</mn></msub></mrow></math> be the
-    value of the <a><code>frequency</code></a>
-    <a><code>AudioParam</code></a>.</li>
+    value of the <a><code>computedFrequency</code></a>.
     <li>Let <math title="dbGain"><mi>dbGain</mi></math> be the value of the
     <a><code>gain</code></a> <a><code>AudioParam</code></a>.</li>
     <li>Let <math title="Q"><mi>Q</mi></math> be the value of the


### PR DESCRIPTION
This is on top of the filter type definition branch and fixes #64 
