### PR TITLE
Display formulas for the basic oscillator waves nicely.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4468,7 +4468,7 @@ to determine a <em>computedFrequency</em> value:
 </dl>
 
 <section>
-<h2>Basic waveform phase</h2>
+<h2>Basic Waveform Phase</h2>
 <p>
   The idealized mathematical waveforms for the various oscillator types are defined here. In summary,
   all waveforms are defined mathematically to be an odd function with a positive slope at time
@@ -4477,24 +4477,39 @@ to determine a <em>computedFrequency</em> value:
 <dl>
   <dt> "sine" </dt>
   <dd>
-    The waveform for sine oscillator is sin(t).
+    The waveform for sine oscillator is $$x(t) = \sin t$$.
   </dd>
   <dt>"square"</dt>
   <dd>
-    The waveform for the square wave oscillator is 1 for 0&le; t &lt; &pi; and
-    -1 for -&pi; &lt; t &lt; 0.
+    The waveform for the square wave oscillator is 
+    $$
+      x(t) =
+        \begin{cases}
+          1 & \mbox{for } 0&le; t &lt; \pi \\
+          -1 & \mbox{for } -\pi &lt; t &lt; 0.
+        \end{cases}
+    $$
   </dd>
   <dt>"sawtooth"</dt>
   <dd>
-    The waveform for the sawtooth oscillator is the ramp t/&pi; for -&pi; &lt; t
-    &le; &pi;
+    The waveform for the sawtooth oscillator is the ramp
+    $$
+      x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t &le; \pi;
+    $$
   </dd>
   <dt>"triangle"</dt>
   <dd>
-    The waveform for the triangle oscillator is 2/&pi;*t for 0 &le; t &le;
-    &pi;/2 and 1-2/&pi;*(t-&pi;/2) for &pi;/2 &lt; t &le; &pi;. This is extended
-    to all t by using the fact that the waveform is an odd function with period
-    2&pi;.
+    The waveform for the triangle oscillator is 
+    $$
+      x(t) = 
+        \begin{cases}
+          \frac{2}{\pi} t & \mbox{for } 0 &le; t &le; \frac{\pi}{2} \\
+          1-\frac{2}{\pi} (t-\frac{\pi}{2}) & \mbox{for } \frac{\pi}{2} &lt; t &le; \pi. 
+        \end{cases}
+    $$
+    This is extended
+    to all \(t\) by using the fact that the waveform is an odd function with period
+    \(2\pi\).
   </dd>
 </dl>
 </section>


### PR DESCRIPTION
Simple change to display nicely the equations of the basic oscillator waveforms.  We take advantage of using TeX mode of MathJax to display these nicely.