### PR TITLE
Fix typo and state that any change to a different state fires the onstatechange event

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,8 +554,8 @@ cases, only a single <a><code>AudioContext</code></a> is used per document.</p>
     <a><code>AudioContext</code></a> when the state of the AudioContext has changed (i.e. when the
     corresponding promise would have resolved). An event of type <a><code>Event</code></a> will be 
     dispatched to the event handler, which can query the AudioContext's state directly.  A 
-    newly-created AudioContext will always begin in the "paused" state, and a state change event will be fired 
-    when it transitions to "running".
+    newly-created AudioContext will always begin in the "suspended" state, and a state change event will be fired 
+    whenever the state changes to a different state.
   </dd>
 
   <dt>AudioBuffer createBuffer()</dt>


### PR DESCRIPTION
Fix #433.
