### PR TITLE
Clarify that computedPlaybackRate must be implemented by resampling the audio.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2255,14 +2255,22 @@ invoked in the following cases:
 Both <code>playbackRate</code> and <code>detune</code> are <a>k-rate</a>
 parameters and are used together to determine a <em>computedPlaybackRate</em>
 value:
+</p>
 
 <pre class=highlight>
   computedPlaybackRate(t) = playbackRate(t) * pow(2, detune(t) / 1200)
 </pre>
 
+<p>
 The <code>computedPlaybackRate</code> is the effective speed at which the
 <a><code>AudioBuffer</code></a> of this <a><code>AudioBufferSourceNode</code></a>
 MUST be played.
+</p>
+
+<p>
+This MUST be implemented by <em>resampling</em> the input data using a
+resampling ratio of 1 / <code>computedPlaybackRate</code>, hence
+changing both the pitch and speed of the audio.
 </p>
 
 <section>


### PR DESCRIPTION
This fixes #497.