### PR TITLE
Add note about using setTargetAtTime for exponential ramp to 0.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2377,7 +2377,14 @@ function setupRoutingGraph() {
             </p>
             <p>
               where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
-              <code>value</code> parameter passed into this method.
+              <code>value</code> parameter passed into this method.  It is an error if either
+              \(V_0\) or \(V_1\) is not strictly positive.
+            </p>
+            <p>
+              This also implies an exponential ramp to 0 is not possible.  A good approximation can
+              be achieved using <a href=
+            "#widl-AudioParam-setTargetAtTime-void-float-target-double-startTime-float-timeConstant">setTargetAtTime</a>
+            with an appropriately chosen time constant.
             </p>
             <p>
               If there are no more events after this ExponentialRampToValue


### PR DESCRIPTION
Also state in the formula that V0 and V1 must be both positive.

Fixes WebAudio/web-audio-api#486.