### PR TITLE
Make StereoPannerNode a-rate and spec the algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -6424,7 +6424,11 @@ Quad up-mix:
             </pre>
             Or when panning stereo to stereo:
             <pre class="highlight">
-  x = azimuth + 1;
+  if (azymuth &lt;= 0) {
+    x = azimuth + 1;
+  } else {
+    x = azimuth;
+  }
             </pre>
           </li>
         </ol>


### PR DESCRIPTION
It was somewhat obvious, but it's clearer to also have the formulas for [-1, +1]. Also I made it a a-rate mostly because it's technically just two gain nodes with carefully computed values, and gain nodes are a-rate.

This fixes #439.
