### PR TITLE
Describe constraints for getFrequencyResponse.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4146,13 +4146,15 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>a-rate</a>
     <dt>Float32Array magResponse</dt>
     <dd>
       This parameter specifies an output array receiving the linear magnitude
-      response values.
+      response values.  If this array is shorter than <code>frequencyHz</code> a NotSupportedError
+      MUST be signaled. 
     </dd>
     <dt>Float32Array phaseResponse</dt>
-   <dd>
-    This parameter specifies an output array receiving the phase response values
-    in radians.
-   </dd>
+    <dd>
+      This parameter specifies an output array receiving the phase response values
+      in radians.  If this array is shorter than <code>frequencyHz</code> a NotSupportedError
+      MUST be signaled.
+    </dd>
   </dl>
   </dd>
 </dl>


### PR DESCRIPTION
Fix #584.  The output arrays have to be longer than the frequencyHz array.