### PR TITLE
Use rejected promise instead of exception for suspend/resume/close.

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,17 +564,17 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
     need the <a>AudioContext</a> for some time, and wishes to let the audio hardware
     power down.  The promise resolves when the frame buffer is empty (has been
     handed off to the hardware), or immediately (with no other effect) if the
-    context is already suspended.  The promise is rejected if the context has been
-    closed.
+    context is already suspended.  The promise is rejected with
+    <code>InvalidStateError</code> if the context has been closed.
     </p>
 
     <p>
       While the system is suspended, MediaStreams will have their output ignored;
       that is, data will be lost by the real time nature of media streams.
-      HTMLMediaElements will similarly have their output ignored until the system is
-      resumed.  Audio Workers and ScriptProcessorNodes will simply not fire their
+      <code>HTMLMediaElement</code>s will similarly have their output ignored until the system is
+      resumed.  Audio Workers and <a<>ScriptProcessorNode</a<>s will simply not fire their
       onaudioprocess events while suspended, but will resume when resumed.  For the
-      purpose of AnalyserNode window functions, the data is considered as a
+      purpose of <a>AnalyserNode</a> window functions, the data is considered as a
       continuous stream - i.e. the resume()/suspend() does not cause silence to
       appear in the AnalyserNode's stream of data.
     </p>
@@ -589,8 +589,9 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
     contents.  The promise resolves when the system has re-acquired (if
     necessary) access to audio hardware and has begun streaming to the
     destination, or immediately (with no other effect) if the context is already
-    running.  The promise is rejected if the context has been closed.  If the
-    context is not currently suspended, the promise will resolve.
+    running.  The promise is rejected with <code>InvalidStateError</code> if the
+    context has been closed.  If the context is not currently suspended, the
+    promise will resolve.
   </dd>
 
   <dt>Promise&lt;void&gt; close()</dt>


### PR DESCRIPTION
This also specs what exception should be thrown when suspend and resume are
called on a close context.

This fixes #441.