### PR TITLE
Clarify real array usage in createPeriodicWave

### DIFF
--- a/index.html
+++ b/index.html
@@ -851,11 +851,12 @@ cases, only a single <a><code>AudioContext</code></a> is used per document.</p>
       <dt> Float32Array real </dt>
       <dd>
         The <dfn id="dfn-real">real</dfn> parameter represents an array of
-        <code>cosine</code> terms (traditionally the A terms).  In audio
-        terminology, the first element (index 0) is the DC-offset of the periodic
-        waveform and is usually set to zero.  The second element (index 1)
-        represents the fundamental frequency.  The third element represents the
-        first overtone, and so on.
+        <code>cosine</code> terms (traditionally the A terms).  In
+        audio terminology, the first element (index 0) is the
+        DC-offset of the periodic waveform. The second element (index
+        1) represents the fundamental frequency.  The third element
+        represents the first overtone, and so on. The first element is
+        ignored and implementations must set it to zero internally.
       </dd>
       <dt>Float32Array imag</dt>
       <dd>


### PR DESCRIPTION
Addresses #478. Implementations must ignore any value set for the first
element of the real array when creating a periodic wave.