### PR TITLE
Throw InvalidStateError when setting oscillator type to 'custom'.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4442,7 +4442,8 @@ to determine a <em>computedFrequency</em> value:
     <dt> attribute OscillatorType type </dt>
     <dd>
       The shape of the periodic waveform.  It may directly be set to any of the
-      type constant values except for "custom".  The <a
+      type constant values except for "custom".  Doing so MUST throw an InvalidStateError
+      exception. The <a
       href="#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave"><code>setPeriodicWave()</code></a> method can be
       used to set a custom waveform, which results in this attribute being set to
       "custom".  The default value is "sine". When this attribute is set, the


### PR DESCRIPTION
Fix #311.