### PR TITLE
Use `unsigned long` for index type in copyFromChannel and copyToChannel.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2008,7 +2008,7 @@ interface is an <a><code>AudioNode</code></a> with a single input and single out
       <dl class="parameters">
         <dt>Float32Array destination</dt>
         <dd>The array the channel data will be copied to.</dd>
-        <dt>long channelNumber</dt>
+        <dt>unsigned long channelNumber</dt>
         <dd>
           The index of the channel to copy the data from. If
           <code>channelNumber</code> is greater or equal than the number of
@@ -2031,7 +2031,7 @@ interface is an <a><code>AudioNode</code></a> with a single input and single out
       <dl class="parameters">
         <dt>Float32Array source</dt>
         <dd>The array the channel data will be copied from.</dd>
-        <dt>long channelNumber</dt>
+        <dt>unsigned long channelNumber</dt>
         <dd>
           The index of the channel to copy the data to. If
           <code>channelNumber</code> is greater or equal than the number of


### PR DESCRIPTION
This fixes #565