### PR TITLE
Added missing names to the WG memeber list

### DIFF
--- a/index.html
+++ b/index.html
@@ -7104,7 +7104,7 @@ battery-life issues.
 <p>Members of the Working Group are (at the time of writing, and by alphabetical order): <br />
 Adenot, Paul (Mozilla Foundation) - Specification Co-editor;
 Akhgari, Ehsan (Mozilla Foundation);
-Berkovitz, Joe (Invited Expert) – WG Chair;
+Berkovitz, Joe (Hal Leonard/Noteflight) – WG Chair;
 Bossart, Pierre (Intel Corporation);
 Carlson, Eric (Apple, Inc.);
 Choi, Hongchan (Google, Inc.);

--- a/index.html
+++ b/index.html
@@ -7102,11 +7102,12 @@ battery-life issues.
 <p>This specification is the collective work of the W3C <a href="http://www.w3.org/2011/audio/">Audio Working Group</a>.</p>
 
 <p>Members of the Working Group are (at the time of writing, and by alphabetical order): <br />
-Adenot, Paul (Mozilla Foundation);
+Adenot, Paul (Mozilla Foundation) - Specification Co-editor;
 Akhgari, Ehsan (Mozilla Foundation);
-Berkovitz, Joe (Invited Expert);
+Berkovitz, Joe (Invited Expert) – WG Chair;
 Bossart, Pierre (Intel Corporation);
 Carlson, Eric (Apple, Inc.);
+Choi, Hongchan (Google, Inc.);
 Geelnard, Marcus (Opera Software);
 Goode, Adam (Google, Inc.);
 Gregan, Matthew (Mozilla Foundation);
@@ -7123,9 +7124,10 @@ Raman, T.V. (Google, Inc.);
 Schepers, Doug (W3C/MIT);
 Shires, Glen (Google, Inc.);
 Smith, Michael (W3C/Keio);
-Thereaux, Olivier (British Broadcasting Corporation) – WG Chair;
+Thereaux, Olivier (British Broadcasting Corporation);
+Toy, Raymond (Google, Inc.);
 Verdie, Jean-Charles (MStar Semiconductor, Inc.);
-Wilson, Chris (Google,Inc.);
+Wilson, Chris (Google,Inc.) - Specification Co-editor;
 ZERGAOUI, Mohamed (INNOVIMAX)
 </p>
 


### PR DESCRIPTION
This PR is to reflect recent changes in WG member names and roles in the spec.