### PR TITLE
Fix issue #386.

### DIFF
--- a/index.html
+++ b/index.html
@@ -821,8 +821,9 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
       Creates a <a><code>PeriodicWave</code></a> representing a waveform
       containing arbitrary harmonic content.  The <code>real</code> and
       <code>imag</code> parameters must be of type <code>Float32Array</code>
-      (described in [[!TYPED-ARRAYS]]) of equal lengths greater than zero and less
-      than or equal to 2048 or an IndexSizeError exception MUST be thrown.  These
+      (described in [[!TYPED-ARRAYS]]) of equal lengths greater than zero or an IndexSizeError
+      exception MUST be thrown.  All implementations must support arrays up to at least 8192.
+      These
       parameters specify the Fourier coefficients of a
       <a href="https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
       representing the partials of a periodic waveform.  The created


### PR DESCRIPTION
Instead of limiting the max array size to 2048, change the spec to say
that arrays of at least 8192 elements must be supported.  No error is
thrown if larger sizes are specified.

It is left to the implementation to optimize this appropriately for the actual 
context sampleRate.