### PR TITLE
Add optional normalization parameter to createPeriodicWave

### DIFF
--- a/index.html
+++ b/index.html
@@ -835,7 +835,7 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
       Conveniently, this corresponds to the full-range of the signal values used by
       the Web Audio API.  Because the PeriodicWave is normalized by default on creation,
       the <code>real</code> and <code>imag</code> parameters represent
-      <em>relative</em> values. If normalization is disabled via the <code>normalize</code>
+      <em>relative</em> values. If normalization is disabled via the <code>disableNormalization</code>
       parameter, this normalization is disabled, and the time-domain waveform has the amplitudes as
       given by the Fourier coefficients.
     <p>

--- a/index.html
+++ b/index.html
@@ -828,14 +828,16 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
       <a href="https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
       representing the partials of a periodic waveform.  The created
       <a><code>PeriodicWave</code></a> will be used with an
-      <a><code>OscillatorNode</code></a> and will represent a <em>normalized</em>
+      <a><code>OscillatorNode</code></a> and, by default,  will represent a <em>normalized</em>
       time-domain waveform having maximum absolute peak value of 1.  Another way of
       saying this is that the generated waveform of an
       <a><code>OscillatorNode</code></a> will have maximum peak value at 0dBFS.
       Conveniently, this corresponds to the full-range of the signal values used by
-      the Web Audio API.  Because the PeriodicWave will be normalized on creation,
+      the Web Audio API.  Because the PeriodicWave is normalized by default on creation,
       the <code>real</code> and <code>imag</code> parameters represent
-      <em>relative</em> values.
+      <em>relative</em> values. If normalization is disabled via the <code>normalize</code>
+      parameter, this normalization is disabled, and the time-domain waveform has the amplitudes as
+      given by the Fourier coefficients.
     <p>
       As <a>PeriodicWave</a> objects maintain their own representation, any
       modification of the arrays uses as the <code>real</code> and
@@ -864,6 +866,12 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
         not exist in the Fourier series.  The second element (index 1) represents
         the fundamental frequency.  The third element represents the first
         overtone, and so on.
+      </dd>
+      <dt>optional boolean normalize</dt>
+      <dd>
+        The <dfn id="dfn-normalize">normalize</dfn> parameter indicates whether the periodic wave
+        should be normalized or not.  By default the periodic wave is normalized.  If the parameter
+        is not given, the periodic wave is normalized.
       </dd>
     </dl>
     </dd>
@@ -4468,7 +4476,7 @@ to determine a <em>computedFrequency</em> value:
 </dl>
 
 <section>
-<h2>Basic waveform phase</h2>
+<h2>Basic Waveform Phase</h2>
 <p>
   The idealized mathematical waveforms for the various oscillator types are defined here. In summary,
   all waveforms are defined mathematically to be an odd function with a positive slope at time
@@ -4514,6 +4522,33 @@ href="#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">setPe
 <dl title="interface PeriodicWave" class="idl">
 </dl>
 
+<section>
+<h2>Waveform Generation</h2>
+<p>
+The <a
+href="#widl-AudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag">createPeriodicWave()</a>
+method takes two arrays to specify the Fourier coefficients of the PeriodicWave. Let \(a\) and \(b\)
+represent the real and imaginary arrays of length \(L\).  Then the basic time-domain waveform
+\(x(t)\) can be computed using
+
+$$
+  x(n) = \sum_{k=1}^{L-1} a[k]\cos\frac{2\pi k n}{F_s} + b[k]\sin\frac{2\pi k n}{F_s}
+$$            
+where \(F_s\) is the sampling frequency of the context. This is the basic (unnormalized) waveform.
+</p>
+<p>
+When normalization is applied (the default), the fixed normalization factor \(f\) is computed as
+follows: 
+$$
+  f = \max_n |x(n)|
+$$
+Thus, the actual normalized waveform \(\hat{x}(n)\) is
+$$
+  \hat{x}(n) = \frac{x(n)}{f}
+$$
+</p>
+            
+</section>
 </section>
 
 <section>

--- a/index.html
+++ b/index.html
@@ -867,11 +867,10 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
         the fundamental frequency.  The third element represents the first
         overtone, and so on.
       </dd>
-      <dt>optional boolean normalize</dt>
+      <dt>optional PeriodicWaveConstraints constraints</dt>
       <dd>
-        The <dfn id="dfn-normalize">normalize</dfn> parameter indicates whether the periodic wave
-        should be normalized or not.  By default the periodic wave is normalized.  If the parameter
-        is not given, the periodic wave is normalized.
+        If not given, the waveform is normalized. Otherwise, the waveform is normalized according
+        the value given by <code>constraints</code>.
       </dd>
     </dl>
     </dd>
@@ -4523,6 +4522,18 @@ href="#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">setPe
 </dl>
 
 <section>
+<h2>PeriodicWaveConstraints</h2>
+The <code>PeriodicWaveConstraints</code> dictionary is used to specify how the waveform is
+normalized.
+<dl title="dictionary PeriodicWaveConstraints" class="idl">
+  <dt> boolean disableNormalization = false</dt>
+  <dd>
+    Controls whether the periodic wave is normalized or not.  If <code>true</code>, the waveform is
+    not normalized; otherwise, the waveform is normalized.
+  </dd>
+</dl>
+</section>
+<section>
 <h2>Waveform Generation</h2>
 <p>
 The <a
@@ -4562,7 +4573,7 @@ This fixed normalization factor must be applied to all generated waveforms.
 </p>
             
 </section>
-
+</section>
 <section>
 <h2 id="MediaStreamAudioSourceNode"> The MediaStreamAudioSourceNode Interface</h2>
 

--- a/index.html
+++ b/index.html
@@ -4528,27 +4528,39 @@ href="#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">setPe
 The <a
 href="#widl-AudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag">createPeriodicWave()</a>
 method takes two arrays to specify the Fourier coefficients of the PeriodicWave. Let \(a\) and \(b\)
-represent the real and imaginary arrays of length \(L\).  Then the basic time-domain waveform
-\(x(t)\) can be computed using
+represent the real and imaginary arrays of length \(L\).  Then the basic time-domain waveform,
+\(x(t)\), can be computed using
 
 $$
-  x(n) = \sum_{k=1}^{L-1} a[k]\cos\frac{2\pi k n}{F_s} + b[k]\sin\frac{2\pi k n}{F_s}
+  x(t) = \sum_{k=1}^{L-1} \left(a[k]\cos2\pi k t + b[k]\sin2\pi k t\right)
 $$            
-where \(F_s\) is the sampling frequency of the context. This is the basic (unnormalized) waveform.
+This is the basic (unnormalized) waveform.
+</p>
+</section>
+<section>
+<h2>Waveform Normalization</h2>
+<p>
+By default, the waveform defined in the previous section is normalized so that the maximum value is
+1. The normalization is done as follows.
 </p>
 <p>
-When normalization is applied (the default), the fixed normalization factor \(f\) is computed as
-follows: 
+Let 
 $$
-  f = \max_n |x(n)|
+  \tilde{x}(n) = \sum_{k=1}^{L-1} \left(a[k]\cos\frac{2\pi k n}{N}  + b[k]\sin\frac{2\pi k n}{N}\right)
+$$
+where \(N\) is a power of two.  (Note: \(\tilde{x}(n)\) can conveniently be computed using an
+inverse FFT.)
+The fixed normalization factor \(f\) is computed as follows: 
+$$
+  f = \max_{n = 0, \ldots, N - 1} |\tilde{x}(n)|
 $$
 Thus, the actual normalized waveform \(\hat{x}(n)\) is
 $$
-  \hat{x}(n) = \frac{x(n)}{f}
+  \hat{x}(n) = \frac{\tilde{x}(n)}{f}
 $$
+This fixed normalization factor must be applied to all generated waveforms.
 </p>
             
-</section>
 </section>
 
 <section>


### PR DESCRIPTION
Fix #91 

This adds the optional normalization parameter to createPeriodicWave, defines how normalization is done and how the time-domain waveform can be created from the Fourier coefficients.