### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@ function playSound() {
 send with a dynamics compressor at the final output stage: </p>
 <figure>
   <img alt="modular routing2" src="images/modular-routing2.png" />
-  <figcaption>A more complex example of modular rounting.</figcaption>
+  <figcaption>A more complex example of modular routing.</figcaption>
 </figure>
 
 <pre class="highlight example">
@@ -1189,7 +1189,7 @@ way that other EventTargets accept events.
   <dd>
     <p>
       Determines how channels will be counted when up-mixing and down-mixing
-      connections to any inputs to the node .  This attribute has no effect
+      connections to any inputs to the node. This attribute has no effect
       for nodes with no inputs.
     </p>
     <p>


### PR DESCRIPTION
- modular rounting -> modular routing
- to the node .  This -> to the node. This
