### PR TITLE
Fix #323: Add IIRFilterNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,7 +778,7 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
       <dl class=parameters>
         <dt> Float32Array feedforward</dt>
 	<dd>
-          An array of the feedforward (numerator) coefficients for the tranfer function of the IIR
+          An array of the feedforward (numerator) coefficients for the transfer function of the IIR
           filter. The maximum length of this array is 20.  If all of the values are zero, an
           InvalidStateError MUST be thrown.  A NotSupportedError MUST be thrown if the array length
           is 0 or greater than 20.

--- a/index.html
+++ b/index.html
@@ -4386,13 +4386,15 @@ The number of channels of the output always equals the number of channels of the
     <dt>Float32Array magResponse</dt>
     <dd>
       This parameter specifies an output array receiving the linear magnitude
-      response values.
+      response values.  If this array is shorter than <code>frequencyHz</code> a NotSupportedError
+      MUST be signaled. 
     </dd>
     <dt>Float32Array phaseResponse</dt>
-   <dd>
-    This parameter specifies an output array receiving the phase response values
-    in radians.
-   </dd>
+    <dd>
+      This parameter specifies an output array receiving the phase response values
+      in radians.  If this array is shorter than <code>frequencyHz</code> a NotSupportedError
+      MUST be signaled.
+    </dd>
   </dl>
   </dd>
 </dl>

--- a/index.html
+++ b/index.html
@@ -774,19 +774,21 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
       several common filter types.
     </dd>
     <dt> IIRFilterNode createIIRFilter(Float32Array b, Float32Array a) </dt>
-    <dd>Creates a <a><code>IIRFilterNode</code></a> representing a general IIR FIlter.
+    <dd>Creates an <a><code>IIRFilterNode</code></a> representing a general IIR Filter.
       <dl class=parameters>
         <dt> Float32Array b</dt>
 	<dd>
           An array of the numerator coefficients for the tranfer function of the IIR filter. The
-          maximum length of this array is 20.  A NotSupportedError MUST be thrown if the array
+          maximum length of this array is 20.  If all of the values are zero, an InvalidStateError
+          MUST be thrown.  A NotSupportedError MUST be thrown if the array
           length is 0 or greater than 20.
 	</dd>
         <dt> Float32Array a</dt>
         <dd>
           An array of the denominator coefficients for the tranfer function of the IIR filter. The
-          maximum length of this array is 20.  A NotSupportedError MUST be thrown if the array
-          length is 0 or greater than 20.
+          maximum length of this array is 20.  If the first element of the array is 0, an
+          InvalidStateError MUST be thrown.  A NotSupportedError MUST be thrown if the array length
+          is 0 or greater than 20. 
         </dd>
       </dl>
     </dd>
@@ -4399,10 +4401,17 @@ The number of channels of the output always equals the number of channels of the
     <p>
       The transfer function of the general IIR filter is given by
       $$
-        H(z) = \frac{\sum_{m=0}^{M-1} b_m z^{-m}}{\sum_{n=0}^{N-1} a_n z^{-n}}
+        H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}}
       $$
-      where \(M\) is the length of the <code>b</code> array and \(N\) is the length of the
-      <code>a</code> array.
+      where \(M + 1\) is the length of the <code>b</code> array and \(N + 1\) is the length of the
+      <code>a</code> array.  The coefficient \(a_0\) cannot be 0.  At least one of \(b_m\) must be
+      non-zero. 
+    </p>
+    <p>
+      Equivalently, the time-domain equation is
+      $$
+        \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k)
+      $$
     </p>
     <p>
       The initial filter state is the all-zeroes state.

--- a/index.html
+++ b/index.html
@@ -431,6 +431,9 @@ function setupRoutingGraph () {
       <li>Allpass </li>
     </ul>
   </li>
+  <li>A <a><code>IIRFilterNode</code></a> interface, an <a><code>AudioNode</code></a> for a general
+  IIR filter.
+  </li>	  
   <li>A <a><code>DelayNode</code></a> interface, an
     <a><code>AudioNode</code></a> which applies a dynamically adjustable variable delay. </li>
   <li>A <a><code>PannerNode</code></a>
@@ -767,6 +770,23 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
     <dd>Creates a <a><code>BiquadFilterNode</code></a>
       representing a second order filter which can be configured as one of
       several common filter types.
+    </dd>
+    <dt> IIRFilterNode createIIRFilter(Float32Array b, Float32Array a) </dt>
+    <dd>Creates a <a><code>IIRFilterNode</code></a> representing a general IIR FIlter.
+      <dl class=parameters>
+        <dt> Float32Array b</dt>
+	<dd>
+          An array of the numerator coefficients for the tranfer function of the IIR filter. The
+          maximum length of this array is 20.  A NotSupportedError MUST be thrown if the array
+          length is 0 or greater than 20.
+	</dd>
+        <dt> Float32Array a</dt>
+        <dd>
+          An array of the denominator coefficients for the tranfer function of the IIR filter. The
+          maximum length of this array is 20.  A NotSupportedError MUST be thrown if the array
+          length is 0 or greater than 20.
+        </dd>
+      </dl>
     </dd>
     <dt> WaveShaperNode createWaveShaper() </dt>
     <dd>
@@ -4241,6 +4261,77 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>k-rate</a>
   </p>
 </section>
 
+</section>
+<section>
+<h2>The IIRFilterNode Interface</h2>
+<p>
+ <a><code>IIRFilterNode</code></a> is an <a><code>AudioNode</code></a> processor implementing a general
+ IIR Filter.  In general, it is best to use <a><code>BiquadFilterNode</code></a>'s to implement
+ higher-order filters for the following reasons:
+ <ul>
+   <li>Generally less sensitive to numeric issues</li>
+   <li>Filter parameters can be automated</li>
+   <li>Can be used to create all even-ordered IIR filters</li>	    
+ </ul>
+</p>
+<p>
+  However, odd-ordered filters cannot be created, so if such filters are needed or automation is not
+  needed, then IIR filters are appropriate.
+</p>
+<p>
+  Once created, the coefficients of the IIR filter cannot be changed.	  
+</p>
+<pre>
+    numberOfInputs  : 1
+    numberOfOutputs : 1
+
+    channelCountMode = "max";
+    channelInterpretation = "speakers";
+</pre>	  
+<p>
+The number of channels of the output always equals the number of channels of the input.
+</p>
+
+<dl title="interface IIRFilterNode : AudioNode" class="idl">
+  <dt>void getFrequencyResponse() </dt>
+  <dd>
+  <p>
+    Given the current filter parameter settings, calculates the
+    frequency response for the specified frequencies.
+  </p>
+  <dl class="parameters">
+    <dt>Float32Array frequencyHz</dt>
+    <dd>
+      This parameter specifies an array of frequencies at which the response
+      values will be calculated.
+    </dd>
+    <dt>Float32Array magResponse</dt>
+    <dd>
+      This parameter specifies an output array receiving the linear magnitude
+      response values.
+    </dd>
+    <dt>Float32Array phaseResponse</dt>
+   <dd>
+    This parameter specifies an output array receiving the phase response values
+    in radians.
+   </dd>
+  </dl>
+  </dd>
+</dl>
+  <section>
+    <h3>Filter Definition</h3>
+    <p>
+      The transfer function of the general IIR filter is given by
+      $$
+        H(z) = \frac{\sum_{m=0}^{M-1} b_m z^{-m}}{\sum_{n=0}^{N-1} a_n z^{-n}}
+      $$
+      where \(M\) is the length of the <code>b</code> array and \(N\) is the length of the
+      <code>a</code> array.
+    </p>
+    <p>
+      The initial filter state is the all-zeroes state.
+    </p>	  
+  </section>
 </section>
 <section>
 <h2 id="WaveShaperNode">The WaveShaperNode Interface</h2>

--- a/index.html
+++ b/index.html
@@ -776,19 +776,19 @@ or <a href="#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-
     <dt> IIRFilterNode createIIRFilter(Float32Array b, Float32Array a) </dt>
     <dd>Creates an <a><code>IIRFilterNode</code></a> representing a general IIR Filter.
       <dl class=parameters>
-        <dt> Float32Array b</dt>
+        <dt> Float32Array feedforward</dt>
 	<dd>
-          An array of the numerator coefficients for the tranfer function of the IIR filter. The
-          maximum length of this array is 20.  If all of the values are zero, an InvalidStateError
-          MUST be thrown.  A NotSupportedError MUST be thrown if the array
-          length is 0 or greater than 20.
-	</dd>
-        <dt> Float32Array a</dt>
-        <dd>
-          An array of the denominator coefficients for the tranfer function of the IIR filter. The
-          maximum length of this array is 20.  If the first element of the array is 0, an
+          An array of the feedforward (numerator) coefficients for the tranfer function of the IIR
+          filter. The maximum length of this array is 20.  If all of the values are zero, an
           InvalidStateError MUST be thrown.  A NotSupportedError MUST be thrown if the array length
-          is 0 or greater than 20. 
+          is 0 or greater than 20.
+	</dd>
+        <dt> Float32Array feedback</dt>
+        <dd>
+          An array of the feedback (denominator) coefficients for the tranfer function of the IIR
+          filter. The maximum length of this array is 20.  If the first element of the array is 0,
+          an InvalidStateError MUST be thrown.  A NotSupportedError MUST be thrown if the array
+          length is 0 or greater than 20.
         </dd>
       </dl>
     </dd>
@@ -4354,7 +4354,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>a-rate</a>
 </p>
 <p>
   However, odd-ordered filters cannot be created, so if such filters are needed or automation is not
-  needed, then IIR filters are appropriate.
+  needed, then IIR filters may be appropriate.
 </p>
 <p>
   Once created, the coefficients of the IIR filter cannot be changed.	  
@@ -4399,12 +4399,15 @@ The number of channels of the output always equals the number of channels of the
   <section>
     <h3>Filter Definition</h3>
     <p>
-      The transfer function of the general IIR filter is given by
+      Let \(b_m\) be the <code>feedforward</code> coefficients and \(a_n\) be the
+      <code>feedback</code> coefficients specified by <a
+href="#widl-AudioContext-createIIRFilter-IIRFilterNode-Float32Array-feedforward-Float32Array-feedback"><code>createIIRFilter</code></a>.
+      Then the transfer function of the general IIR filter is given by
       $$
         H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}}
       $$
-      where \(M + 1\) is the length of the <code>b</code> array and \(N + 1\) is the length of the
-      <code>a</code> array.  The coefficient \(a_0\) cannot be 0.  At least one of \(b_m\) must be
+      where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is the length of the
+      \(a\) array.  The coefficient \(a_0\) cannot be 0.  At least one of \(b_m\) must be
       non-zero. 
     </p>
     <p>


### PR DESCRIPTION
This adds a new IIRFilterNode that implements a general IIR filter.
The filter coefficients are fixed and cannot be changed.  The maximum
number of coefficients is 20.

Is "IIRFIlterNode" the desired name?  What is the limit on the number of coefficients?  Should there be any?  In the constructor, the order of the arguments is the b (numerator coefficients) and a (denominator coefficients).  Is this the correct order?