### PR TITLE
Use HTTPS URLs where possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,21 +4,21 @@
   <title>Web Audio API</title>
   <meta charset=utf-8>
   <script src='respec-w3c-common' async class='remove'></script>
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML"></script>
+  <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML"></script>
   <script class='remove'>
     var respecConfig = {
         specStatus: "ED",
         shortName:  "webaudio",
-        edDraftURI: "http://webaudio.github.io/web-audio-api/",
+        edDraftURI: "https://webaudio.github.io/web-audio-api/",
         editors: [
               {   name:       "Paul Adenot",
                   company:    "Mozilla",
-                  companyURL: "http://mozilla.org/",
+                  companyURL: "https://www.mozilla.org/",
                   mailto:     "padenot@mozilla.com" },
               {
                   name:       "Chris Wilson",
                   company:    "Google, Inc.",
-                  companyURL: "http://google.com",
+                  companyURL: "https://www.google.com/",
                   mailto:     "cwilso@google.com" },
         ],
         previousMaturity: "WD",
@@ -555,9 +555,9 @@ cases, only a single <a><code>AudioContext</code></a> is used per document.</p>
   <dd>
     A property used to set the <code>EventHandler</code> for an event that is dispatched to
     <a><code>AudioContext</code></a> when the state of the AudioContext has changed (i.e. when the
-    corresponding promise would have resolved). An event of type <a><code>Event</code></a> will be 
-    dispatched to the event handler, which can query the AudioContext's state directly.  A 
-    newly-created AudioContext will always begin in the "suspended" state, and a state change event will be fired 
+    corresponding promise would have resolved). An event of type <a><code>Event</code></a> will be
+    dispatched to the event handler, which can query the AudioContext's state directly.  A
+    newly-created AudioContext will always begin in the "suspended" state, and a state change event will be fired
     whenever the state changes to a different state.
   </dd>
 
@@ -681,8 +681,8 @@ cases, only a single <a><code>AudioContext</code></a> is used per document.</p>
 
     <dt> AudioWorkerNode createAudioWorker()</dt>
     <dd>
-      Creates an <a><code>AudioWorkerNode</code></a> and its associated <a><code>AudioWorkerGlobalScope</code></a> 
-      for direct audio processing using JavaScript.  An IndexSizeError exception MUST 
+      Creates an <a><code>AudioWorkerNode</code></a> and its associated <a><code>AudioWorkerGlobalScope</code></a>
+      for direct audio processing using JavaScript.  An IndexSizeError exception MUST
       be thrown if <a><code>numberOfInputChannels</code></a> or
       <a><code>numberOfOutputChannels</code></a> are outside the valid range.
 
@@ -827,7 +827,7 @@ cases, only a single <a><code>AudioContext</code></a> is used per document.</p>
       (described in [[!TYPED-ARRAYS]]) of equal lengths greater than zero and less
       than or equal to 2048 or an IndexSizeError exception MUST be thrown.  These
       parameters specify the Fourier coefficients of a
-      <a href="http://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
+      <a href="https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
       representing the partials of a periodic waveform.  The created
       <a><code>PeriodicWave</code></a> will be used with an
       <a><code>OscillatorNode</code></a> and will represent a <em>normalized</em>
@@ -1027,7 +1027,7 @@ roughly 3ms at a sample-rate of 44.1KHz.
 </p>
 
 <p>
-AudioNodes are <em>EventTarget</em>s, as described in <cite><a href="http://dom.spec.whatwg.org/">DOM</a></cite>
+AudioNodes are <em>EventTarget</em>s, as described in <cite><a href="https://dom.spec.whatwg.org/">DOM</a></cite>
 [[!DOM]].  This means that it is possible to dispatch events to
 <a><code>AudioNode</code></a>s the same
 way that other EventTargets accept events.
@@ -1164,8 +1164,8 @@ way that other EventTargets accept events.
     <dt>unsigned long output</dt>
     <dd>
       This parameter is an index describing which output of the
-      <a><code>AudioNode</code></a> to disconnect. It disconnects all outgoing 
-      connections from the given output. If this parameter is out-of-bounds, an 
+      <a><code>AudioNode</code></a> to disconnect. It disconnects all outgoing
+      connections from the given output. If this parameter is out-of-bounds, an
       IndexSizeError exception MUST be thrown.
     </dd>
   </dl>
@@ -1176,9 +1176,9 @@ way that other EventTargets accept events.
   <dl class=parameters>
     <dt>AudioNode destination</dt>
     <dd>
-      The <code>destination</code> parameter is the <a><code>AudioNode</code></a> 
-      to disconnect. It disconnects all outgoing connections to the given 
-      <code>destination</code>. If there is no connection to <code>destination</code>, 
+      The <code>destination</code> parameter is the <a><code>AudioNode</code></a>
+      to disconnect. It disconnects all outgoing connections to the given
+      <code>destination</code>. If there is no connection to <code>destination</code>,
       an InvalidAccessError exception MUST be thrown.
     </dd>
   </dl>
@@ -1189,14 +1189,14 @@ way that other EventTargets accept events.
   <dl class=parameters>
     <dt>AudioNode destination</dt>
     <dd>
-      The <code>destination</code> parameter is the <a><code>AudioNode</code></a> 
+      The <code>destination</code> parameter is the <a><code>AudioNode</code></a>
       to disconnect. If there is no connection to the <code>destination</code>
       from the given output, an InvalidAccessError exception MUST be thrown.
     </dd>
     <dt>unsigned long output</dt>
     <dd>
       The <code>output</code> parameter is an index describing which output of the
-      <a><code>AudioNode</code></a> from which to disconnect. If this parameter 
+      <a><code>AudioNode</code></a> from which to disconnect. If this parameter
       is out-of-bound, an IndexSizeError exception MUST be thrown.
     </dd>
   </dl>
@@ -1207,15 +1207,15 @@ way that other EventTargets accept events.
   <dl class=parameters>
     <dt>AudioNode destination</dt>
     <dd>
-      The <code>destination</code> parameter is the <a><code>AudioNode</code></a> 
-      to disconnect. If there is no connection to the <code>destination</code> 
-      from the given output to the given input, an InvalidAccessError exception 
+      The <code>destination</code> parameter is the <a><code>AudioNode</code></a>
+      to disconnect. If there is no connection to the <code>destination</code>
+      from the given output to the given input, an InvalidAccessError exception
       MUST be thrown.
     </dd>
     <dt>unsigned long output</dt>
     <dd>
       The <code>output</code> parameter is an index describing which output of the
-      <a><code>AudioNode</code></a> from which to disconnect.  If this parameter 
+      <a><code>AudioNode</code></a> from which to disconnect.  If this parameter
       is out-of-bound, an IndexSizeError exception MUST be thrown.
     </dd>
     <dt>unsigned long input</dt>
@@ -1231,10 +1231,10 @@ way that other EventTargets accept events.
   <dd>
   <dl class=parameters>
     <dt>AudioParam destination</dt>
-    <dd>The <code>destination</code> parameter is the <a><code>AudioParam</code></a> 
-      to disconnect. If there is no connection to the <code>destination</code>, an 
+    <dd>The <code>destination</code> parameter is the <a><code>AudioParam</code></a>
+      to disconnect. If there is no connection to the <code>destination</code>, an
       InvalidAccessError exception MUST be thrown.
-    </dd> 
+    </dd>
   </dl>
   </dd>
 
@@ -1242,14 +1242,14 @@ way that other EventTargets accept events.
   <dd>
   <dl class=parameters>
     <dt>AudioParam destination</dt>
-    <dd>The <code>destination</code> parameter is the <a><code>AudioParam</code></a> 
-      to disconnect. If there is no connection to the <code>destination</code>, an 
+    <dd>The <code>destination</code> parameter is the <a><code>AudioParam</code></a>
+      to disconnect. If there is no connection to the <code>destination</code>, an
       InvalidAccessError exception MUST be thrown.
-    </dd> 
+    </dd>
     <dt>unsigned long output</dt>
     <dd>
       The <code>output</code> parameter is an index describing which output of the
-      <a><code>AudioNode</code></a> from which to disconnect. If the <code>parameter</code> 
+      <a><code>AudioNode</code></a> from which to disconnect. If the <code>parameter</code>
       is out-of-bound, an IndexSizeError exception MUST be thrown.
     </dd>
   </dl>
@@ -1516,7 +1516,7 @@ The following rules will apply when calling these methods:
     </p>
     <p>
       The <code>startTime</code> parameter is the time
-      in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError exception MUST be 
+      in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError exception MUST be
       thrown if <code>startTime</code> is negative or is not a finite number.
     </p>
     <p>
@@ -1631,7 +1631,7 @@ The following rules will apply when calling these methods:
     </p>
     <p>
       The <code>startTime</code> parameter is the time in the
-      same time coordinate system as the <a><code>AudioContext</code></a>'s <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError exception MUST be 
+      same time coordinate system as the <a><code>AudioContext</code></a>'s <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError exception MUST be
       thrown if <code>start</code> is negative or is not a finite number.
     </p>
     <p>
@@ -1712,9 +1712,9 @@ The following rules will apply when calling these methods:
         The <code>startTime</code> parameter is the starting time at and after
         which any previously scheduled parameter changes will be cancelled.  It
         is a time in the same time coordinate system as
-        the <a><code>AudioContext</code></a>'s 
+        the <a><code>AudioContext</code></a>'s
         <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.
-        An InvalidAccessError exception MUST be thrown if <code>startTime</code> 
+        An InvalidAccessError exception MUST be thrown if <code>startTime</code>
         is negative or is not a finite number.
       </p>
     </dd>
@@ -2098,7 +2098,7 @@ invoked in the following cases:
         value is less than <b>currentTime</b>, then the sound will start playing
         immediately.  <code>start</code> may only be called one time and must be
         called before <code>stop</code> is called or an InvalidStateError
-        exception MUST be thrown.  An InvalidAccessError exception MUST be 
+        exception MUST be thrown.  An InvalidAccessError exception MUST be
         thrown if <code>when</code> is negative or is not a finite number.
       </dd>
       <dt>optional double offset = 0</dt>
@@ -2106,7 +2106,7 @@ invoked in the following cases:
         The <dfn id="dfn-offset">offset</dfn> parameter describes the offset
         time in the buffer (in seconds) where playback will begin. If 0 is
         passed in for this value, then playback will start from the beginning of
-        the buffer.  An InvalidAccessError exception MUST be thrown if 
+        the buffer.  An InvalidAccessError exception MUST be thrown if
         <code>offset</code> is negative or is not a finite number.
       </dd>
       <dt>optional double duration</dt>
@@ -2116,8 +2116,8 @@ invoked in the following cases:
         not passed, the duration will be equal to the total duration of the
         AudioBuffer minus the <code>offset</code> parameter.  Thus if neither
         <code>offset</code> nor <code>duration</code> are specified then the
-        implied duration is the total duration of the AudioBuffer.  An 
-        InvalidAccessError exception MUST be thrown if <code>duration</code> 
+        implied duration is the total duration of the AudioBuffer.  An
+        InvalidAccessError exception MUST be thrown if <code>duration</code>
         is negative or is not a finite number.
       </dd>
     </dl>
@@ -2135,8 +2135,8 @@ invoked in the following cases:
         <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  If 0
         is passed in for this value or if the value
         is less than <a><code>currentTime</code></a>, then the sound will stop playing
-        immediately.  An InvalidAccessError exception MUST be thrown if 
-        <code>when</code> is negative or is not a finite number.  If <code>stop</code> 
+        immediately.  An InvalidAccessError exception MUST be thrown if
+        <code>when</code> is negative or is not a finite number.  If <code>stop</code>
         is called again after already have been
         called, the last invocation will be the only one applied; stop times set by previous
         calls will not be applied, unless the buffer has already stopped prior to any
@@ -2150,13 +2150,13 @@ invoked in the following cases:
   <dt> attribute EventHandler onended </dt>
   <dd>
   A property used to set the <code>EventHandler</code> (described in <cite>
-    <a href="http://www.whatwg.org/specs/web-apps/current-work/#eventhandler">
+    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">
       HTML</a></cite>[[!HTML]]) for the ended event that is dispatched to
   <a><code>AudioBufferSourceNode</code></a>
   node types.  When the playback of the buffer for an
   <a><code>AudioBufferSourceNode</code></a> is finished, an event of type <code>Event
   </code> (described in <cite> <a
-      href="http://www.whatwg.org/specs/web-apps/current-work/#event">HTML</a>
+      href="https://html.spec.whatwg.org/multipage/infrastructure.html#event">HTML</a>
   </cite>[[!HTML]]) will be dispatched to the event handler.
   </dd>
 </dl>
@@ -2301,28 +2301,28 @@ href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cros
 <section>
 <h2>The <dfn>AudioWorker</dfn></h2>
 
-<p>AudioWorker is not an actual class in the Web Audio API; an Audio Worker is 
-  represented in the main thread by the <a>AudioWorkerNode</a> methods 
-  (postMessage, onmessage and terminate, in particular). From inside an audio 
-  worker script, an Audio Worker is represented by an 
-  <a><code>AudioWorkerGlobalScope</code></a> object representing the node's 
-  contextual information; all worker scripts are run in the audio processing 
+<p>AudioWorker is not an actual class in the Web Audio API; an Audio Worker is
+  represented in the main thread by the <a>AudioWorkerNode</a> methods
+  (postMessage, onmessage and terminate, in particular). From inside an audio
+  worker script, an Audio Worker is represented by an
+  <a><code>AudioWorkerGlobalScope</code></a> object representing the node's
+  contextual information; all worker scripts are run in the audio processing
   thread.</p>
 
 <section>
 <h2>The <dfn>AudioWorkerNode</dfn> Interface</h2>
 
-<p>This interface represents an <a><code>AudioNode</code></a> which interacts 
-  with a <a>Worker</a> thread to generate, process, or analyse audio directly. 
-  The user creates a separate audio processing worker script, which is hosted 
-  inside the AudioWorkerGlobalScope and runs inside the audio processing 
-  thread, rather than the main UI thread.  The AudioWorkerNode represents the 
-  processing node in the main processing thread's node graph; the 
-  AudioWorkerGlobalScope represents the context in which the user's audio 
+<p>This interface represents an <a><code>AudioNode</code></a> which interacts
+  with a <a>Worker</a> thread to generate, process, or analyse audio directly.
+  The user creates a separate audio processing worker script, which is hosted
+  inside the AudioWorkerGlobalScope and runs inside the audio processing
+  thread, rather than the main UI thread.  The AudioWorkerNode represents the
+  processing node in the main processing thread's node graph; the
+  AudioWorkerGlobalScope represents the context in which the user's audio
   processing script is run.</p>
-<p>Nota bene that if the Web Audio implementation normally runs audio process 
-  at higher than normal thread priority, utilizing AudioWorkerNodes may cause 
-  demotion of the priority of the audio thread (since user scripts cannot be 
+<p>Nota bene that if the Web Audio implementation normally runs audio process
+  at higher than normal thread priority, utilizing AudioWorkerNodes may cause
+  demotion of the priority of the audio thread (since user scripts cannot be
   run with higher than normal priority).</p>
 
 <pre>
@@ -2337,7 +2337,7 @@ href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cros
 <p>
 <dfn id="AudioWorker-numberOfInputChannels">numberOfInputChannels</dfn> and
 <dfn id="AudioWorker-numberOfOutputChannels">numberOfOutputChannels</dfn>
-determine the number of input and output channels (and the number of channels 
+determine the number of input and output channels (and the number of channels
 present in the AudioBuffers passed to the AudioProcess event handler inside the
 <a>AudioWorkerGlobalScope</a>). It is invalid for both <a
   href="#AudioWorker-numberOfInputChannels"><code>numberOfInputChannels</code></a>
@@ -2352,9 +2352,9 @@ to be zero.
 
 <dl title="interface AudioWorkerNode : AudioNode" class="idl">
   <dt>void terminate()</dt>
-  <dd>The terminate() method, when invoked, must cause the 
-    <a href="http://dev.w3.org/html5/workers/#terminate-a-worker">"terminate 
-      a worker"</a> algorithm to be run on the worker with which the object 
+  <dd>The terminate() method, when invoked, must cause the
+    <a href="http://dev.w3.org/html5/workers/#terminate-a-worker">"terminate
+      a worker"</a> algorithm to be run on the worker with which the object
       is associated.  This will cease any <a>AudioProcessEvent</a>s being
       dispatched to the Audio Worker, and will cause the destruction of the
       worker thread.  In practical terms, this means the node will disconnect itself from any downstream connections.</dd>
@@ -2363,53 +2363,53 @@ to be zero.
     algorithm defined by <a href="http://dev.w3.org/html5/workers/#dom-worker-postmessage">
     the Worker specification</a>.</dd>
   <dt>attribute EventHandler onmessage</dt>
-  <dd>The onmessage handler is called whenever the Audio Worker posts a 
+  <dd>The onmessage handler is called whenever the Audio Worker posts a
     message back to the main thread.</dd>
   <dt>AudioParam addParameter(DOMString name, optional float defaultValue) </dt>
   <dd>
     <p>
-      Causes a correspondingly-named read-only <a>AudioParam</a> to be 
-      present on the <a>AudioWorkerNode</a>, and a correspondingly-named 
-      read-only <a>Float32Array</a> to be present on the 
-      <a><code>parameters</code></a> object exposed on the 
-      <a>AudioProcessEvent</a> on subsequent audio processing events.  The 
-      AudioParam may immediately have its scheduling methods called, its 
+      Causes a correspondingly-named read-only <a>AudioParam</a> to be
+      present on the <a>AudioWorkerNode</a>, and a correspondingly-named
+      read-only <a>Float32Array</a> to be present on the
+      <a><code>parameters</code></a> object exposed on the
+      <a>AudioProcessEvent</a> on subsequent audio processing events.  The
+      AudioParam may immediately have its scheduling methods called, its
       .<a>value</a> set, or AudioNodes connected to it.</p>
-    <p>The <code>name</code> parameter is the name used for the read-only 
-      AudioParam added to the AudioWorkerNode, and the name used for the 
-      read-only <code>Float32Array</code> that will be present on the 
-      <a><code>parameters</code></a> object exposed on subsequent 
+    <p>The <code>name</code> parameter is the name used for the read-only
+      AudioParam added to the AudioWorkerNode, and the name used for the
+      read-only <code>Float32Array</code> that will be present on the
+      <a><code>parameters</code></a> object exposed on subsequent
       <a>AudioProcessEvent</a>s.</p>
     <p>The <dfn
-      id="dfn-defaultValue">defaultValue</dfn> parameter is the default value 
-      for the <a>AudioParam</a>'s <a>value</a> attribute, as well as 
-      therefore the default value that will appear in the Float32Array in the 
-      worker script (if no other parameter changes or connections affect the 
+      id="dfn-defaultValue">defaultValue</dfn> parameter is the default value
+      for the <a>AudioParam</a>'s <a>value</a> attribute, as well as
+      therefore the default value that will appear in the Float32Array in the
+      worker script (if no other parameter changes or connections affect the
       value).</p>
   </dd>
   <dt>void removeParameter(DOMString name) </dt>
   <dd>
     <p>
-      Removes a previously-added parameter named <code>name</code> from the 
-      <a>AudioWorkerNode</a>.  This will also remove the correspondingly-named 
-      read-only <a>AudioParam</a> from the <a>AudioWorkerNode</a>, and will 
-      remove the correspondingly-named read-only <a>Float32Array</a> from the 
-      <a>AudioProcessEvent</a>'s <a><code>parameters</code></a> member on 
-      subsequent audio processing events. A 
-      NotFoundError exception must be thrown if no parameter with that name 
+      Removes a previously-added parameter named <code>name</code> from the
+      <a>AudioWorkerNode</a>.  This will also remove the correspondingly-named
+      read-only <a>AudioParam</a> from the <a>AudioWorkerNode</a>, and will
+      remove the correspondingly-named read-only <a>Float32Array</a> from the
+      <a>AudioProcessEvent</a>'s <a><code>parameters</code></a> member on
+      subsequent audio processing events. A
+      NotFoundError exception must be thrown if no parameter with that name
       exists on this node.</p>
-    <p>The <code>name</code> parameter identifies the parameter to be 
+    <p>The <code>name</code> parameter identifies the parameter to be
       removed.</p>
   </dd>
 </dl>
 </dl>
 <p>
-  Note that <a>AudioWorkerNode</a> objects will also have read-only 
-  AudioParam objects for each named parameter added via the 
+  Note that <a>AudioWorkerNode</a> objects will also have read-only
+  AudioParam objects for each named parameter added via the
   <code>addParameter</code> method.  As this is dynamic, it cannot be captured
   in IDL.
 </p>
-  
+
 <!--<div title="AudioWorkerNode implements Worker" class="idl">-->
   <p>AudioWorkerNodes must implement the <a>Worker</a>
   interface for communication with the audio worker script.</p>
@@ -2419,15 +2419,15 @@ to be zero.
 <section>
 <h2>The AudioWorkerGlobalScope Interface</h2>
 
-<p>This interface is a <a><code>DedicatedWorkerGlobalScope</code></a>-derived 
-  object representing the context in which an audio processing script is run; 
-  it is designed to enable the generation, processing, and analysis of audio 
+<p>This interface is a <a><code>DedicatedWorkerGlobalScope</code></a>-derived
+  object representing the context in which an audio processing script is run;
+  it is designed to enable the generation, processing, and analysis of audio
   data directly using JavaScript in a Worker thread. </p>
 
 <p>
-The <a><code>AudioWorkerGlobalScope</code></a> has an 
+The <a><code>AudioWorkerGlobalScope</code></a> has an
 <dfn id="audioprocess-worker">audioprocess</dfn> event that is dispatched
-synchronously to process audio frames.  
+synchronously to process audio frames.
 <a href="#audioprocess-worker"><code>audioprocess</code></a> events are only
 dispatched if the <a><code>AudioWorkerNode</code></a> has at least one input or
 one output connected.
@@ -2436,18 +2436,18 @@ one output connected.
   <dt>attribute EventHandler onaudioprocess</dt>
   <dd>
     A property used to set the <code>EventHandler</code> (described in <cite>
-    <a href="http://www.whatwg.org/specs/web-apps/current-work/#eventhandler">
+    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">
     HTML</a></cite>[[!HTML]]) for the <a href="#audioprocess-worker">
     <code>audioprocess</code></a> event that is dispatched to
     <a><code>AudioWorkerGlobalScope</code></a> when the associated
     <a><code>AudioWorkerNode</code></a> is connected. An event of type
-    <a><code>AudioProcessEvent</code></a> will be dispatched to the event 
+    <a><code>AudioProcessEvent</code></a> will be dispatched to the event
     handler.
   </dd>
   <dt>readonly attribute float sampleRate</dt>
   <dd>
-    The sample rate of the host <a>AudioContext</a> (since inside the 
-    <a>Worker</a> scope, the user will not have direct access to the 
+    The sample rate of the host <a>AudioContext</a> (since inside the
+    <a>Worker</a> scope, the user will not have direct access to the
     <a>AudioContext</a>.
   </dd>
 </dl>
@@ -2457,11 +2457,11 @@ one output connected.
   <h3>Audio Worker Examples</h3>
   <section>
     <h4>A Bitcrusher Node</h4>
-      <p>Bitcrushing is a mechanism by which the audio quality of an audio 
-        stream is reduced - both by quantizing the value (simulating lower 
-        bit-depth in integer-based audio), and by quantizing in time 
-        (simulating a lower digital sample rate).  This example shows how to 
-        use AudioParams (in this case, treated as a-rate) inside an 
+      <p>Bitcrushing is a mechanism by which the audio quality of an audio
+        stream is reduced - both by quantizing the value (simulating lower
+        bit-depth in integer-based audio), and by quantizing in time
+        (simulating a lower digital sample rate).  This example shows how to
+        use AudioParams (in this case, treated as a-rate) inside an
         AudioWorker.</p>
 
     <h5>Main file javascript</h5>
@@ -2501,9 +2501,9 @@ onaudioprocess= function (e) {
   </section>
   <section>
     <h4>A Volume Meter and Clip Detector</h4>
-    <p>Another common need is a clip-detecting volume meter.  This example 
-      shows how to communicate basic parameters (that do not need AudioParam 
-      scheduling) across to a Worker, as well as communicating data back to 
+    <p>Another common need is a clip-detecting volume meter.  This example
+      shows how to communicate basic parameters (that do not need AudioParam
+      scheduling) across to a Worker, as well as communicating data back to
       the main thread.</p>
 
     <h5>Main file javascript</h5>
@@ -2520,7 +2520,7 @@ vuNode.onmessage = function (event) {
 }
 
 // Set up some configuration parameters
-vuNode.postMessage( 
+vuNode.postMessage(
   { "smoothing": 0.9,   // Smoothing parameter
     "clipLevel": 0.9,   // Level to consider "clipping"
     "clipLag": 750,     // How long to keep "clipping" lit up after clip (ms)
@@ -2633,7 +2633,7 @@ be zero.
   <dt>attribute EventHandler onaudioprocess</dt>
   <dd>
     A property used to set the <code>EventHandler</code> (described in <cite>
-    <a href="http://www.whatwg.org/specs/web-apps/current-work/#eventhandler">
+    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">
     HTML</a></cite>[[!HTML]]) for the <a
   href="#audioprocess-spnode"><code>audioprocess</code></a> event that is
 dispatched to <a><code>ScriptProcessorNode</code></a> node types. An event of
@@ -2675,32 +2675,32 @@ This is an <code>Event</code> object which is dispatched to
     </dd>
     <dt> readonly attribute Float32Array[] inputBuffers </dt>
     <dd>
-      An Array of Float32Arrays, one per channel, containing the input audio 
-      buffer with input data.  The number of channels will be equal to the 
-      <code>numberOfInputChannels</code> parameter of the createAudioWorker() 
-      method.  It is expected that the event object, the Array and the input 
-      and output buffers may be reused by the processing system, in order to 
+      An Array of Float32Arrays, one per channel, containing the input audio
+      buffer with input data.  The number of channels will be equal to the
+      <code>numberOfInputChannels</code> parameter of the createAudioWorker()
+      method.  It is expected that the event object, the Array and the input
+      and output buffers may be reused by the processing system, in order to
       minimize memory churn; it is not recommended to maintain global handles
       to them.
       </dd>
     <dt> readonly attribute Float32Array[] outputBuffers </dt>
     <dd>
-      An Array of Float32Arrays, one per channel, containing the output audio 
-      buffer.  The number of channels will be equal to the 
-      <code>numberOfOutputChannels</code> parameter of the createAudioWorker() 
-      method.  It is expected that the event object, the Array and the input 
-      and output buffers may be reused by the processing system, in order to 
+      An Array of Float32Arrays, one per channel, containing the output audio
+      buffer.  The number of channels will be equal to the
+      <code>numberOfOutputChannels</code> parameter of the createAudioWorker()
+      method.  It is expected that the event object, the Array and the input
+      and output buffers may be reused by the processing system, in order to
       minimize memory churn; it is not recommended to maintain global handles
       to them.
     </dd>
     <dt> readonly attribute object parameters</dt>
-    <dd>This object attribute exposes a correspondingly-named 
-      read-only <a>Float32Array</a> for each parameter that has been added 
-      via <a>addParameter</a>.  As this is dynamic, this cannot be captured 
-      in IDL.  The length of this Float32Array will correspond to the length 
-      of the inputBuffer.  The contents of this Float32Array will be the 
-      values to be used for the AudioParam at the corresponding points in 
-      time.  It is expected that this Float32Array will be reused by the 
+    <dd>This object attribute exposes a correspondingly-named
+      read-only <a>Float32Array</a> for each parameter that has been added
+      via <a>addParameter</a>.  As this is dynamic, this cannot be captured
+      in IDL.  The length of this Float32Array will correspond to the length
+      of the inputBuffer.  The contents of this Float32Array will be the
+      values to be used for the AudioParam at the corresponding points in
+      time.  It is expected that this Float32Array will be reused by the
       audio engine.</dd>
 </dl>
 </section>
@@ -2710,8 +2710,8 @@ This is an <code>Event</code> object which is dispatched to
 
 <p>
 This is an <code>Event</code> object which is dispatched to
-<a><code>ScriptProcessorNode</code></a> nodes.  It will be removed 
-when the ScriptProcessorNode is removed, as the replacement 
+<a><code>ScriptProcessorNode</code></a> nodes.  It will be removed
+when the ScriptProcessorNode is removed, as the replacement
 <a>AudioWorker</a> uses the <a>AudioProcessEvent</a>.
 </p>
 
@@ -3599,7 +3599,7 @@ The number of channels of the output always equals the number of channels of the
 <dl title="enum BiquadFilterType" class="idl">
   <dt>lowpass</dt>
   <dd>
-    <p>A <a href="http://en.wikipedia.org/wiki/Low-pass_filter">lowpass filter</a>
+    <p>A <a href="https://en.wikipedia.org/wiki/Low-pass_filter">lowpass filter</a>
     allows frequencies below the cutoff frequency to pass through and attenuates
     frequencies above the cutoff. It implements a standard second-order
     resonant lowpass filter with 12dB/octave rolloff.</p>
@@ -3619,7 +3619,7 @@ The number of channels of the output always equals the number of channels of the
   </dd>
   <dt>highpass</dt>
   <dd>
-    <p>A <a href="http://en.wikipedia.org/wiki/High-pass_filter">highpass
+    <p>A <a href="https://en.wikipedia.org/wiki/High-pass_filter">highpass
     filter</a> is the opposite of a lowpass filter. Frequencies above the cutoff
     frequency are passed through, but frequencies below the cutoff are attenuated.
     It implements a standard second-order resonant highpass filter with
@@ -3640,7 +3640,7 @@ The number of channels of the output always equals the number of channels of the
   </dd>
   <dt>bandpass</dt>
   <dd>
-    <p>A <a href="http://en.wikipedia.org/wiki/Band-pass_filter">bandpass
+    <p>A <a href="https://en.wikipedia.org/wiki/Band-pass_filter">bandpass
     filter</a> allows a range of frequencies to pass through and attenuates the
     frequencies below and above this frequency range. It implements a
     second-order bandpass filter.</p>
@@ -3649,7 +3649,7 @@ The number of channels of the output always equals the number of channels of the
       <dl>
         <dt>frequency</dt>
           <dd>The center of the frequency band</dd>
-        <dt><a href="http://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
+        <dt><a href="https://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
           <dd>Controls the width of the band. The width becomes narrower as the Q
             value increases.</dd>
         <dt>gain</dt>
@@ -3668,7 +3668,7 @@ The number of channels of the output always equals the number of channels of the
         <dt>frequency</dt>
           <dd>The upper limit of the frequences where the boost (or attenuation) is
             applied.</dd>
-        <dt><a href="http://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
+        <dt><a href="https://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
           <dd>Not used in this filter type.</dd>
         <dt>gain</dt>
           <dd>The boost, in dB, to be applied. If the value is negative, the
@@ -3687,7 +3687,7 @@ The number of channels of the output always equals the number of channels of the
         <dt>frequency</dt>
           <dd>The lower limit of the frequences where the boost (or attenuation) is
             applied.</dd>
-        <dt><a href="http://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
+        <dt><a href="https://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
           <dd>Not used in this filter type.</dd>
         <dt>gain</dt>
           <dd>The boost, in dB, to be applied. If the value is negative, the
@@ -3704,7 +3704,7 @@ The number of channels of the output always equals the number of channels of the
       <dl>
         <dt>frequency</dt>
           <dd>The center frequency of where the boost is applied.</dd>
-        <dt><a href="http://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
+        <dt><a href="https://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
           <dd>Controls the width of the band of frequencies that are boosted. A
             large value implies a narrow width.</dd>
         <dt>gain</dt>
@@ -3716,7 +3716,7 @@ The number of channels of the output always equals the number of channels of the
   <dt>notch</dt>
   <dd>
     <p>The notch filter (also known as a <a
-    href="http://en.wikipedia.org/wiki/Band-stop_filter">band-stop or
+    href="https://en.wikipedia.org/wiki/Band-stop_filter">band-stop or
     band-rejection filter</a>) is the opposite of a bandpass filter. It allows all
     frequencies through, except for a set of frequencies.</p>
 
@@ -3724,7 +3724,7 @@ The number of channels of the output always equals the number of channels of the
       <dl>
         <dt>frequency</dt>
           <dd>The center frequency of where the notch is applied.</dd>
-        <dt><a href="http://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
+        <dt><a href="https://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
           <dd>Controls the width of the band of frequencies that are attenuated. A
             large value implies a narrow width.</dd>
         <dt>gain</dt>
@@ -3735,7 +3735,7 @@ The number of channels of the output always equals the number of channels of the
   <dt>allpass</dt>
   <dd>
     <p>An <a
-    href="http://en.wikipedia.org/wiki/All-pass_filter#Digital_Implementation">allpass
+    href="https://en.wikipedia.org/wiki/All-pass_filter#Digital_Implementation">allpass
     filter</a> allows all frequencies through, but changes the phase relationship
     between the various frequencies. It implements a second-order allpass
     filter</p>
@@ -3745,8 +3745,8 @@ The number of channels of the output always equals the number of channels of the
         <dt>frequency</dt>
           <dd>The frequency where the center of the phase transition occurs. Viewed
             another way, this is the frequency with maximal <a
-            href="http://en.wikipedia.org/wiki/Group_delay">group delay</a>.</dd>
-        <dt><a href="http://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
+            href="https://en.wikipedia.org/wiki/Group_delay">group delay</a>.</dd>
+        <dt><a href="https://en.wikipedia.org/wiki/Q_factor">Q</a></dt>
           <dd>Controls how sharp the phase transition is at the center frequency. A
             larger value implies a sharper transition and a larger group delay.</dd>
         <dt>gain</dt>
@@ -3777,7 +3777,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>k-rate</a>
   <dd> A detune value, in cents, for the frequency. Its default value is 0. </dd>
   <dt>readonly attribute AudioParam Q</dt>
   <dd>
-    The <a href="http://en.wikipedia.org/wiki/Q_factor">Q</a> factor has a
+    The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor has a
     default value of 1, with a nominal range of 0.0001 to 1000.
   </dd>
   <dt>readonly attribute AudioParam gain</dt>
@@ -3987,7 +3987,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>k-rate</a>
     <li>Let <math title="A_1"><msub><mi>A</mi><mn>1</mn></msub></math> be
     <li>Let <math title="omega0"><msub><mi>ω</mi><mn>0</mn></msub></math> be
     <math><mn>2</mn><mo>⋅</mo><mi>π</mi><mo>⋅</mo><mfrac><msub><mi>f</mi><mn>0</mn></msub><msub><mi>F</mi><mi>s</mi></msub></mfrac></math>.</li>
-    <li>Let <math title="Q_Q"><msub><mi>α</mi><mn>Q</mn></msub></math> be 
+    <li>Let <math title="Q_Q"><msub><mi>α</mi><mn>Q</mn></msub></math> be
     <math><mfrac><mrow><mi>sin</mi><mrow><mo>(</mo><msub><mi>ω</mi><mn>0</mn></msub><mo>)</mo></mrow></mrow><mrow><mn>2</mn><mo>⋅</mo><mi>Q</mi></mrow></mfrac></math></li>
     <li>Let <math title="Q_BW"><msub><mi>α</mi><mn>BW</mn></msub></math> be
     <math>
@@ -4043,7 +4043,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>k-rate</a>
       </mrow>
     </math>
             </li>
-    <li>Let <math title="Q_S"><msub><mi>α</mi><mn>S</mn></msub></math> be 
+    <li>Let <math title="Q_S"><msub><mi>α</mi><mn>S</mn></msub></math> be
     <math>
       <mfrac>
         <mrow>
@@ -5681,11 +5681,11 @@ to determine a <em>computedFrequency</em> value:
     <dt> attribute EventHandler onended </dt>
     <dd>
       A property used to set the <code>EventHandler</code> (described in <cite><a
-      href="http://www.whatwg.org/specs/web-apps/current-work/#eventhandler">HTML</a></cite>[[HTML]])
+      href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">HTML</a></cite>[[HTML]])
       for the ended event that is dispatched to <a >OscillatorNode</a>
       node types.  When the <a><code>OscillatorNode</code></a> has finished playing
       (i.e. its stop time has been reached), an event of type <code>Event</code> (described in <cite><a
-      href="http://www.whatwg.org/specs/web-apps/current-work/#event">HTML</a></cite>[[HTML]])
+      href="https://html.spec.whatwg.org/multipage/infrastructure.html#event">HTML</a></cite>[[HTML]])
       will be dispatched to the event handler.
     </dd>
 </dl>
@@ -6378,7 +6378,7 @@ Quad up-mix:
   </p>
   </section>
   <section id="azimuth-elevation">
-  <h3>Azimuth and Elevation</h3> 
+  <h3>Azimuth and Elevation</h3>
   <p>
   The following algorithm must be used to calculate the <em>azimuth</em>
   and <em>elevation</em>: for the <a><code>PannerNode</code></a>
@@ -6576,7 +6576,7 @@ Quad up-mix:
 
     </li>
     <li><a
-      href="http://en.wikipedia.org/wiki/Head-related_transfer_function">HRTF</a>
+      href="https://en.wikipedia.org/wiki/Head-related_transfer_function">HRTF</a>
       panning (stereo only).
       <p>This requires a set of HRTF impulse responses recorded at a variety of
       azimuths and elevations. There are a small number of open/free impulse
@@ -6736,7 +6736,7 @@ clamped to [0, 1].
 <section>
   <h3 id="Convolution-background">Background</h3>
 
-  <p><a href="http://en.wikipedia.org/wiki/Convolution">Convolution</a> is a
+  <p><a href="https://en.wikipedia.org/wiki/Convolution">Convolution</a> is a
   mathematical process which can be applied to an audio signal to achieve many
   interesting high-quality linear effects. Very often, the effect is used to
   simulate an acoustic space such as a concert hall, cathedral, or outdoor
@@ -7078,7 +7078,7 @@ battery-life issues.
   <p>Currently audio input is not specified in this document, but it will involve
   gaining access to the client machine's audio input or microphone. This will
   require asking the user for permission in an appropriate way, probably via the
-  <a href="http://developers.whatwg.org/">getUserMedia()
+  <a href="https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">getUserMedia()
   API</a>. </p>
 </section>
 


### PR DESCRIPTION
This also fixes the mixed content issues on https://webaudio.github.io/web-audio-api/ due to the MathJax script being loaded over HTTP.

Preview: https://mathiasbynens.github.io/web-audio-api/