### PR TITLE
InvalidStateError must be thrown if WaveShaper curve is too short.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5799,7 +5799,7 @@ may be specified.
       for a signal at zero.
     </p>
     <p>
-      A <code>InvalidAccessError</code> MUST be thrown if this attribute is set
+      A <code>InvalidStateError</code> MUST be thrown if this attribute is set
       with a <code>Float32Array</code> that has a <code>length</code> less than
       2.
     </p>


### PR DESCRIPTION
Fixes #464.