### PR TITLE
Fix #547: Define index for setValueCurveAtTime

### DIFF
--- a/index.html
+++ b/index.html
@@ -1699,18 +1699,19 @@ The following rules will apply when calling these methods:
         calculated according to the <em>values</em> parameter.
       </p>
       <p>
-        During the time interval: <code>startTime</code> &lt;= t &lt;
-        <code>startTime</code> + <em>duration</em>, values will be calculated:
+        During the time interval \(T_0 \leq t &lt; T_0 + D\) where \(T_0\) is 
+        <code>startTime</code> and \(D\) is <code>duration</code>, values will be calculated
+        according to
+        $$
+          v(t) = V[k]
+        $$
+        where \(V\) is the <code>values</code> array, \(N\) is the length of the <code>values</code>
+        array, and \(k = \left\lfloor \frac{1}{2} + \frac{t-T_0}{D} N \right\rfloor\).  That is the
+        index is rounded to the nearest integer.
       </p>
-      <pre>
-        v(t) = values[N * (t - startTime) / duration]
-      </pre>
       <p>
-        where <em>N</em> is the length of the <em>values</em> array.
-      </p>
-      <p>
-        After the end of the curve time interval (t &gt;= <code>startTime</code> +
-        <em>duration</em>), the value will remain constant at the final curve
+        After the end of the curve time interval (\(t \geq T_0 + D\)),
+        the value will remain constant at the final curve
         value, until there is another automation event (if any).
       </p>
     </dd>


### PR DESCRIPTION
The indexing into the values array was not well-defined.  Specify that
the floating-point index is rounded to the nearest integer to index
into the array.  No interpolation is done.