### PR TITLE
Hack around wrapping in tidy HTML to keep nicely formatted formulas

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     }
 
     // This allow wrapping mathjax formulas in <pre> so the LaTeX code is not
-    // auto wrapperd and keeps a nice formatting.
+    // auto wrapped and keeps a nice formatting.
     MathJax.Hub.Config({
       tex2jax: {
          skipTags: ["script","noscript","style","textarea","code"]
@@ -2330,8 +2330,13 @@ function setupRoutingGraph() {
               If the next event (having time \(T_1\)) after this
               <em>SetValue</em> event is not of type <em>LinearRampToValue</em>
               or <em>ExponentialRampToValue</em>, then, for \(T_0 \leq t &lt;
-              T_1\): $$ v(t) = V $$
+              T_1\):
             </p>
+            <pre>
+              $$
+                v(t) = V
+              $$
+            </pre>
             <p>
               In other words, the value will remain constant during this time
               interval, allowing the creation of "step" functions.
@@ -2380,7 +2385,9 @@ function setupRoutingGraph() {
               calculated as:
             </p>
             <pre>
-              $$ v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 - T_0} $$
+              $$
+                v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 - T_0}
+              $$
             </pre>
             <p>
               Where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
@@ -2409,7 +2416,9 @@ function setupRoutingGraph() {
               calculated as:
             </p>
             <pre>
-              $$ v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t - T_0}{T_1 - T_0} $$
+              $$
+                v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t - T_0}{T_1 - T_0}
+              $$
             </pre>
             <p>
               where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
@@ -2504,7 +2513,9 @@ function setupRoutingGraph() {
               there are no following events):
             </p>
             <pre>
-              $$ v(t) = V_1 + (V_0 - V_1)\, e^{-\left(\frac{t - T_0}{\tau}\right)} $$
+              $$
+                v(t) = V_1 + (V_0 - V_1)\, e^{-\left(\frac{t - T_0}{\tau}\right)}
+              $$
             </pre>
             <p>
               where \(V_0\) is the initial value (the <code>.value</code>
@@ -4296,7 +4307,9 @@ onaudioprocess= function (e) {
               according to:
             </p>
             <pre>
-            $$ 1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}} $$
+            $$
+              1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}}
+            $$
             </pre>
             <p>
               That is, \(d\) is clamped to the interval \([d_{ref},\,
@@ -4312,7 +4325,9 @@ onaudioprocess= function (e) {
               according to:
             </p>
             <pre>
-              $$ \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})} $$
+              $$
+                \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})}
+              $$
             </pre>
             <p>
               That is, \(d\) is clamped to the interval \([d_{ref},\,
@@ -4328,8 +4343,10 @@ onaudioprocess= function (e) {
               <em>distanceGain</em> according to:
             </p>
             <pre>
-                $$ \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f} $$
-              </pre>
+              $$
+                \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f}
+              $$
+            </pre>
             <p>
               That is, \(d\) is clamped to the interval \([d_{ref},\,
               \infty)\).
@@ -4940,7 +4957,9 @@ float calculateNormalizationScale(buffer)
             The windowed signal \(\hat{x}[n]\) is
           </p>
           <pre>
-            $$ \hat{x}[n] = x[n] w[n], \mbox{ for } n = 0, \ldots, N - 1 $$
+            $$
+              \hat{x}[n] = x[n] w[n], \mbox{ for } n = 0, \ldots, N - 1
+            $$
           </pre>
           <p>
             <dfn id="fourier-transform">Applying a Fourier tranform</dfn>
@@ -4950,8 +4969,10 @@ float calculateNormalizationScale(buffer)
             Then
           </p>
           <pre>
-              $$ X[k] = \sum_{n = 0}^{N - 1} \hat{x}[n] e^{\frac{-2\pi i k n}{N}} $$
-            </pre>
+            $$
+              X[k] = \sum_{n = 0}^{N - 1} \hat{x}[n] e^{\frac{-2\pi i k n}{N}}
+            $$
+          </pre>
           <p>
             for \(k = 0, \dots, N/2-1\).
           </p>
@@ -4980,8 +5001,10 @@ float calculateNormalizationScale(buffer)
             Then the smoothed value, \(\hat{X}[k]\), is computed by
           </p>
           <pre>
-              $$ \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]| $$
-            </pre>
+            $$
+              \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]|
+            $$
+          </pre>
           <p>
             for \(k = 0, \ldots, N - 1\).
           </p>
@@ -4991,8 +5014,13 @@ float calculateNormalizationScale(buffer)
             "#smoothing-over-time">smoothing over time</a>:
           </p>
           <pre>
-        $$ Y[k] = 20\log_{10}\hat{X}[k] $$ for \(k = 0, \ldots, N-1\).
-        </pre>
+          $$
+            Y[k] = 20\log_{10}\hat{X}[k]
+          $$
+          </pre>
+          <p>
+            for \(k = 0, \ldots, N-1\).
+          </p>
           <p>
             This array, \(Y[k]\), is copied to the output array for
             <code>getFloatFrequencyData</code>. For
@@ -5892,7 +5920,9 @@ $$
             general IIR filter is given by
           </p>
           <pre>
-            $$ H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}} $$
+            $$
+              H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}}
+            $$
           </pre>
           <p>
             where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is
@@ -5903,7 +5933,9 @@ $$
             Equivalently, the time-domain equation is:
           </p>
           <pre>
-            $$ \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k) $$
+            $$
+              \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k)
+            $$
           </pre>
           <p>
             The initial filter state is the all-zeroes state.
@@ -6210,9 +6242,15 @@ $$
               "square"
             </dt>
             <dd>
-              The waveform for the square wave oscillator is: $$ x(t) =
-              \begin{cases} 1 & \mbox{for } 0≤ t &lt; \pi \\ -1 & \mbox{for }
-              -\pi &lt; t &lt; 0. \end{cases} $$
+              The waveform for the square wave oscillator is:
+              <pre>
+                $$
+                  x(t) = \begin{cases}
+                         1 & \mbox{for } 0≤ t &lt; \pi \\
+                         -1 & \mbox{for } -\pi &lt; t &lt; 0.
+                         \end{cases}
+                $$
+              </pre>
             </dd>
             <dt>
               "sawtooth"
@@ -6220,17 +6258,26 @@ $$
             <dd>
               The waveform for the sawtooth oscillator is the ramp:
               <pre>
-                $$ x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi; $$
+                $$
+                  x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi;
+                $$
               </pre>
             </dd>
             <dt>
               "triangle"
             </dt>
             <dd>
-              The waveform for the triangle oscillator is: $$ x(t) =
-              \begin{cases} \frac{2}{\pi} t & \mbox{for } 0 ≤ t ≤ \frac{\pi}{2}
-              \\ 1-\frac{2}{\pi} (t-\frac{\pi}{2}) & \mbox{for } \frac{\pi}{2}
-              &lt; t ≤ \pi. \end{cases} $$ This is extended to all \(t\) by
+              The waveform for the triangle oscillator is:
+              <pre>
+                $$
+                  x(t) = \begin{cases}
+                           \frac{2}{\pi} t & \mbox{for } 0 ≤ t ≤ \frac{\pi}{2} \\
+                           1-\frac{2}{\pi} (t-\frac{\pi}{2}) & \mbox{for }
+                           \frac{\pi}{2} &lt; t ≤ \pi.
+                         \end{cases}
+                $$
+              </pre>
+              This is extended to all \(t\) by
               using the fact that the waveform is an odd function with period
               \(2\pi\).
             </dd>
@@ -6310,13 +6357,17 @@ $$
             normalization factor \(f\) is computed as follows:
           </p>
           <pre>
-            $$ f = \max_{n = 0, \ldots, N - 1} |\tilde{x}(n)| $$
+            $$
+              f = \max_{n = 0, \ldots, N - 1} |\tilde{x}(n)|
+            $$
           </pre>
           <p>
             Thus, the actual normalized waveform \(\hat{x}(n)\) is
           </p>
           <pre>
-            $$ \hat{x}(n) = \frac{\tilde{x}(n)}{f} $$
+            $$
+              \hat{x}(n) = \frac{\tilde{x}(n)}{f}
+            $$
           </pre>
           <p>
             This fixed normalization factor must be applied to all generated

--- a/index.html
+++ b/index.html
@@ -90,6 +90,14 @@
         }
       }
     }
+
+    // This allow wrapping mathjax formulas in <pre> so the LaTeX code is not
+    // auto wrapperd and keeps a nice formatting.
+    MathJax.Hub.Config({
+      tex2jax: {
+         skipTags: ["script","noscript","style","textarea","code"]
+      }
+    });
     </script>
   </head>
   <body>
@@ -1776,8 +1784,11 @@ function setupRoutingGraph() {
             void disconnect()
           </dt>
           <dd>
-            <p>Disconnects a single output of the <a><code>AudioNode</code></a> from any other <a><code>AudioNode</code></a>
-            or <a><code>AudioParam</code></a> objects to which it is connected.</p>
+            <p>
+              Disconnects a single output of the <a><code>AudioNode</code></a>
+              from any other <a><code>AudioNode</code></a> or
+              <a><code>AudioParam</code></a> objects to which it is connected.
+            </p>
             <dl class="parameters">
               <dt>
                 unsigned long output
@@ -1794,7 +1805,10 @@ function setupRoutingGraph() {
             void disconnect()
           </dt>
           <dd>
-            <p>Disconnects all outputs of the <a><code>AudioNode</code></a> that go to a specific destination <a><code>AudioNode</code></a>.</p>
+            <p>
+              Disconnects all outputs of the <a><code>AudioNode</code></a> that
+              go to a specific destination <a><code>AudioNode</code></a>.
+            </p>
             <dl class="parameters">
               <dt>
                 AudioNode destination
@@ -1812,7 +1826,11 @@ function setupRoutingGraph() {
             void disconnect()
           </dt>
           <dd>
-            <p>Disconnects a specific output of the <a><code>AudioNode</code></a> from a specific destination <a><code>AudioNode</code></a>.</p>
+            <p>
+              Disconnects a specific output of the
+              <a><code>AudioNode</code></a> from a specific destination
+              <a><code>AudioNode</code></a>.
+            </p>
             <dl class="parameters">
               <dt>
                 AudioNode destination
@@ -1838,7 +1856,11 @@ function setupRoutingGraph() {
             void disconnect()
           </dt>
           <dd>
-            <p>Disconnects a specific output of the <a><code>AudioNode</code></a> from a specific input of some destination <a><code>AudioNode</code></a>.</p>
+            <p>
+              Disconnects a specific output of the
+              <a><code>AudioNode</code></a> from a specific input of some
+              destination <a><code>AudioNode</code></a>.
+            </p>
             <dl class="parameters">
               <dt>
                 AudioNode destination
@@ -1874,9 +1896,14 @@ function setupRoutingGraph() {
             void disconnect()
           </dt>
           <dd>
-            <p>Disconnects all outputs of the <a><code>AudioNode</code></a> that go to a specific destination <a><code>AudioParam</code></a>.
-               The contribution of this <a><code>AudioNode</code></a> to the computed parameter value goes to 0 when this operation takes effect.
-               The intrinsic parameter value is not affected by this operation.</p>
+            <p>
+              Disconnects all outputs of the <a><code>AudioNode</code></a> that
+              go to a specific destination <a><code>AudioParam</code></a>. The
+              contribution of this <a><code>AudioNode</code></a> to the
+              computed parameter value goes to 0 when this operation takes
+              effect. The intrinsic parameter value is not affected by this
+              operation.
+            </p>
             <dl class="parameters">
               <dt>
                 AudioParam destination
@@ -1893,9 +1920,14 @@ function setupRoutingGraph() {
             void disconnect()
           </dt>
           <dd>
-            <p>Disconnects a specific output of the <a><code>AudioNode</code></a> from a specific destination <a><code>AudioParam</code></a>.
-               The contribution of this <a><code>AudioNode</code></a> to the computed parameter value goes to 0 when this operation takes effect.
-               The intrinsic parameter value is not affected by this operation.</p>
+            <p>
+              Disconnects a specific output of the
+              <a><code>AudioNode</code></a> from a specific destination
+              <a><code>AudioParam</code></a>. The contribution of this
+              <a><code>AudioNode</code></a> to the computed parameter value
+              goes to 0 when this operation takes effect. The intrinsic
+              parameter value is not affected by this operation.
+            </p>
             <dl class="parameters">
               <dt>
                 AudioParam destination
@@ -2345,9 +2377,11 @@ function setupRoutingGraph() {
               The value during the time interval \(T_0 \leq t &lt; T_1\) (where
               \(T_0\) is the time of the previous event and \(T_1\) is the
               <code>endTime</code> parameter passed into this method) will be
-              calculated as: $$ v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 -
-              T_0} $$
+              calculated as:
             </p>
+            <pre>
+              $$ v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 - T_0} $$
+            </pre>
             <p>
               Where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
               <code>value</code> parameter passed into this method.
@@ -2372,19 +2406,21 @@ function setupRoutingGraph() {
               The value during the time interval \(T_0 \leq t &lt; T_1\) (where
               \(T_0\) is the time of the previous event and \(T_1\) is the
               <code>endTime</code> parameter passed into this method) will be
-              calculated as: $$ v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t
-              - T_0}{T_1 - T_0} $$
+              calculated as:
             </p>
+            <pre>
+              $$ v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t - T_0}{T_1 - T_0} $$
+            </pre>
             <p>
               where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
-              <code>value</code> parameter passed into this method.  It is an error if either
-              \(V_0\) or \(V_1\) is not strictly positive.
+              <code>value</code> parameter passed into this method. It is an
+              error if either \(V_0\) or \(V_1\) is not strictly positive.
             </p>
             <p>
-              This also implies an exponential ramp to 0 is not possible.  A good approximation can
-              be achieved using <a href=
-            "#widl-AudioParam-setTargetAtTime-void-float-target-double-startTime-float-timeConstant">setTargetAtTime</a>
-            with an appropriately chosen time constant.
+              This also implies an exponential ramp to 0 is not possible. A
+              good approximation can be achieved using <a href=
+              "#widl-AudioParam-setTargetAtTime-void-float-target-double-startTime-float-timeConstant">
+              setTargetAtTime</a> with an appropriately chosen time constant.
             </p>
             <p>
               If there are no more events after this ExponentialRampToValue
@@ -2451,7 +2487,7 @@ function setupRoutingGraph() {
               <dd>
                 The time-constant value of first-order filter (exponential)
                 approach to the target value. The larger this value is, the
-                slower the transition will be.  The value must be strictly
+                slower the transition will be. The value must be strictly
                 positive or a TypeError exception MUST be thrown.
                 <p>
                   More precisely, <em>timeConstant</em> is the time it takes a
@@ -2465,9 +2501,11 @@ function setupRoutingGraph() {
               During the time interval: \(T_0 \leq t &lt; T_1\), where \(T_0\)
               is the <code>startTime</code> parameter and \(T_1\) represents
               the time of the event following this event (or \(\infty\) if
-              there are no following events): $$ v(t) = V_1 + (V_0 - V_1)\,
-              e^{-\left(\frac{t - T_0}{\tau}\right)} $$
+              there are no following events):
             </p>
+            <pre>
+              $$ v(t) = V_1 + (V_0 - V_1)\, e^{-\left(\frac{t - T_0}{\tau}\right)} $$
+            </pre>
             <p>
               where \(V_0\) is the initial value (the <code>.value</code>
               attribute) at \(T_0\) (the <code>startTime</code> parameter),
@@ -2520,10 +2558,17 @@ function setupRoutingGraph() {
               Let \(T_0\) be <code>startTime</code>, \(T_D\) be
               <code>duration</code>, \(V\) be the <code>values</code> array,
               and \(N\) be the length of the <code>values</code> array. Then,
-              during the time interval: \(T_0 \le t &lt; T_0 + T_D\), let $$
-              \begin{align*} k &amp;= \big\lfloor \frac{N}{T_D}(t-T_0)
-              \big\rfloor \\ \end{align*} $$ Then \(v(t)\) is computed by
-              linearly interpolating between \(V[k]\) and \(V[k+1]\),
+              during the time interval: \(T_0 \le t &lt; T_0 + T_D\), let
+            </p>
+            <pre>
+              $$
+                \begin{align*} k &amp;= \big\lfloor \frac{N}{T_D}(t-T_0) \big\rfloor \\
+                \end{align*}
+              $$
+            </pre>
+            <p>
+              Then \(v(t)\) is computed by linearly interpolating between
+              \(V[k]\) and \(V[k+1]\),
             </p>
             <p>
               After the end of the curve time interval (\(t \ge T_0 + T_D\)),
@@ -4246,10 +4291,16 @@ onaudioprocess= function (e) {
             linear
           </dt>
           <dd>
-            <p>A linear distance model which calculates <em>distanceGain</em>
-            according to:
-            $$ 1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}} $$</p>
-            That is, \(d\) is clamped to the interval \([d_{ref},\, d_{max}]\).
+            <p>
+              A linear distance model which calculates <em>distanceGain</em>
+              according to:
+            </p>
+            <pre>
+            $$ 1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}} $$
+            </pre>
+            <p>
+              That is, \(d\) is clamped to the interval \([d_{ref},\,
+              d_{max}]\).
             </p>
           </dd>
           <dt>
@@ -4259,8 +4310,14 @@ onaudioprocess= function (e) {
             <p>
               An inverse distance model which calculates <em>distanceGain</em>
               according to:
-            </p>$$ \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})} $$
-            That is, \(d\) is clamped to the interval \([d_{ref},\, \infty)\).
+            </p>
+            <pre>
+              $$ \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})} $$
+            </pre>
+            <p>
+              That is, \(d\) is clamped to the interval \([d_{ref},\,
+              \infty)\).
+            </p>
           </dd>
           <dt>
             exponential
@@ -4269,8 +4326,14 @@ onaudioprocess= function (e) {
             <p>
               An exponential distance model which calculates
               <em>distanceGain</em> according to:
-            </p>$$ \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f} $$
-            That is, \(d\) is clamped to the interval \([d_{ref},\, \infty)\).
+            </p>
+            <pre>
+                $$ \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f} $$
+              </pre>
+            <p>
+              That is, \(d\) is clamped to the interval \([d_{ref},\,
+              \infty)\).
+            </p>
           </dd>
         </dl>
         <dl title="interface PannerNode : AudioNode" class="idl">
@@ -4856,25 +4919,41 @@ float calculateNormalizationScale(buffer)
           <p>
             In the following, let \(N\) be the value of the
             <code>.fftSize</code> attribute of this <code>AnalyserNode</code>.
-          </p><dfn id="blackman-window">Applying a Blackman window</dfn>
-          consists in the following operation on the input time domain data.
-          Let \(x[n]\) for \(n = 0, \ldots, N - 1\) be the time domain data.
-          The Blackman window is defined by $$ \begin{align*} \alpha &amp;=
-          \mbox{0.16} \\ a_0 &amp;= \frac{1-\alpha}{2} \\ a_1 &amp;=
-          \frac{1}{2} \\ a_2 &amp;= \frac{\alpha}{2} \\ w[n] &amp;= a_0 - a_1
-          \cos\frac{2\pi n}{N} + a_2 \cos\frac{4\pi n}{N}, \mbox{ for } n = 0,
-          \ldots, N - 1 \end{align*} $$
-          <p>
-            The windowed signal \(\hat{x}[n]\) is $$ \hat{x}[n] = x[n] w[n],
-            \mbox{ for } n = 0, \ldots, N - 1 $$
           </p>
+          <p>
+            <dfn id="blackman-window">Applying a Blackman window</dfn> consists
+            in the following operation on the input time domain data. Let
+            \(x[n]\) for \(n = 0, \ldots, N - 1\) be the time domain data. The
+            Blackman window is defined by
+          </p>
+          <pre>
+          $$
+          \begin{align*}
+            \alpha &amp;= \mbox{0.16} \\ a_0 &amp;= \frac{1-\alpha}{2} \\
+             a_1   &amp;= \frac{1}{2} \\
+             a_2   &amp;= \frac{\alpha}{2} \\
+             w[n] &amp;= a_0 - a_1 \cos\frac{2\pi n}{N} + a_2 \cos\frac{4\pi n}{N}, \mbox{ for } n = 0, \ldots, N - 1
+           \end{align*}
+           $$
+          </pre>
+          <p>
+            The windowed signal \(\hat{x}[n]\) is
+          </p>
+          <pre>
+            $$ \hat{x}[n] = x[n] w[n], \mbox{ for } n = 0, \ldots, N - 1 $$
+          </pre>
           <p>
             <dfn id="fourier-transform">Applying a Fourier tranform</dfn>
             consists of computing the Fourier transform in the following way.
             Let \(X[k]\) be the complex frequency domain data and
             \(\hat{x}[n]\) be the windowed time domain data computed above.
-            Then $$ X[k] = \sum_{n = 0}^{N - 1} \hat{x}[n] e^{\frac{-2\pi i k
-            n}{N}} $$ for \(k = 0, \dots, N/2-1\).
+            Then
+          </p>
+          <pre>
+              $$ X[k] = \sum_{n = 0}^{N - 1} \hat{x}[n] e^{\frac{-2\pi i k n}{N}} $$
+            </pre>
+          <p>
+            for \(k = 0, \dots, N/2-1\).
           </p>
           <p>
             <dfn id="smoothing-over-time">Smoothing over time</dfn> frequency
@@ -4898,13 +4977,22 @@ float calculateNormalizationScale(buffer)
             </li>
           </ul>
           <p>
-            Then the smoothed value, \(\hat{X}[k]\), is computed by $$
-            \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]| $$ for
-            \(k = 0, \ldots, N - 1\).
-          </p><dfn id="conversion-to-db">Conversion to dB</dfn> consists of the
-          following operation, where \(\hat{X}[k]\) is computed in <a href=
-          "#smoothing-over-time">smoothing over time</a>: $$ Y[k] =
-          20\log_{10}\hat{X}[k] $$ for \(k = 0, \ldots, N-1\).
+            Then the smoothed value, \(\hat{X}[k]\), is computed by
+          </p>
+          <pre>
+              $$ \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]| $$
+            </pre>
+          <p>
+            for \(k = 0, \ldots, N - 1\).
+          </p>
+          <p>
+            <dfn id="conversion-to-db">Conversion to dB</dfn> consists of the
+            following operation, where \(\hat{X}[k]\) is computed in <a href=
+            "#smoothing-over-time">smoothing over time</a>:
+          </p>
+          <pre>
+        $$ Y[k] = 20\log_{10}\hat{X}[k] $$ for \(k = 0, \ldots, N-1\).
+        </pre>
           <p>
             This array, \(Y[k]\), is copied to the output array for
             <code>getFloatFrequencyData</code>. For
@@ -5530,9 +5618,15 @@ float calculateNormalizationScale(buffer)
           </p>
           <p>
             The transfer function for the filters implemented by the
-            <a><code>BiquadFilterNode</code></a> is: $$H(z) =
-            \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} +
-            \frac{b_2}{a_0}z^{-2}}{1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}$$
+            <a><code>BiquadFilterNode</code></a> is:
+          </p>
+          <pre>
+  $$
+  H(z) = \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} + \frac{b_2}{a_0}z^{-2}}
+              {1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}
+  $$
+            </pre>
+          <p>
             The initial filter state is 0.
           </p>The coefficients in the transfer function above are different for
           each node type. The following intermediate variable are necessary for
@@ -5557,13 +5651,18 @@ float calculateNormalizationScale(buffer)
             </li>
             <li>Finally let 
             <!-- Should \alpha_S be simplified since S is always 1?-->
-               $$\begin{align*} A &amp;= 10^{\frac{G}{40}} \\ \omega_0 &amp;=
-              2\pi\frac{f_0}{F_s} \\ \alpha_Q &amp;= \frac{\sin\omega_0}{2Q} \\
-              \alpha_B &amp;= \frac{\sin\omega_0}{2}
-              \sqrt{\frac{4-\sqrt{16-\frac{16}{G^2}}}{2}} \\ S &amp;= 1 \\
-              \alpha_S &amp;=
-              \frac{\sin\omega_0}{2}\sqrt{\left(A+\frac{1}{A}\right)\left(\frac{1}{S}-1\right)+2}
-              \end{align*} $$
+              <pre>
+$$
+\begin{align*}
+  A        &amp;= 10^{\frac{G}{40}} \\
+  \omega_0 &amp;= 2\pi\frac{f_0}{F_s} \\
+  \alpha_Q &amp;= \frac{\sin\omega_0}{2Q} \\
+  \alpha_B &amp;= \frac{\sin\omega_0}{2} \sqrt{\frac{4-\sqrt{16-\frac{16}{G^2}}}{2}} \\
+  S        &amp;= 1 \\
+  \alpha_S &amp;= \frac{\sin\omega_0}{2}\sqrt{\left(A+\frac{1}{A}\right)\left(\frac{1}{S}-1\right)+2}
+\end{align*}
+$$
+            </pre>
             </li>
           </ul>The six coefficients (\(b_0, b_1, b_2, a_0, a_1, a_2\)) for each
           filter type, are:
@@ -5572,77 +5671,137 @@ float calculateNormalizationScale(buffer)
               <code>lowpass</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= \frac{1 - \cos\omega_0}{2} \\ b_1
-              &amp;= 1 - \cos\omega_0 \\ b_2 &amp;= \frac{1 - \cos\omega_0}{2}
-              \\ a_0 &amp;= 1 + \alpha_B \\ a_1 &amp;= -2 \cos\omega_0 \\ a_2
-              &amp;= 1 - \alpha_B \end{align*} $$
+              <pre>
+                $$
+                  \begin{align*}
+                    b_0 &amp;= \frac{1 - \cos\omega_0}{2} \\
+                    b_1 &amp;= 1 - \cos\omega_0 \\
+                    b_2 &amp;= \frac{1 - \cos\omega_0}{2} \\
+                    a_0 &amp;= 1 + \alpha_B \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \alpha_B
+                  \end{align*}
+                $$
+              </pre>
             </dd>
             <dt>
               <code>highpass</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= \frac{1 + \cos\omega_0}{2} \\ b_1
-              &amp;= -(1 + \cos\omega_0) \\ b_2 &amp;= \frac{1 +
-              \cos\omega_0}{2} \\ a_0 &amp;= 1 + \alpha_B \\ a_1 &amp;= -2
-              \cos\omega_0 \\ a_2 &amp;= 1 - \alpha_B \end{align*} $$
+              <pre>
+                  $$
+                    \begin{align*}
+                      b_0 &amp;= \frac{1 + \cos\omega_0}{2} \\
+                      b_1 &amp;= -(1 + \cos\omega_0) \\
+                      b_2 &amp;= \frac{1 + \cos\omega_0}{2} \\
+                      a_0 &amp;= 1 + \alpha_B \\
+                      a_1 &amp;= -2 \cos\omega_0 \\
+                      a_2 &amp;= 1 - \alpha_B
+                    \end{align*}
+                  $$
+              </pre>
             </dd>
             <dt>
               <code>bandpass</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= \alpha_Q \\ b_1 &amp;= 0 \\ b_2
-              &amp;= -\alpha_Q \\ a_0 &amp;= 1 + \alpha_Q \\ a_1 &amp;= -2
-              \cos\omega_0 \\ a_2 &amp;= 1 - \alpha_Q \end{align*} $$
+              <pre>
+              $$
+                \begin{align*}
+                  b_0 &amp;= \alpha_Q \\
+                  b_1 &amp;= 0 \\
+                  b_2 &amp;= -\alpha_Q \\
+                  a_0 &amp;= 1 + \alpha_Q \\
+                  a_1 &amp;= -2 \cos\omega_0 \\
+                  a_2 &amp;= 1 - \alpha_Q
+                \end{align*}
+              $$
+            </pre>
             </dd>
             <dt>
               <code>notch</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= 1 \\ b_1 &amp;= -2\cos\omega_0 \\
-              b_2 &amp;= 1 \\ a_0 &amp;= 1 + \alpha_Q \\ a_1 &amp;= -2
-              \cos\omega_0 \\ a_2 &amp;= 1 - \alpha_Q \end{align*} $$
+              <pre>
+                $$
+                  \begin{align*}
+                    b_0 &amp;= 1 \\
+                    b_1 &amp;= -2\cos\omega_0 \\
+                    b_2 &amp;= 1 \\
+                    a_0 &amp;= 1 + \alpha_Q \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \alpha_Q
+                  \end{align*}
+                $$
+              </pre>
             </dd>
             <dt>
               <code>allpass</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= 1 - \alpha_Q \\ b_1 &amp;=
-              -2\cos\omega_0 \\ b_2 &amp;= 1 + \alpha_Q \\ a_0 &amp;= 1 +
-              \alpha_Q \\ a_1 &amp;= -2 \cos\omega_0 \\ a_2 &amp;= 1 - \alpha_Q
-              \end{align*} $$
+              <pre>
+                $$
+                  \begin{align*}
+                    b_0 &amp;= 1 - \alpha_Q \\
+                    b_1 &amp;= -2\cos\omega_0 \\
+                    b_2 &amp;= 1 + \alpha_Q \\
+                    a_0 &amp;= 1 + \alpha_Q \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \alpha_Q
+                  \end{align*}
+                $$
+              </pre>
             </dd>
             <dt>
               <code>peaking</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= 1 + \alpha_Q\, A \\ b_1 &amp;=
-              -2\cos\omega_0 \\ b_2 &amp;= 1 - \alpha_Q\,A \\ a_0 &amp;= 1 +
-              \frac{\alpha_Q}{A} \\ a_1 &amp;= -2 \cos\omega_0 \\ a_2 &amp;= 1
-              - \frac{\alpha_Q}{A} \end{align*} $$
+              <pre>
+                $$
+                  \begin{align*}
+                    b_0 &amp;= 1 + \alpha_Q\, A \\
+                    b_1 &amp;= -2\cos\omega_0 \\
+                    b_2 &amp;= 1 - \alpha_Q\,A \\
+                    a_0 &amp;= 1 + \frac{\alpha_Q}{A} \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \frac{\alpha_Q}{A}
+                  \end{align*}
+                $$
+              </pre>
             </dd>
             <dt>
               <code>lowshelf</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0
-              + 2 \alpha_S \sqrt{A})\right] \\ b_1 &amp;= 2 A \left[ (A-1) -
-              (A+1) \cos\omega_0 )\right] \\ b_2 &amp;= A \left[ (A+1) - (A-1)
-              \cos\omega_0 - 2 \alpha_S \sqrt{A}) \right] \\ a_0 &amp;= (A+1) +
-              (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A} \\ a_1 &amp;= -2 \left[
-              (A-1) + (A+1) \cos\omega_0\right] \\ a_2 &amp;= (A+1) + (A-1)
-              \cos\omega_0 - 2 \alpha_S \sqrt{A}) \end{align*} $$
+              <pre>
+                $$
+                  \begin{align*}
+                    b_0 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A})\right] \\
+                    b_1 &amp;= 2 A \left[ (A-1) - (A+1) \cos\omega_0 )\right] \\
+                    b_2 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A}) \right] \\
+                    a_0 &amp;= (A+1) + (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A} \\
+                    a_1 &amp;= -2 \left[ (A-1) + (A+1) \cos\omega_0\right] \\
+                    a_2 &amp;= (A+1) + (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A})
+                  \end{align*}
+                $$
+              </pre>
             </dd>
             <dt>
               <code>highshelf</code>
             </dt>
             <dd>
-              $$ \begin{align*} b_0 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 +
-              2\alpha_S\sqrt{A} )\right] \\ b_1 &amp;= -2A\left[ (A-1) +
-              (A+1)\cos\omega_0 )\right] \\ b_2 &amp;= A\left[ (A+1) +
-              (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A} )\right] \\ a_0 &amp;=
-              (A+1) - (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} \\ a_1 &amp;=
-              2\left[ (A-1) - (A+1)\cos\omega_0\right] \\ a_2 &amp;= (A+1) -
-              (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A} \end{align*} $$
+              <pre>
+                $$
+                  \begin{align*}
+                    b_0 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} )\right] \\
+                    b_1 &amp;= -2A\left[ (A-1) + (A+1)\cos\omega_0 )\right] \\
+                    b_2 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A} )\right] \\
+                    a_0 &amp;= (A+1) - (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} \\
+                    a_1 &amp;= 2\left[ (A-1) - (A+1)\cos\omega_0\right] \\
+                    a_2 &amp;= (A+1) - (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A}
+                  \end{align*}
+                $$
+              </pre>
             </dd>
           </dl>
         </section>
@@ -5730,16 +5889,22 @@ float calculateNormalizationScale(buffer)
             <a href=
             "#widl-AudioContext-createIIRFilter-IIRFilterNode-Float32Array-feedforward-Float32Array-feedback">
             <code>createIIRFilter</code></a>. Then the transfer function of the
-            general IIR filter is given by $$ H(z) = \frac{\sum_{m=0}^{M} b_m
-            z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}} $$ where \(M + 1\) is the length
-            of the \(b\) array and \(N + 1\) is the length of the \(a\) array.
-            The coefficient \(a_0\) cannot be 0. At least one of \(b_m\) must
-            be non-zero.
+            general IIR filter is given by
+          </p>
+          <pre>
+            $$ H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}} $$
+          </pre>
+          <p>
+            where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is
+            the length of the \(a\) array. The coefficient \(a_0\) cannot be 0.
+            At least one of \(b_m\) must be non-zero.
           </p>
           <p>
-            Equivalently, the time-domain equation is $$ \sum_{k=0}^{N} a_k
-            y(n-k) = \sum_{k=0}^{M} b_k x(n-k) $$
+            Equivalently, the time-domain equation is:
           </p>
+          <pre>
+            $$ \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k) $$
+          </pre>
           <p>
             The initial filter state is the all-zeroes state.
           </p>
@@ -6036,13 +6201,16 @@ float calculateNormalizationScale(buffer)
               "sine"
             </dt>
             <dd>
-              The waveform for sine oscillator is $$x(t) = \sin t$$.
+              The waveform for sine oscillator is:
+              <pre>
+                $$x(t) = \sin t$$.
+              </pre>
             </dd>
             <dt>
               "square"
             </dt>
             <dd>
-              The waveform for the square wave oscillator is $$ x(t) =
+              The waveform for the square wave oscillator is: $$ x(t) =
               \begin{cases} 1 & \mbox{for } 0≤ t &lt; \pi \\ -1 & \mbox{for }
               -\pi &lt; t &lt; 0. \end{cases} $$
             </dd>
@@ -6050,14 +6218,16 @@ float calculateNormalizationScale(buffer)
               "sawtooth"
             </dt>
             <dd>
-              The waveform for the sawtooth oscillator is the ramp $$ x(t) =
-              \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi; $$
+              The waveform for the sawtooth oscillator is the ramp:
+              <pre>
+                $$ x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi; $$
+              </pre>
             </dd>
             <dt>
               "triangle"
             </dt>
             <dd>
-              The waveform for the triangle oscillator is $$ x(t) =
+              The waveform for the triangle oscillator is: $$ x(t) =
               \begin{cases} \frac{2}{\pi} t & \mbox{for } 0 ≤ t ≤ \frac{\pi}{2}
               \\ 1-\frac{2}{\pi} (t-\frac{\pi}{2}) & \mbox{for } \frac{\pi}{2}
               &lt; t ≤ \pi. \end{cases} $$ This is extended to all \(t\) by
@@ -6106,9 +6276,15 @@ float calculateNormalizationScale(buffer)
             createPeriodicWave()</a> method takes two arrays to specify the
             Fourier coefficients of the PeriodicWave. Let \(a\) and \(b\)
             represent the real and imaginary arrays of length \(L\). Then the
-            basic time-domain waveform, \(x(t)\), can be computed using $$ x(t)
-            = \sum_{k=1}^{L-1} \left(a[k]\cos2\pi k t + b[k]\sin2\pi k t\right)
-            $$ This is the basic (unnormalized) waveform.
+            basic time-domain waveform, \(x(t)\), can be computed using:
+          </p>
+          <pre>
+            $$
+              x(t) = \sum_{k=1}^{L-1} \left(a[k]\cos2\pi k t + b[k]\sin2\pi k t\right)
+            $$
+          </pre>
+          <p>
+            This is the basic (unnormalized) waveform.
           </p>
         </section>
         <section>
@@ -6121,14 +6297,30 @@ float calculateNormalizationScale(buffer)
             done as follows.
           </p>
           <p>
-            Let $$ \tilde{x}(n) = \sum_{k=1}^{L-1} \left(a[k]\cos\frac{2\pi k
-            n}{N} + b[k]\sin\frac{2\pi k n}{N}\right) $$ where \(N\) is a power
-            of two. (Note: \(\tilde{x}(n)\) can conveniently be computed using
-            an inverse FFT.) The fixed normalization factor \(f\) is computed
-            as follows: $$ f = \max_{n = 0, \ldots, N - 1} |\tilde{x}(n)| $$
-            Thus, the actual normalized waveform \(\hat{x}(n)\) is $$
-            \hat{x}(n) = \frac{\tilde{x}(n)}{f} $$ This fixed normalization
-            factor must be applied to all generated waveforms.
+            Let
+          </p>
+          <pre>
+          $$
+            \tilde{x}(n) = \sum_{k=1}^{L-1} \left(a[k]\cos\frac{2\pi k n}{N} + b[k]\sin\frac{2\pi k n}{N}\right)
+          $$
+          </pre>
+          <p>
+            where \(N\) is a power of two. (Note: \(\tilde{x}(n)\) can
+            conveniently be computed using an inverse FFT.) The fixed
+            normalization factor \(f\) is computed as follows:
+          </p>
+          <pre>
+            $$ f = \max_{n = 0, \ldots, N - 1} |\tilde{x}(n)| $$
+          </pre>
+          <p>
+            Thus, the actual normalized waveform \(\hat{x}(n)\) is
+          </p>
+          <pre>
+            $$ \hat{x}(n) = \frac{\tilde{x}(n)}{f} $$
+          </pre>
+          <p>
+            This fixed normalization factor must be applied to all generated
+            waveforms.
           </p>
         </section>
       </section>


### PR DESCRIPTION
This wraps formulas in `pre` tags that are ignored by tidy, and we enabled their parsing in MathJax.
This also tidies the document.

This fixes #619.