### PR TITLE
#598: Adjust reference to Audio EQ Cookbook

### DIFF
--- a/index.html
+++ b/index.html
@@ -4224,7 +4224,7 @@ All attributes of the <a><code>BiquadFilterNode</code></a> are <a>a-rate</a>
     through the <a><code>BiquadFilterNode</code></a> each having very different
     characteristics. The formulas in this section describe the filters that a
     <a>conforming implementation</a> MUST implement, as they determine the
-    characteristics of the different filter type. They are derived from formulas
+    characteristics of the different filter types. They are inspired by formulas
     found in the <a href
     ="http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt">Audio EQ
     Cookbook</a>.


### PR DESCRIPTION
Fixes WebAudio/web-audio-api/#598.

Instead of saying the biquad formulas from the cookbook, say they're
inspired by the cookbook because the many of formulas are different
from the ones in the cookbook.