### PR TITLE
Specify PeriodicWave coefficients to generate Oscillator waveforms

### DIFF
--- a/index.html
+++ b/index.html
@@ -6131,6 +6131,59 @@ float calculateNormalizationScale(buffer)
             factor must be applied to all generated waveforms.
           </p>
         </section>
+        <section>
+          <h2>
+            Oscillator Coefficients
+          </h2>
+          <p>
+            The builtin oscillator types are created using PeriodicWave
+            objects.  For completeness the coefficients for the
+            PeriodicWave for each of the builtin oscillator types is given
+            here.  This is useful if a builtin type is desired but without
+            the default normalization.
+          </p>
+          <p>
+            In the following descriptions, let \(a\) be the array of real
+            coefficients and \(b\) be the array of imaginary coefficients
+            for <a href=
+            "#widl-AudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag">
+            <code>createPeriodicWave()</code></a>.  In all cases \(a[n] = 0\) for all
+            \(n\) because the waveforms are odd functions. Also, \(b[0] =
+            0\) in all cases.  Hence, only \(b[n]\) for \(n \ge 1\) is
+            specified below.
+          </p>
+          <dl>
+            <dt>"sine"</dt>
+            <dd>
+              $$
+                b[n] = \begin{cases}
+                         1 & \mbox{for } n = 1 \\
+                         0 & \mbox{otherwise}
+                       \end{cases}
+              $$
+            </dd>
+            <dt>"square"</dt>
+            <dd>
+              $$
+                b[n] = \frac{2}{n\pi}\left[1 - (-1)^n\right]
+              $$
+            </dd>
+            <dt>"sawtooth"</dt>
+            <dd>
+              $$
+                b[n] = (-1)^{n+1} \dfrac{2}{n\pi}
+              $$
+            </dd>
+            <dt>"triangle"</dt>
+            <dd>
+              $$
+                b[n] = \frac{8\sin\dfrac{n\pi}{2}}{(\pi n)^2}
+              $$
+            </dd>
+          </dl>
+          <p>
+          </p>
+        </section>
       </section>
       <section>
         <h2 id="MediaStreamAudioSourceNode">

--- a/index.html
+++ b/index.html
@@ -6136,7 +6136,7 @@ float calculateNormalizationScale(buffer)
             Oscillator Coefficients
           </h2>
           <p>
-            The builtin oscillator types are created using PeriodicWave
+            The builtin oscillator types are created using <a>PeriodicWave</a>
             objects.  For completeness the coefficients for the
             PeriodicWave for each of the builtin oscillator types is given
             here.  This is useful if a builtin type is desired but without


### PR DESCRIPTION

Include formulas appropriate for PeriodicWave objects to create the
basic builtin Oscillator waveforms.

Fixes WebAudio/web-audio-api#569.