### PR TITLE
Update distance formulas to clamp the distance appropriately.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4238,8 +4238,11 @@ onaudioprocess= function (e) {
             linear
           </dt>
           <dd>
-            A linear distance model which calculates <em>distanceGain</em>
-            according to: $$ 1 - f\frac{d - d_{ref}}{d_{max} - d_{ref}} $$
+            <p>A linear distance model which calculates <em>distanceGain</em>
+            according to:
+            $$ 1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}} $$</p>
+            That is, \(d\) is clamped to the interval \([d_{ref},\, d_{max}]\).
+            </p>
           </dd>
           <dt>
             inverse
@@ -4248,7 +4251,8 @@ onaudioprocess= function (e) {
             <p>
               An inverse distance model which calculates <em>distanceGain</em>
               according to:
-            </p>$$ \frac{d_{ref}}{d_{ref} + f (d - d_{ref})} $$
+            </p>$$ \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})} $$
+            That is, \(d\) is clamped to the interval \([d_{ref},\, \infty)\).
           </dd>
           <dt>
             exponential
@@ -4257,7 +4261,8 @@ onaudioprocess= function (e) {
             <p>
               An exponential distance model which calculates
               <em>distanceGain</em> according to:
-            </p>$$ \left(\frac{d}{d_{ref}}\right)^{-f} $$
+            </p>$$ \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f} $$
+            That is, \(d\) is clamped to the interval \([d_{ref},\, \infty)\).
           </dd>
         </dl>
         <dl title="interface PannerNode : AudioNode" class="idl">


### PR DESCRIPTION
The distance formulas include appropriate clamping of the distances to
lie between d_ref and d_max (or infinity) as appropriate.

Fixes WebAudio/web-audio-api#326 and WebAudio/web-audio-api#328.