### PR TITLE
AudioBufferSourceNode.buffer should only be set once, this fixes #288

### DIFF
--- a/index.html
+++ b/index.html
@@ -2978,7 +2978,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             attribute AudioBuffer? buffer
           </dt>
           <dd>
-            Represents the audio asset to be played.
+            Represents the audio asset to be played. This attribute can only be
+            set once, or a <code>InvalidStateError</code> MUST be thrown.
           </dd>
           <dt>
             readonly attribute AudioParam playbackRate


### PR DESCRIPTION
We'll deal with whether we want to allow setting to null in #436.