### PR TITLE
Use mathematical notation for panner distance formulas

### DIFF
--- a/index.html
+++ b/index.html
@@ -3066,26 +3066,32 @@ The <a><code>DistanceModelType</code></a> enum determines which algorithm will b
 reduce the volume of an audio source as it moves away from the listener.  The
 default is "inverse".
 </p>
+<p>
+  In the description of each distance model below, let \(d\) be the distance between the listener
+  and the panner; \(d_{ref}\) be the value of the <code>refDistance</code> attribute; \(d_{max}\) be
+  the value of the <code>maxDistance</code> attribute; and \(f\) be the value of the
+  <code>rolloffFactor</code> attribute.
+</p>        
 <dl title="enum DistanceModelType" class=idl>
   <dt>linear</dt>
   <dd>
   A linear distance model which calculates <em>distanceGain</em> according to:
-  <pre>
-    1 - rolloffFactor * (distance - refDistance) / (maxDistance - refDistance)
-  </pre>
+  $$
+    1 - f\frac{d - d_{ref}}{d_{max} - d_{ref}}
+  $$
   </dd>
   <dt>inverse</dt>
   <dd>
   <p>An inverse distance model which calculates <em>distanceGain</em> according to: </p>
-  <pre>
-    refDistance / (refDistance + rolloffFactor * (distance - refDistance))
-  </pre>
+  $$
+    \frac{d_{ref}}{d_{ref} + f (d - d_{ref})}
+  $$
   </dd>
   <dt>exponential</dt>
   <dd><p>An exponential distance model which calculates <em>distanceGain</em> according to: </p>
-  <pre>
-    pow(distance / refDistance, -rolloffFactor)
-  </pre>
+  $$
+    \left(\frac{d}{d_{ref}}\right)^{-f}
+  $$
   </dd>
 </dl>
 


### PR DESCRIPTION
Using math notation makes the formulas a little easier to read and understand.