### PR TITLE
Fix #416: Specify the units for the frequency data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1699,19 +1699,18 @@ The following rules will apply when calling these methods:
         calculated according to the <em>values</em> parameter.
       </p>
       <p>
-        During the time interval \(T_0 \leq t &lt; T_0 + D\) where \(T_0\) is 
-        <code>startTime</code> and \(D\) is <code>duration</code>, values will be calculated
-        according to
-        $$
-          v(t) = V[k]
-        $$
-        where \(V\) is the <code>values</code> array, \(N\) is the length of the <code>values</code>
-        array, and \(k = \left\lfloor \frac{1}{2} + \frac{t-T_0}{D} N \right\rfloor\).  That is the
-        index is rounded to the nearest integer.
+        During the time interval: <code>startTime</code> &lt;= t &lt;
+        <code>startTime</code> + <em>duration</em>, values will be calculated:
+      </p>
+      <pre>
+        v(t) = values[N * (t - startTime) / duration]
+      </pre>
+      <p>
+        where <em>N</em> is the length of the <em>values</em> array.
       </p>
       <p>
-        After the end of the curve time interval (\(t \geq T_0 + D\)),
-        the value will remain constant at the final curve
+        After the end of the curve time interval (t &gt;= <code>startTime</code> +
+        <em>duration</em>), the value will remain constant at the final curve
         value, until there is another automation event (if any).
       </p>
     </dd>

--- a/index.html
+++ b/index.html
@@ -3476,6 +3476,9 @@ float calculateNormalizationScale(buffer)
         excess elements will be dropped. If the array has more elements than
         the <a><code>frequencyBinCount</code></a>, the excess elements will be ignored.
       </p>
+      <p>
+        The frequency data are in dB units.
+      </p>
       <dl class="parameters">
         <dt>Float32Array array</dt>
         <dd>
@@ -3582,11 +3585,16 @@ computed, the following operations are to be performed:
   <li> <a href="#blackman-window">Apply a Blackman window</a> to the time domain input data </li>
   <li> <a href="#fourier-transform">Apply a Fourier tranform</a> to the windowed time domain input data to get imaginary and real frequency data </li>
   <li> <a href="#smoothing-over-time">Smooth over time</a> the frequency domain data</li>
+  <li> <a href="#conversion-to-db">Conversion to dB</a>.</li>
 </ol>
+
+<p>
+  In the following, let \(N\) be the value of the <code>.fftSize</code> attribute of this <code>AnalyserNode</code>.
+</p>
 
 <dfn id="blackman-window">Applying a Blackman window</dfn> consists in the
 following operation on the input time domain data.  Let \(x[n]\) for \(n = 0, \ldots, N - 1\) be the
-time domain data, where \(N\) is the value of the <code>.fftSize</code> attribute. The Blackman
+time domain data. The Blackman
 window is defined by
 $$
   \begin{align*}
@@ -3612,55 +3620,50 @@ the windowed time domain data computed above.  Then
 $$
   X[k] = \sum_{n = 0}^{N - 1} \hat{x}[n] e^{\frac{-2\pi i k n}{N}}
 $$
-for \(k = 0, \dots, N/2-1\) where \(N\) is the value of the <code>.fftSize</code> attribute.  The
-desired frequency domain data is \(\left|X[k]\right|\), the magnitude of the complex values.
+for \(k = 0, \dots, N/2-1\).
 </p>
 <p>
 <dfn id="smoothing-over-time">Smoothing over time</dfn> frequency data consists
 in the following operation:
 <ul>
 <li>
-  Let <code>fftSize</code> be the value of <a
-    href="#widl-AnalyserNode-fftSize"><code>fftSize</code></a> for this
-  <a>AnalyserNode</a>.
-</li>
-<li>
-  Let <code>outputBuffer</code> be an array that contains
-  the frequency data that will be made available to the author via <a
-    href="#widl-AnalyserNode-getFloatFrequencyData-void-Float32Array-array"><code>getFloatFrequencyData</code></a>,
-  or <a
-  href="#widl-AnalyserNode-getByteFrequencyData-void-Uint8Array-array"><code>getByteFrequencyData</code></a>.
-</li>
-<li>
-  Let <code>lastOutputBuffer</code> be the result of this operation on the
+  Let \(\hat{X}_{-1}[k]\) be the result of this operation on the
   <a>previous block</a>. The <dfn>previous block</dfn> is defined as being the
-  buffer returned by the previous <a href="#smoothing-over-time">smoothing over
-  time</a> operation, or an array of <code>fftSize</code> zeros if this is the
+  buffer computed by the previous <a href="#smoothing-over-time">smoothing over
+  time</a> operation, or an array of \(N\) zeros if this is the
   first time we are <a href="#smoothing-over-time">smoothing over time</a>.
 </li>
 <li>
-  Let <code>smoothingConstant</code> be the value of the <a
+  Let \(\tau\) be the value of the <a
   href="#widl-AnalyserNode-smoothingTimeConstant"><code>smoothingTimeConstant</code></a> attribute for
   this <a><code>AnalyserNode</code></a>.
 </li>
 <li>
-  Let <code>real</code> and <code>imag</code> be two arrays of length
-  <code>fftSize</code>, that contain the result of the previously applied Fourier
-  transform.
+  Let \(X[k]\) be the result of <a href="#fourier-transform">applying a Fourier transform</a> of the
+  current block.
 </li>
 </ul>
+<p>
+Then the smoothed value, \(\hat{X}[k]\), is computed by
+$$
+  \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]|
+$$
+for \(k = 0, \ldots, N - 1\).
+</p>	    
 
-<pre class="highlight">
-  function smoothingOverTime(outputBuffer, lastOutputBuffer,
-                             smoothingConstant,
-                             real, imag, fftSize) {
-    for (var i = 0; i &lt; outputBuffer.length; i++) {
-      var magnitude = Math.sqrt(real[i] * real[i] + imag[i] * imag[i]) / fftSize;
-      outputBuffer[i] = smoothingTimeConstant * lastOutputBuffer[i] + (1.0 - smoothingTimeConstant) * magnitude;
-    }
-  }
-</pre>
-</p>
+<dfn id="conversion-to-db">Conversion to dB</dfn> consists of the following operation, where
+\(\hat{X}[k]\) is computed in <a href="#smoothing-over-time">smoothing over time</a>:
+$$
+  Y[k] = 20\log_{10}\hat{X}[k]
+$$
+for \(k = 0, \ldots, N-1\).
+<p>
+  This array, \(Y[k]\), is copied to the output array for <code>getFloatFrequencyData</code>.  For
+  <code>getByteFrequencyData</code>, the \(Y[k]\) is clipped to lie between <code>minDecibels</code>
+  and <code>maxDecibels</code> and then scaled to fit in an unsigned byte such that
+  <code>minDecibels</code> is represented by the value 0 and <code>maxDecibels</code> is represented
+  by the value 255.
+</p>	    
 </section>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -1699,18 +1699,19 @@ The following rules will apply when calling these methods:
         calculated according to the <em>values</em> parameter.
       </p>
       <p>
-        During the time interval: <code>startTime</code> &lt;= t &lt;
-        <code>startTime</code> + <em>duration</em>, values will be calculated:
+        During the time interval \(T_0 \leq t &lt; T_0 + D\) where \(T_0\) is 
+        <code>startTime</code> and \(D\) is <code>duration</code>, values will be calculated
+        according to
+        $$
+          v(t) = V[k]
+        $$
+        where \(V\) is the <code>values</code> array, \(N\) is the length of the <code>values</code>
+        array, and \(k = \left\lfloor \frac{1}{2} + \frac{t-T_0}{D} N \right\rfloor\).  That is the
+        index is rounded to the nearest integer.
       </p>
-      <pre>
-        v(t) = values[N * (t - startTime) / duration]
-      </pre>
       <p>
-        where <em>N</em> is the length of the <em>values</em> array.
-      </p>
-      <p>
-        After the end of the curve time interval (t &gt;= <code>startTime</code> +
-        <em>duration</em>), the value will remain constant at the final curve
+        After the end of the curve time interval (\(t \geq T_0 + D\)),
+        the value will remain constant at the final curve
         value, until there is another automation event (if any).
       </p>
     </dd>


### PR DESCRIPTION
Specify that the output of getFloatFrequencyData and
getByteFrequencyData are in dB.  This also updates the description for
the FFT Windowing and smoothing to include a section on converted to
dB. The smoothing section is also replaced with mathematical notation
instead of code.
