### PR TITLE
Fix some links and capitalizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1591,7 +1591,7 @@ through the <code>destination</code> attribute of <a><code>AudioContext</code></
 
 <ul>
 <li><a href="#widl-AudioParam-setValueAtTime-void-float-value-double-startTime">setValueAtTime()</a> - <em>SetValue</em></li>
-<li><a href="#widl-AudioParam-exponentialRampToValueAtTime-void-float-value-double-endTime">linearRampToValueAtTime()</a> - <em>LinearRampToValue</em></li>
+<li><a href="#widl-AudioParam-linearRampToValueAtTime-void-float-value-double-endTime">linearRampToValueAtTime()</a> - <em>LinearRampToValue</em></li>
 <li><a href="#widl-AudioParam-exponentialRampToValueAtTime-void-float-value-double-endTime">exponentialRampToValueAtTime()</a> - <em>ExponentialRampToValue</em></li>
 <li><a href="#widl-AudioParam-setTargetAtTime-void-float-target-double-startTime-float-timeConstant">setTargetAtTime()</a> - <em>SetTarget</em></li>
 <li><a href="#widl-AudioParam-setValueCurveAtTime-void-Float32Array-values-double-startTime-double-duration">setValueCurveAtTime()</a> - <em>SetValueCurve</em></li>
@@ -1753,7 +1753,7 @@ The following rules will apply when calling these methods:
         exception MUST be thrown if this value is less than or equal to 0, or if the value at the
         time of the previous event is less than or equal to 0.
       </dd>
-      <dt>double endtime</dt>              
+      <dt>double endTime</dt>
       <dd>
         The time in the same time coordinate system as the <a><code>AudioContext</code></a>'s <a
         href="#widl-AudioContext-currentTime">currentTime</a> attribute where the exponential ramp
@@ -5970,7 +5970,7 @@ clamped to [0, 1].
 </section>
 
 <section>
-<h3>Audio buffer copying</h3>
+<h3>Audio Buffer Copying</h3>
 <p>
   When an <a href="#acquire-the-content">acquire the content</a> operation is
   performed on an <a>AudioBuffer</a>, the entire operation can usually be
@@ -6000,15 +6000,15 @@ clamped to [0, 1].
 </section>
 
 <section class=informative>
-<h3>AudioParam transitions</h3>
+<h3>AudioParam Transitions</h3>
 <p>
   While no automatic smoothing is done when directly setting the
-  <a><code>value</code></a> attribute of an <a><code>AudioParam</code></a>, for
+  <a href="#widl-AudioParam-value"><code>value</code></a> attribute of an <a><code>AudioParam</code></a>, for
   certain parameters, smooth transition are preferable to directly setting
   the value.
 </p>
 <p>
-  Using the <a><code>setTargetAtTime</code></a> method with a low
+  Using the <a href="#widl-AudioParam-setTargetAtTime-void-float-target-double-startTime-float-timeConstant"><code>setTargetAtTime</code></a> method with a low
   <code>timeConstant</code> allows authors to a perform smooth transition.
 </p>
 </section>
@@ -6026,7 +6026,7 @@ clamped to [0, 1].
 </section>
 
 <section>
-<h3 id="JavaScriptPerformance">JavaScript Issues with real-time Processing and Synthesis: </h3>
+<h3 id="JavaScriptPerformance">JavaScript Issues with Real-Time Processing and Synthesis: </h3>
 While processing audio in JavaScript, it is extremely challenging to get
 reliable, glitch-free audio while achieving a reasonably low-latency,
 especially under heavy processor load.


### PR DESCRIPTION
* The link linearRamp automation method in section "AudioParam
  Interface" was incorrect.
* The name of the endTime parameter for exponentialRampToValue was not
  correctly cased (endtime -> endTime).
* Use correct link for the value attribute in section "AudioParam
  Transitions" and setTargetAtTime link.
* Remove undefined link for timeConstant that caused ReSpec to
  complain.
* Capitalize section names appropriately to match existing style.