### PR TITLE
Value for the cone* members must be used modulo 360

### DIFF
--- a/index.html
+++ b/index.html
@@ -2913,18 +2913,21 @@ default is "inverse".
     <dt>attribute float coneInnerAngle</dt>
     <dd>
       A parameter for directional audio sources, this is an angle, in degrees, inside
-      of which there will be no volume reduction.  The default value is 360.
+      of which there will be no volume reduction. The default value is 360, and
+      the value is modulo 360.
     </dd>
     <dt>attribute float coneOuterAngle</dt>
     <dd>
       A parameter for directional audio sources, this is an angle, in degrees, outside
       of which the volume will be reduced to a constant value of
-      <a><code>coneOuterGain</code></a>.  The default value is 360.
+      <a><code>coneOuterGain</code></a>.  The default value is 360 and the value
+      is modulo 360.
     </dd>
     <dt>attribute float coneOuterGain</dt>
     <dd>
       A parameter for directional audio sources, this is the amount of volume
-      reduction outside of the <a><code>coneOuterAngle</code></a>.  The default value is 0.
+      reduction outside of the <a><code>coneOuterAngle</code></a>.  The default
+      value is 0, and the value is modulo 360.
     </dd>
 </dl>
 
@@ -6649,7 +6652,7 @@ clamped to [0, 1].
   </p>
 
   <pre class="highlight">
-  if (source.orientation.isZero() || ((source.coneInnerAngle == 360) &amp;&amp; (source.coneOuterAngle == 360)))
+  if (source.orientation.isZero() || ((source.coneInnerAngle == 0) &amp;&amp; (source.coneOuterAngle == 0)))
       return 1; // no cone specified - unity gain
 
   // Normalized source-listener vector

--- a/index.html
+++ b/index.html
@@ -2914,20 +2914,20 @@ default is "inverse".
     <dd>
       A parameter for directional audio sources, this is an angle, in degrees, inside
       of which there will be no volume reduction. The default value is 360, and
-      the value is modulo 360.
+      the value is used modulo 360.
     </dd>
     <dt>attribute float coneOuterAngle</dt>
     <dd>
       A parameter for directional audio sources, this is an angle, in degrees, outside
       of which the volume will be reduced to a constant value of
       <a><code>coneOuterGain</code></a>.  The default value is 360 and the value
-      is modulo 360.
+      is used modulo 360.
     </dd>
     <dt>attribute float coneOuterGain</dt>
     <dd>
       A parameter for directional audio sources, this is the amount of volume
       reduction outside of the <a><code>coneOuterAngle</code></a>.  The default
-      value is 0, and the value is modulo 360.
+      value is 0, and the value is used modulo 360.
     </dd>
 </dl>
 


### PR DESCRIPTION
I split this off from the other unrelated PR. This includes review comments.