### PR TITLE
Fix #564: Add descriptions of the parameters for automation functions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1567,15 +1567,19 @@ The following rules will apply when calling these methods:
     <p>
       Schedules a parameter value change at the given time.
     </p>
-    <p>
-      The <code>value</code> parameter is the value the parameter
-      will change to at the given time.
-    </p>
-    <p>
-      The <code>startTime</code> parameter is the time
-      in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError exception MUST be
-      thrown if <code>startTime</code> is negative or is not a finite number.
-    </p>
+    <dl class=parameters>
+      <dt>float value</dt>              
+      <dd>
+        The value the parameter will change to at the given time.
+      </dd>
+      <dt>double startTime</dt>
+      <dd>
+        The time in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a
+        href="#widl-AudioContext-currentTime">currentTime</a> attribute at which the parameter
+        changes to the given value.  An InvalidAccessError exception MUST be thrown if
+        <code>startTime</code> is negative or is not a finite number.
+      </dd>
+    </dl>
     <p>
       If there are no more events after this <em>SetValue</em> event, then for
       \(t \geq T_0\),  \(v(t) = V\), where \(T_0\) is the <code>startTime</code> parameter and \(V\)
@@ -1606,17 +1610,19 @@ The following rules will apply when calling these methods:
       Schedules a linear continuous change in parameter value from the previous
       scheduled parameter value to the given value.
     </p>
-    <p>
-      The <code>value</code> parameter is the value the parameter will linearly ramp
-      to at the given time.</p>
-    <p>
-      The <code>endTime</code> parameter is the time in the same time coordinate
-      system as the <a><code>AudioContext</code></a>'s <a
-      href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An
-      InvalidAccessError exception MUST be thrown if <code>endTime</code> is
-      negative or is not a finite number.
-    </p>
-
+    <dl class=parameters>
+      <dt>float value</dt>
+      <dd>
+        The value the parameter will linearly ramp to at the given time.
+      </dd>
+      <dt>double endTime</dt>
+      <dd>
+        The time in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a
+        href="#widl-AudioContext-currentTime">currentTime</a> attribute at which the automation
+        ends.  An InvalidAccessError exception MUST be thrown if <code>endTime</code> is negative or
+        is not a finite number.
+      </dd>
+    </dl>
     <p>
       The value during the time interval \(T_0 \leq t &lt; T_1\) (where \(T_0\) is the time
       of the previous event and \(T_1\) is the <code>endTime</code> parameter passed
@@ -1643,19 +1649,6 @@ The following rules will apply when calling these methods:
       exponentially because of the way humans perceive sound.
     </p>
     <p>
-      The <code>value</code> parameter is the value the parameter
-      will exponentially ramp to at the given time.  A NotSupportedError exception
-      MUST be thrown if this value is less than or equal to 0, or if the value at
-      the time of the previous event is less than or equal to 0.
-    </p>
-    <p>
-      The <code>endTime</code> parameter is the time in the same
-      time coordinate system as the <a><code>AudioContext</code></a>'s <a
-      href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An
-      InvalidAccessError exception MUST be thrown if <code>endTime</code> is
-      negative or is not a finite number.
-    </p>
-    <p>
       The value during the time interval \(T_0 \leq t &lt; T_1\) (where \(T_0\) is the time
       of the previous event and \(T_1\) is the <code>endTime</code> parameter passed into this
       method) will be calculated as:
@@ -1671,6 +1664,21 @@ The following rules will apply when calling these methods:
       If there are no more events after this ExponentialRampToValue event then for
       \(t \geq T_1\), \(v(t) = V_1\).
     </p>
+    <dl class=parameters>
+      <dt>float value</dt>
+      <dd>
+        The value the parameter will exponentially ramp to at the given time.  A NotSupportedError
+        exception MUST be thrown if this value is less than or equal to 0, or if the value at the
+        time of the previous event is less than or equal to 0.
+      </dd>
+      <dt>double endtime</dt>              
+      <dd>
+        The time in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a
+        href="#widl-AudioContext-currentTime">currentTime</a> attribute where the exponential ramp
+        ends.  An InvalidAccessError exception MUST be thrown if <code>endTime</code> is negative or
+        is not a finite number.
+      </dd>
+    <dl>
   </dd>
   <dt> void setTargetAtTime(float target, double startTime, float timeConstant) </dt>
   <dd>
@@ -1683,26 +1691,29 @@ The following rules will apply when calling these methods:
       change to the target value at the given time, but instead gradually
       changes to the target value.
     </p>
-    <p>
-      The <code>target</code> parameter is the value
-      the parameter will <em>start</em> changing to at the given time.
-    </p>
-    <p>
-      The <code>startTime</code> parameter is the time in the
-      same time coordinate system as the <a><code>AudioContext</code></a>'s <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError exception MUST be
-      thrown if <code>start</code> is negative or is not a finite number.
-    </p>
-    <p>
-      The <dfn id="dfn-timeConstant">timeConstant</dfn> parameter is the
-      time-constant value of first-order filter (exponential) approach to the
-      target value. The larger this value is, the slower the transition will
-      be.
-    </p>
-    <p>
-      More precisely, <em>timeConstant</em> is the time it takes a first-order
-      linear continuous time-invariant system to reach the value \(1 - 1/e\) (around
-      63.2%) given a step input response (transition from 0 to 1 value).
-    </p>
+    <dl class=parameters>
+      <dt>float target</dt>
+      <dd>
+        The value the parameter will <em>start</em> changing to at the given time.
+      </dd>
+      <dt>double startTime</dt>
+      <dd>
+        The time at which the exponential approach will begin, in the same time coordinate system as
+        the <a><code>AudioContext</code></a>'s <a
+        href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError
+        exception MUST be thrown if <code>start</code> is negative or is not a finite number.
+      </dd>
+      <dt>float timeConstant</dt>              
+      <dd>
+        The time-constant value of first-order filter (exponential) approach to the target
+        value. The larger this value is, the slower the transition will be.
+        <p>
+        More precisely, <em>timeConstant</em> is the time it takes a first-order
+        linear continuous time-invariant system to reach the value \(1 - 1/e\) (around
+        63.2%) given a step input response (transition from 0 to 1 value).
+        </p>
+      </dd>
+    </dl>            
     <p>
       During the time interval: \(T_0 \leq t &lt; T_1\), where \(T_0\)
       is the <code>startTime</code> parameter and \(T_1\) represents the time of the
@@ -1725,25 +1736,28 @@ The following rules will apply when calling these methods:
         time for the given duration. The number of values will be scaled to fit
         into the desired duration.
       </p>
-      <p>
-        The <code>values</code> parameter is a Float32Array
-        representing a parameter value curve. These values will apply starting at
-        the given time and lasting for the given duration. Any modification to the
-        the array used as <a id="#dfn-values"><code>values</code></a> argument
-        after the call won't have any effect on the <a>AudioParam</a>.
-      </p>
-      <p>
-        The <code>startTime</code> parameter is the time in the same time
-        coordinate system as the <a><code>AudioContext</code></a>'s <a
-        href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An
-        InvalidAccessError exception MUST be thrown if <code>startTime</code> is
-        negative or is not a finite number.
-      </p>
-      <p>
-        The <dfn id="dfn-duration_5">duration</dfn> parameter is the amount of
-        time in seconds (after the <em>time</em> parameter) where values will be
-        calculated according to the <em>values</em> parameter.
-      </p>
+      <dl class=parameters>
+        <dt>Float32Array values</dt>              
+        <dd>
+          A Float32Array representing a parameter value curve. These values will apply starting at
+          the given time and lasting for the given duration. Any modification to the the array used
+          as <a id="#dfn-values"><code>values</code></a> argument after the call won't have any
+          effect on the <a>AudioParam</a>.
+        </dd>
+        <dt>double startTime</dt>
+        <dd>
+          The start time in the same time coordinate system as the
+          <a><code>AudioContext</code></a>'s <a
+          href="#widl-AudioContext-currentTime">currentTime</a> attribute at which the value curve
+          will be applied.  An InvalidAccessError exception MUST be thrown if <code>startTime</code>
+          is negative or is not a finite number.
+        </dd>
+        <dt>double duration</dt>
+        <dd>
+          The amount of time in seconds (after the <em>time</em> parameter) where values will be
+          calculated according to the <em>values</em> parameter.
+        </dd>
+      </dl>              
       <p>
         During the time interval: <code>startTime</code> &lt;= t &lt;
         <code>startTime</code> + <em>duration</em>, values will be calculated:
@@ -1766,15 +1780,16 @@ The following rules will apply when calling these methods:
         Cancels all scheduled parameter changes with times greater than or
         equal to <code>startTime</code>.
       </p>
-      <p>
-        The <code>startTime</code> parameter is the starting time at and after
-        which any previously scheduled parameter changes will be cancelled.  It
-        is a time in the same time coordinate system as
-        the <a><code>AudioContext</code></a>'s
-        <a href="#widl-AudioContext-currentTime">currentTime</a> attribute.
-        An InvalidAccessError exception MUST be thrown if <code>startTime</code>
-        is negative or is not a finite number.
-      </p>
+      <dl class=parameters>
+        <dt>double startTime</dt>
+        <dd>
+          The starting time at and after which any previously scheduled parameter changes will be
+          cancelled.  It is a time in the same time coordinate system as the
+          <a><code>AudioContext</code></a>'s <a
+          href="#widl-AudioContext-currentTime">currentTime</a> attribute.  An InvalidAccessError
+          exception MUST be thrown if <code>startTime</code> is negative or is not a finite number.
+        </dd>
+      </dl>
     </dd>
 </dl>
 


### PR DESCRIPTION
This moves the description of the parameters for each automation
function from the paragraphs to the description box in the parameter
list.