### PR TITLE
Describe getByteTimeDomainData and getByteFrequencyData

### DIFF
--- a/index.html
+++ b/index.html
@@ -4736,7 +4736,7 @@ float calculateNormalizationScale(buffer)
               The values stored in the unsigned byte array are computed in the
               following way.  Let \(Y[k]\) be the <a>current frequency data</a>
               as described in <a
-              href="http://localhost:7100/#fft-windowing-and-smoothing-over-time">FFT windowing and
+              href="#fft-windowing-and-smoothing-over-time">FFT windowing and
               smoothing</a>.  Then the byte value, \(b[k]\), is
               $$
                 b[k] = \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}

--- a/index.html
+++ b/index.html
@@ -4732,14 +4732,18 @@ float calculateNormalizationScale(buffer)
               be ignored.
             </p>
             <p>
-              The values stored in the unsigned byte array are computed in the following way.  Let
-              \(Y[k]\) be the <a>current frequency data</a> as described in <a
+              The values stored in the unsigned byte array are computed in the
+              following way.  Let \(Y[k]\) be the <a>current frequency data</a>
+              as described in <a
               href="http://localhost:7100/#fft-windowing-and-smoothing-over-time">FFT windowing and
-              smoothing</a>.  Then the byte value, \(b[k]\), is $$ b[k] = \frac{255}{\mbox{dB}_{max}
-              - \mbox{dB}_{min}} \left(Y[k] - \mbox{dB}_{min}\right) $$ where \(\mbox{dB}_{min}\) is
-              <code><a>minDecibels</a></code> and \(\mbox{dB}_{max}\) is
-              <code><a>maxDecibels</a></code>. If \(b[k]\) lies outside the range of 0 to 255,
-              \(b[k]\) is clipped to lie in that range.
+              smoothing</a>.  Then the byte value, \(b[k]\), is
+              $$
+                b[k] = \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
+                 \left(Y[k] - \mbox{dB}_{min}\right)
+              $$ where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code> and
+              \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If \(b[k]\)
+              lies outside the range of 0 to 255, \(b[k]\) is clipped to lie in
+              that range.
             </p>
             <dl class="parameters">
               <dt>
@@ -4784,9 +4788,10 @@ float calculateNormalizationScale(buffer)
               <a><code>fftSize</code></a>, the excess elements will be ignored.
             </p>
             <p>
-              The values stored in the unsigned byte array are computed in the following way.  Let
-              \(x[k]\) be the time-domain data.  The the byte value, \(b[k]\), is $$ b[k] = 128(1 +
-              x[k]). $$ If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is clipped to lie in
+              The values stored in the unsigned byte array are computed in the
+              following way.  Let \(x[k]\) be the time-domain data.  Then the
+              byte value, \(b[k]\), is $$ b[k] = 128(1 + x[k]). $$ If \(b[k]\)
+              lies outside the range 0 to 255, \(b[k]\) is clipped to lie in
               that range.
             </p>
             <dl class="parameters">
@@ -4924,8 +4929,8 @@ float calculateNormalizationScale(buffer)
             This array, \(Y[k]\), is copied to the output array for
             <code>getFloatFrequencyData</code>. For
             <code>getByteFrequencyData</code>, the \(Y[k]\) is clipped to lie
-            between <code><a>minDecibels</a></code> and <code><a>maxDecibels</a></code> and
-            then scaled to fit in an unsigned byte such that
+            between <code><a>minDecibels</a></code> and <code><a>maxDecibels</a></code>
+            and then scaled to fit in an unsigned byte such that
             <code><a>minDecibels</a></code> is represented by the value 0 and
             <code><a>maxDecibels</a></code> is represented by the value 255.
           </p>

--- a/index.html
+++ b/index.html
@@ -4731,6 +4731,16 @@ float calculateNormalizationScale(buffer)
               <a><code>frequencyBinCount</code></a>, the excess elements will
               be ignored.
             </p>
+            <p>
+              The values stored in the unsigned byte array are computed in the following way.  Let
+              \(Y[k]\) be the <a>current frequency data</a> as described in <a
+              href="http://localhost:7100/#fft-windowing-and-smoothing-over-time">FFT windowing and
+              smoothing</a>.  Then the byte value, \(b[k]\), is $$ b[k] = \frac{255}{\mbox{dB}_{max}
+              - \mbox{dB}_{min}} \left(Y[k] - \mbox{dB}_{min}\right) $$ where \(\mbox{dB}_{min}\) is
+              <code><a>minDecibels</a></code> and \(\mbox{dB}_{max}\) is
+              <code><a>maxDecibels</a></code>. If \(b[k]\) lies outside the range of 0 to 255,
+              \(b[k]\) is clipped to lie in that range.
+            </p>
             <dl class="parameters">
               <dt>
                 Uint8Array array
@@ -4773,6 +4783,12 @@ float calculateNormalizationScale(buffer)
               dropped. If the array has more elements than
               <a><code>fftSize</code></a>, the excess elements will be ignored.
             </p>
+            <p>
+              The values stored in the unsigned byte array are computed in the following way.  Let
+              \(x[k]\) be the time-domain data.  The the byte value, \(b[k]\), is $$ b[k] = 128(1 +
+              x[k]). $$ If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is clipped to lie in
+              that range.
+            </p>
             <dl class="parameters">
               <dt>
                 Uint8Array array
@@ -4802,20 +4818,20 @@ float calculateNormalizationScale(buffer)
             attribute float minDecibels
           </dt>
           <dd>
-            The minimum power value in the scaling range for the FFT analysis
+            <dfn id="minDecibels">minDecibels</dfn> is the minimum power value in the scaling range for the FFT analysis
             data for conversion to unsigned byte values. The default value is
             -100. If the value of this attribute is set to a value more than or
-            equal to <code>maxDecibels</code>, an IndexSizeError exception MUST
+            equal to <code><a>maxDecibels</a></code>, an IndexSizeError exception MUST
             be thrown.
           </dd>
           <dt>
             attribute float maxDecibels
           </dt>
           <dd>
-            The maximum power value in the scaling range for the FFT analysis
+            <dfn id="maxDecibels">maxDecibels</dfn> is the maximum power value in the scaling range for the FFT analysis
             data for conversion to unsigned byte values. The default value is
             -30. If the value of this attribute is set to a value less than or
-            equal to <code>minDecibels</code>, an IndexSizeError exception MUST
+            equal to <code><a>minDecibels</a></code>, an IndexSizeError exception MUST
             be thrown.
           </dd>
           <dt>
@@ -4908,10 +4924,10 @@ float calculateNormalizationScale(buffer)
             This array, \(Y[k]\), is copied to the output array for
             <code>getFloatFrequencyData</code>. For
             <code>getByteFrequencyData</code>, the \(Y[k]\) is clipped to lie
-            between <code>minDecibels</code> and <code>maxDecibels</code> and
+            between <code><a>minDecibels</a></code> and <code><a>maxDecibels</a></code> and
             then scaled to fit in an unsigned byte such that
-            <code>minDecibels</code> is represented by the value 0 and
-            <code>maxDecibels</code> is represented by the value 255.
+            <code><a>minDecibels</a></code> is represented by the value 0 and
+            <code><a>maxDecibels</a></code> is represented by the value 255.
           </p>
         </section>
       </section>


### PR DESCRIPTION
Add description on how the byte values are computed for the time and frequency data.

Fixes WebAudio/web-audio-api#571.