### PR TITLE
Fix #110 by adding explicit section on Audio Signal Values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7566,8 +7566,10 @@ Quad up-mix:
         Audio Signal Values
       </h2>
       <p>
-        The nominal range of all audio signals at a destination node of any audio graph is from -1 to +1. The audio rendition of
-        signal values outside this range, or of the values <code>NaN</code>, positive infinity or negative infinities, is undefined by this specification.
+        The nominal range of all audio signals at a destination node of any
+        audio graph is [-1, 1]. The audio rendition of signal values outside
+        this range, or of the values <code>NaN</code>, positive infinity or
+        negative infinity, is undefined by this specification.
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -7179,6 +7179,15 @@ Quad up-mix:
       </section>
     </section>
     <section>
+      <h2 id="audio-sample-values">
+        Audio Signal Values
+      </h2>
+      <p>
+        The nominal range of all audio signals at a destination node of any audio graph is from -1 to +1. The audio rendition of
+        signal values outside this range, or of the values <code>NaN</code>, positive infinity or negative infinities, is undefined by this specification.
+      </p>
+    </section>
+    <section>
       <h2 id="Spatialization">
         Spatialization / Panning
       </h2>


### PR DESCRIPTION
After reviewing the thread in #110 I feel that it's best to add a new and extremely brief section that states the nominal range of legal signal values at a destination node (note that there is more than one type of destination node, so specing this in `AudioDestinationNode` seems like an unclear option). I have opted to say that the audio rendition of values outside [-1,+1] or of NaN/+Inf/-Inf are not defined by this specification as this feels like a perfectly reasonable V1 approach.

Open to suggestions that some sort of clipping for [-1, +1] should be forced, but adding more cost to the impl doesn't seem like a great idea to me.