### PR TITLE
Fix issue 471: Default panner is equal-power.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2694,7 +2694,7 @@ The output of this node is hard-coded to stereo (2 channels) and
 <p>
   The <a><code>PanningModelType</code></a> enum determines which spatialization
   algorithm will be used to position the audio in 3D space. The default is
-  <code>"equal-power"</code>.
+  <code>"equalpower"</code>.
 </p>
 <dl title="enum PanningModelType" class=idl>
   <dt>equalpower</dt>
@@ -2739,10 +2739,10 @@ default is "inverse".
 
 <dl title="interface PannerNode : AudioNode" class=idl>
 
-    <!--<dt>// Default for stereo is HRTF</dt>-->
+    <!--<dt>// Default for stereo is equalpower</dt>-->
     <dt>attribute PanningModelType panningModel</dt>
     <dd> Specifies the panning model used by this <a><code>PannerNode</code></a>. Defaults to
-    <a><code>"HRTF"</code></a>.</dd>
+    <a><code>"equalpower"</code></a>.</dd>
 
     <!--<dt> // Uses a 3D cartesian coordinate system </dt>-->
     <dt>void setPosition(float x, float y, float z)</dt>
@@ -6484,7 +6484,7 @@ Quad up-mix:
       <p>This requires a set of HRTF impulse responses recorded at a variety of
       azimuths and elevations. There are a small number of open/free impulse
       responses available. The implementation requires a highly optimized
-      convolution function. It is somewhat more costly than "equal-power", but
+      convolution function. It is somewhat more costly than "equalpower", but
       provides a more spatialized sound. </p>
       <figure>
         <img alt="HRTF panner" src="images/HRTF_panner.png" />


### PR DESCRIPTION
Primarily fixes the typo in the description of the panningModel
attribute that says HRTF is the default. Also updated a couple of
places where the attribute value was written "equal-power" when the
actual attribute is "equalpower".