### PR TITLE
createIIRFilter takes double coefficients

### DIFF
--- a/index.html
+++ b/index.html
@@ -1153,14 +1153,14 @@ function setupRoutingGraph() {
             common filter types.
           </dd>
           <dt>
-            IIRFilterNode createIIRFilter(sequence&lt;double> b, sequence&lt;double> a)
+            IIRFilterNode createIIRFilter(sequence&lt;double&gt; b, sequence&lt;double&gt; a)
           </dt>
           <dd>
             Creates an <a><code>IIRFilterNode</code></a> representing a general
             IIR Filter.
             <dl class="parameters">
               <dt>
-                sequence&lt;double> feedforward
+                sequence&lt;double&gt; feedforward
               </dt>
               <dd>
                 An array of the feedforward (numerator) coefficients for the
@@ -1170,7 +1170,7 @@ function setupRoutingGraph() {
                 thrown if the array length is 0 or greater than 20.
               </dd>
               <dt>
-                sequence&lt;double> feedback
+                sequence&lt;double&gt; feedback
               </dt>
               <dd>
                 An array of the feedback (denominator) coefficients for the

--- a/index.html
+++ b/index.html
@@ -1153,7 +1153,8 @@ function setupRoutingGraph() {
             common filter types.
           </dd>
           <dt>
-            IIRFilterNode createIIRFilter(sequence&lt;double&gt; b, sequence&lt;double&gt; a)
+            IIRFilterNode createIIRFilter(sequence&lt;double&gt; b,
+            sequence&lt;double&gt; a)
           </dt>
           <dd>
             Creates an <a><code>IIRFilterNode</code></a> representing a general

--- a/index.html
+++ b/index.html
@@ -1137,14 +1137,14 @@ function setupRoutingGraph() {
             common filter types.
           </dd>
           <dt>
-            IIRFilterNode createIIRFilter(sequence<double> b, sequence<double> a)
+            IIRFilterNode createIIRFilter(sequence&lt;double> b, sequence&lt;double> a)
           </dt>
           <dd>
             Creates an <a><code>IIRFilterNode</code></a> representing a general
             IIR Filter.
             <dl class="parameters">
               <dt>
-                sequence<double> feedforward
+                sequence&lt;double> feedforward
               </dt>
               <dd>
                 An array of the feedforward (numerator) coefficients for the
@@ -1154,7 +1154,7 @@ function setupRoutingGraph() {
                 thrown if the array length is 0 or greater than 20.
               </dd>
               <dt>
-                sequence<double> feedback
+                sequence&lt;double> feedback
               </dt>
               <dd>
                 An array of the feedback (denominator) coefficients for the

--- a/index.html
+++ b/index.html
@@ -1137,14 +1137,14 @@ function setupRoutingGraph() {
             common filter types.
           </dd>
           <dt>
-            IIRFilterNode createIIRFilter(Float32Array b, Float32Array a)
+            IIRFilterNode createIIRFilter(sequence<double> b, sequence<double> a)
           </dt>
           <dd>
             Creates an <a><code>IIRFilterNode</code></a> representing a general
             IIR Filter.
             <dl class="parameters">
               <dt>
-                Float32Array feedforward
+                sequence<double> feedforward
               </dt>
               <dd>
                 An array of the feedforward (numerator) coefficients for the
@@ -1154,7 +1154,7 @@ function setupRoutingGraph() {
                 thrown if the array length is 0 or greater than 20.
               </dd>
               <dt>
-                Float32Array feedback
+                sequence<double> feedback
               </dt>
               <dd>
                 An array of the feedback (denominator) coefficients for the


### PR DESCRIPTION
The coefficients for createIIRFilter are explicitly doubles and not
floats now.

We also fix a minor issue that was accepted in
WebAudio/web-audio-api#323 where a `sequence<float>` was allowed instead
of `Float32Array` to make it easier for the developer to specify
coefficients.

Note that for some reason respec replaces `sequence<double>` with just
`sequence` in the document.  Is this a bug in respec?

Fix WebAudio/web-audio-api#631