### PR TITLE
Address issue 477, making the max array size 2048, not 4096.

### DIFF
--- a/index.html
+++ b/index.html
@@ -825,7 +825,7 @@ cases, only a single <a><code>AudioContext</code></a> is used per document.</p>
       containing arbitrary harmonic content.  The <code>real</code> and
       <code>imag</code> parameters must be of type <code>Float32Array</code>
       (described in [[!TYPED-ARRAYS]]) of equal lengths greater than zero and less
-      than or equal to 4096 or an IndexSizeError exception MUST be thrown.  These
+      than or equal to 2048 or an IndexSizeError exception MUST be thrown.  These
       parameters specify the Fourier coefficients of a
       <a href="http://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
       representing the partials of a periodic waveform.  The created


### PR DESCRIPTION
The maximum size of the arrays for a PeriodicWave is 2048, not 4096.  All current implementations ignore anything above 2048 anyway.