### PR TITLE
channelCountMode for the AnalyserNode should be "max"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3101,7 +3101,7 @@ float calculateNormalizationScale(buffer)
     numberOfOutputs : 1    <em>Note that this output may be left unconnected.</em>
 
     channelCount = 1;
-    channelCountMode = "explicit";
+    channelCountMode = "max";
     channelInterpretation = "speakers";
 </pre>
 


### PR DESCRIPTION
So it respects the paragraph above: "The audio stream will be passed un-processed from input to output".

This fixes #450.
