### PR TITLE
Annotate synchronous sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,18 @@
       }
     });
     </script>
+    <style>
+    .todo {
+      border: 1px solid red;
+      background-color: rgba(255, 0, 0, 0.3);
+    }
+    .todo:before {
+      content: "TODO:";
+    }
+    .synchronous:before {
+      content: "⌛ ";
+    }
+    </style>
   </head>
   <body>
     <section id="abstract">
@@ -666,6 +678,45 @@ function setupRoutingGraph() {
           cases, only a single <a><code>AudioContext</code></a> is used per
           document.
         </p>
+        <p>
+          <!-- ReSpec does not support documenting constructor -->
+           <span class="synchronous">When creating an <a>AudioContext</a>,
+          execute these steps:</span>
+        </p>
+        <ol>
+          <li>Set a <code>control thread flag</code> to
+          <code>"suspended"</code> on the <a>AudioContext</a>.
+          </li>
+          <li>Send a <a>control message</a> to start processing.
+          </li>
+        </ol>
+        <p>
+          Sending a <a>control message</a> to start processing means executing
+          the following steps:
+        </p>
+        <ol>
+          <li>Attempt to <a href="#acquiring">Acquire system resources</a>.
+          </li>
+          <li>In case of failure, abort these steps.
+          </li>
+          <li>Queue a task on the <a>control thread</a> event loop, to execute
+          these steps:
+            <ol>
+              <li>Set the <a href="#widl-audiocontext-state">state</a>
+              attribute of the <a>AudioContext</a> to <code>"running"</code>.
+              </li>
+              <li>Queue a task to fire a simple event named
+              <code>"statechange"</code> at the <a>AudioContext</a>.
+              </li>
+            </ol>
+          </li>
+        </ol>
+        <p class="note">
+          It is unfortunately not possible to programatically notify authors
+          that the creation of the <a>AudioContext</a> failed. User-Agents are
+          encouraged to log an informative message if they have access to a
+          logging mecanism, such an a developer tools console.
+        </p>
         <dl title="enum AudioContextState" class="idl">
           <dt>
             suspended
@@ -686,8 +737,9 @@ function setupRoutingGraph() {
           <dd>
             The AudioContext has been released, and can no longer be used to
             process audio. All system audio resources have been released.
-            Attempts to create new Nodes on the AudioContext will throw
-            InvalidStateError. (AudioBuffers may still be created, through
+            <span class=synchronous>Attempts to create new Nodes on the
+              AudioContext will throw InvalidStateError</span>. (AudioBuffers
+            may still be created, through
             <a href=
             "#widl-AudioContext-createBuffer-AudioBuffer-unsigned-long-numberOfChannels-unsigned-long-length-float-sampleRate">
             createBuffer</a> or <a href=
@@ -783,56 +835,223 @@ function setupRoutingGraph() {
               to be played to the destination, and then allows the system to
               release its claim on audio hardware. This is generally useful
               when the application knows it will not need the
-              <a>AudioContext</a> for some time, and wishes to let the audio
-              hardware power down. The promise resolves when the frame buffer
-              is empty (has been handed off to the hardware), or immediately
-              (with no other effect) if the context is already suspended. The
-              promise is rejected if the context has been closed.
+              <a>AudioContext</a> for some time, and wishes to temporarily
+              <a>release system resources</a> associated to the
+              <a>AudioContext</a>.
             </p>
             <p>
-              While the system is suspended, MediaStreams will have their
-              output ignored; that is, data will be lost by the real time
-              nature of media streams. HTMLMediaElements will similarly have
-              their output ignored until the system is resumed. Audio Workers
-              and ScriptProcessorNodes will simply not fire their
-              onaudioprocess events while suspended, but will resume when
-              resumed. For the purpose of AnalyserNode window functions, the
-              data is considered as a continuous stream - i.e. the
-              resume()/suspend() does not cause silence to appear in the
-              AnalyserNode's stream of data.
+              <span class="synchronous">When suspend is called, execute these
+              steps:</span>
+            </p>
+            <ol>
+              <li>Let <em>promise</em> be a new Promise.
+              </li>
+              <li>If the <em>control thread state</em> flag on the
+              <a>AudioContext</a> is <code>"closed"</code> reject the promise
+              with <code>InvalidStateError</code>, abort these steps, returning
+              <em>promise</em>.
+              </li>
+              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
+              of the <a>AudioContext</a> is already <code>"suspended"</code>,
+              resolve <em>promise</em>, return it, and abort these steps.
+              </li>
+              <li>Set the <em>control thread state</em> flag on the
+              <a>AudioContext</a> to <code>"suspended"</code>.
+              </li>
+              <li>
+                <a href="#queue">Queue a control message</a> to suspend the
+                <a>AudioContext</a>.
+              </li>
+              <li>Return <em>promise</em>.
+              </li>
+            </ol>
+            <p>
+              Running a <a>control message</a> to suspend an
+              <a>AudioContext</a> means running these steps on the <a>rendering
+              thread</a>:
+            </p>
+            <ol>
+              <li>Attempt to <a>release system resources</a>.
+              </li>
+              <li>Queue a task on the <a>control thread</a>'s event loop, to
+              execute these steps:
+                <ol>
+                  <li>Resolve <em>promise</em>.
+                  </li>
+                  <li>If the <a href="#widl-audiocontext-state">state</a>
+                  attribute of the <a>AudioContext</a> is not already
+                  <code>"suspended"</code>:
+                    <ol>
+                      <li>Set the <a href="#widl-audiocontext-state">state</a>
+                      attribute of the <a>AudioContext</a> to
+                      <code>"suspended"</code>.
+                      </li>
+                      <li>Queue a task to fire a simple event named
+                      <code>"statechanged"</code> at the <a>AudioContext</a>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+            <p>
+              While an <a>AudioContext</a> is suspended,
+              <code>MediaStream</code>s will have their output ignored; that
+              is, data will be lost by the real time nature of media streams.
+              <code>HTMLMediaElement</code>s will similarly have their output
+              ignored until the system is resumed. <a>AudioWorker</a>s and
+              <a>ScriptProcessorNode</a>s will simply not fire their
+              <code>onaudioprocess</code> events while suspended, but will
+              resume when resumed. For the purpose of <a>AnalyserNode</a>
+              window functions, the data is considered as a continuous stream -
+              i.e. the <code>resume()</code>/<code>suspend()</code> does not
+              cause silence to appear in the <a>AnalyserNode</a>'s stream of
+              data.
             </p>
           </dd>
           <dt>
             Promise&lt;void&gt; resume()
           </dt>
           <dd>
-            Resumes the progression of the <a><code>AudioContext</code></a>'s
-            <a href="#widl-AudioContext-currentTime">currentTime</a> in an
-            audio context that has been suspended, which may involve re-priming
-            the frame buffer contents. The promise resolves when the system has
-            re-acquired (if necessary) access to audio hardware and has begun
-            streaming to the destination, or immediately (with no other effect)
-            if the context is already running. The promise is rejected if the
-            context has been closed. If the context is not currently suspended,
-            the promise will resolve.
+            Resumes the progression of the <a><code>AudioContext</code></a>'s'
+            <a href="#widl-AudioContext-currentTime">currentTime</a> when it
+            has been suspended.
+            <p>
+              <span class="synchronous">When resume is called, execute these
+              steps:</span>
+            </p>
+            <ol>
+              <li>Let <em>promise</em> be a new Promise.
+              </li>
+              <li>If the <em>control thread state</em> flag on the
+              <a>AudioContext</a> is <code>"closed"</code> reject the promise
+              with <code>InvalidStateError</code>, abort these steps, returning
+              <em>promise</em>.
+              </li>
+              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
+              of the <a>AudioContext</a> is already <code>"running"</code>,
+              resolve <em>promise</em>, return it, and abort these steps.
+              </li>
+              <li>Set the <em>control thread state</em> flag on the
+              <a>AudioContext</a> to <code>"running"</code>.
+              </li>
+              <li>
+                <a href="#queue">Queue a control message</a> to resume the
+                <a>AudioContext</a>.
+              </li>
+              <li>Return <em>promise</em>.
+              </li>
+            </ol>
+            <p>
+              Running a <a>control message</a> to resume an <a>AudioContext</a>
+              means running these steps on the <a>rendering thread</a>:
+            </p>
+            <ol>
+              <li>Attempt to <a href="#acquiring">acquire system resources</a>.
+              </li>
+              <li>In case of failure, queue a task on the <a>control thread</a>
+              to execute the following, and abort these steps
+                <ol>
+                  <li>Reject <em>promise</em>
+                  </li>
+                </ol>
+              </li>
+              <li>Queue a task on the <a>control thread</a>'s event loop, to
+              execute these steps:
+                <ol>
+                  <li>Resolve <em>promise</em>.
+                  </li>
+                  <li>If the <a href="#widl-audiocontext-state">state</a>
+                  attribute of the <a>AudioContext</a> is not already
+                  <code>"running"</code>:
+                    <ol>
+                      <li>Set the <a href="#widl-audiocontext-state">state</a>
+                      attribute of the <a>AudioContext</a> to
+                      <code>"running"</code>.
+                      </li>
+                      <li>Queue a task to fire a simple event named
+                      <code>"statechange"</code> at the <a>AudioContext</a>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
           </dd>
           <dt>
             Promise&lt;void&gt; close()
           </dt>
           <dd>
-            Closes the audio context, releasing any system audio resources used
-            by the <a>AudioContext</a>. This will not automatically release all
-            AudioContext-created objects, unless other references have been
-            released as well; however, it will forcibly release any system
-            audio resources that might prevent additional AudioContexts from
-            being created and used, suspend the progression of the
-            <a><code>AudioContext</code></a>'s <a href=
+            Closes the <a>AudioContext</a>, <a>releasing system resources</a>
+            it's using. This will not automatically release all
+            AudioContext-created objects, but will suspend the progression of
+            the <a><code>AudioContext</code></a>'s <a href=
             "#widl-AudioContext-currentTime">currentTime</a>, and stop
-            processing audio data. The promise resolves when all
-            AudioContext-creation-blocking resources have been released. If
-            this is called on <a>OfflineAudioContext</a>, then return a promise
-            rejected with a <code>DOMException</code> whose name is
-            <code>InvalidStateError</code>.
+            processing audio data.
+            <p>
+              <span class="synchronous">When close is called, execute these
+              steps:</span>
+            </p>
+            <ol>
+              <li>Let <em>promise</em> be a new Promise.
+              </li>
+              <li>If this <a>AudioContext</a> is an <a>OfflineAudioContext</a>,
+              reject <em>promise</em> with <code>NotSupportedError</code>,
+              return it, and abort these steps.
+              </li>
+              <li>If the <em>control thread state</em> flag on the
+              <a>AudioContext</a> is <code>"closed"</code> reject the promise
+              with <code>InvalidStateError</code>, abort these steps, returning
+              <em>promise</em>.
+              </li>
+              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
+              of the <a>AudioContext</a> is already <code>"closed"</code>,
+              resolve <em>promise</em>, return it, and abort these steps.
+              </li>
+              <li>Set the <em>control thread state</em> flag on the
+              <a>AudioContext</a> to <code>"closed"</code>.
+              </li>
+              <li>
+                <a href="#queue">Queue a control message</a> to the
+                <a>AudioContext</a>.
+              </li>
+              <li>Return <em>promise</em>.
+              </li>
+            </ol>
+            <p>
+              Running a <a>control message</a> to suspend an
+              <a>AudioContext</a> means running these steps on the <a>rendering
+              thread</a>:
+            </p>
+            <ol>
+              <li>Attempt to <a>release system resources</a>.
+              </li>
+              <li>Queue a task on the <a>control thread</a>'s event loop, to
+              execute these steps:
+                <ol>
+                  <li>Resolve <em>promise</em>.
+                  </li>
+                  <li>If the <a href="#widl-audiocontext-state">state</a>
+                  attribute of the <a>AudioContext</a> is not already
+                  <code>"closed"</code>:
+                    <ol>
+                      <li>Set the <a href="#widl-audiocontext-state">state</a>
+                      attribute of the <a>AudioContext</a> to
+                      <code>"closed"</code>.
+                      </li>
+                      <li>Queue a task to fire a simple event named
+                      <code>"statechange"</code> at the <a>AudioContext</a>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+            <p class="note">
+              When an <a>AudioContext</a> is has been closed, implementation
+              can choose to aggressively release more resource than when
+              suspending.
+            </p>
           </dd>
           <dt>
             attribute EventHandler onstatechange
@@ -1374,6 +1593,44 @@ function setupRoutingGraph() {
             be able to observe garbage collections.
           </p>
         </section>
+        <section>
+          <h3>
+            System resources associated with an AudioContext
+          </h3>
+          <p>
+            <a>AudioContext</a>s should be considered expensive objects.
+            Creating an <a>AudioContext</a> often involves creating an
+            high-priority thread, and use a low-latency system audio stream,
+            both having impact on energy consumption. Creating more than one
+            <a>AudioContext</a> in a document is most of the time unnecessary.
+          </p>
+          <p>
+            Additionaly, user-agent can have an implementation-defined maximum
+            number of <a>AudioContext</a>, after which any attempt to create a
+            new <a>AudioContext</a> will fail, <span class=
+            "synchronous">throwing <code>NotSupportedError</code></span>.
+          </p>
+          <p>
+            <a href="#widl-AudioContext-suspend-Promise-void">suspend</a> and
+            <a href="#widl-AudioContext-resume-Promise-void">close</a> allow
+            authors to <dfn id="releasing">release system resources</dfn>.
+            <a href="#releasing">Releasing system resources</a> means releasing
+            the system resources such as threads, processes, audio streams, but
+            conserving the state of the <a>AudioContext</a> such that it can
+            continue to operate later after resuming if needed.
+          </p>
+          <p>
+            Constructing or resuming an <a>AudioContext</a> involves <dfn id=
+            "acquiring">acquiring system resources</dfn>. This means opening an
+            system audio stream. This operation returns when the the audios
+            stream is ready.
+          </p>
+          <p class="note">
+            For example, this can involve waiting for the audio callbacks to
+            fire regularly, or to wait for the hardware to be ready for
+            processing.
+          </p>
+        </section>
       </section>
       <section>
         <h2 id="OfflineAudioContext">
@@ -1566,7 +1823,7 @@ function setupRoutingGraph() {
           The <dfn>AudioNode</dfn> Interface
         </h2>
         <p>
-          AudioNodes are the building blocks of an <a href=
+          <a>AudioNode</a>s are the building blocks of an <a href=
           "#AudioContext"><code>AudioContext</code></a>. This interface
           represents audio sources, the audio destination, and intermediate
           processing modules. These modules can be connected together to form
@@ -1625,9 +1882,9 @@ function setupRoutingGraph() {
           44.1KHz.
         </p>
         <p>
-          AudioNodes are <em>EventTarget</em>s, as described in <cite><a href=
-          "https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]]. This means
-          that it is possible to dispatch events to
+          <a>AudioNode</a>s are <em>EventTarget</em>s, as described in <cite><a
+              href= "https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]]. This
+          means that it is possible to dispatch events to
           <a><code>AudioNode</code></a>s the same way that other EventTargets
           accept events.
         </p>
@@ -1687,7 +1944,7 @@ function setupRoutingGraph() {
                 <code>destination</code> parameter is an
                 <a><code>AudioNode</code></a> that has been created using
                 another <a><code>AudioContext</code></a>, an InvalidAccessError
-                MUST be thrown. That is, <a><code>AudioNodes</code></a> cannot
+                MUST be thrown. That is, <a><code>AudioNode</code></a>s cannot
                 be shared between <a><code>AudioContext</code></a>.
               </dd>
               <dt>
@@ -2646,7 +2903,7 @@ function setupRoutingGraph() {
           </h3>
           <p>
             <dfn>computedValue</dfn> is the final value controlling the audio
-            DSP and is computed by the audio rendering thread during each
+            DSP and is computed by the audio <a>rendering thread</a> during each
             rendering time quantum. It must be internally computed as follows:
           </p>
           <ol>
@@ -3657,13 +3914,13 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
               </p>
               <p>
                 It is purposeful that AudioParams can be added (or removed)
-                from an Audio Worker from either the main thread or the worker
-                script; this enables immediate creation of worker-based nodes
-                and their prototypes, but also enables packaging an entire
-                worker including its AudioParam configuration into a single
-                script. It is recommended that nodes be used only after the
-                AudioWorkerNode's oninitialized has been called, in order to
-                allow the worker script to configure the node.
+                from an Audio Worker from either the control thread or the
+                worker script; this enables immediate creation of worker-based
+                nodes and their prototypes, but also enables packaging an
+                entire worker including its AudioParam configuration into a
+                single script. It is recommended that nodes be used only after
+                the AudioWorkerNode's oninitialized has been called, in order
+                to allow the worker script to configure the node.
               </p>
               <p>
                 The <code>name</code> parameter is the name used for the
@@ -5120,17 +5377,17 @@ float calculateNormalizationScale(buffer)
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
-              following way. Let \(Y[k]\) be the <a>current frequency data</a>
-              as described in <a href=
-              "#fft-windowing-and-smoothing-over-time">FFT windowing and
-              smoothing</a>. Then the byte value, \(b[k]\), is
+              following way.  Let \(Y[k]\) be the <a>current frequency data</a>
+              as described in <a
+              href="#fft-windowing-and-smoothing-over-time">FFT windowing and
+              smoothing</a>.  Then the byte value, \(b[k]\), is
             </p>
             <pre>
-                  $$
-                    b[k] = \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
-                     \left(Y[k] - \mbox{dB}_{min}\right)
-                  $$
-              </pre>
+              $$
+                b[k] = \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
+                 \left(Y[k] - \mbox{dB}_{min}\right)
+              $$
+            </pre>
             <p>
               where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code> and
               \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If
@@ -5181,14 +5438,14 @@ float calculateNormalizationScale(buffer)
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
-              following way. Let \(x[k]\) be the time-domain data. Then the
+              following way.  Let \(x[k]\) be the time-domain data.  Then the
               byte value, \(b[k]\), is
             </p>
             <pre>
               $$
                 b[k] = 128(1 + x[k]).
               $$
-              </pre>
+           </pre>
             <p>
               If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is clipped
               to lie in that range.
@@ -6881,6 +7138,303 @@ waveform is an odd function with period \(2\pi\).
             same number of channels as the node itself.
           </dd>
         </dl>
+      </section>
+    </section>
+    <section>
+      <h2> Processing model </h2>
+      <section class="informative">
+      <h3> Background </h3>
+        <p>
+          Real-time audio systems that require low latency are, often time,
+          implemented using <em>callback functions</em>, where the operating
+          system calls the program back when more audio has to be computed in
+          order for the playback to stay uninterrupted. Such callback is called
+          on a high priority thread (often the highest priority on the system).
+          This means that a program that deals with audio only executes code
+          from this callback, as any buffering between a rendering thread and
+          the callback would naturally add latency or make the system less
+          resilient to glitches.
+        </p>
+        <p>
+          For this reason, the traditional way of executing asynchronous
+          operations on the Web Platform, the event loop, does not work here,
+          as the thread is no <em>continuously executing</em>. Additionaly, a
+          lot of unnecessary and potentially blocking operations are available
+          from traditional execution contexts (Windows and Workers), which is
+          not something that is desirable to reach an acceptable level of
+          performance.
+        </p>
+        <p>
+          Additionaly, the Worker model makes creating a dedicated thread
+          necessary for a script execution context, while all <a>AudioNode</a>s
+          usually share the same execution context.
+        </p>
+      </section>
+      <section>
+        <h3> Control thread and rendering thread </h3>
+        <p>
+          The Web Audio API MUST be implemented using a <a>control thread</a>,
+          and one <a>rendering thread</a>.
+        </p>
+        <p>
+          The <dfn>control thread</dfn> is the thread from
+          which the <a>AudioContext</a> is instanciated, and from which authors
+          manipulate the audio graph. The <dfn>rendering
+          thread</dfn> is the thread on which the actual audio output is
+          computed, in reaction to the calls from the <a>control thread</a>. It
+          can be a real-time, callback-based audio thread, if computing audio
+          for an <a>AudioContext</a>, or a normal thread if rendering and audio
+          graph offline using an <a>OfflineAudioContext</a>.
+        </p>
+        <p>
+          The <a>control thread</a> uses a traditional
+          event loop, as described in [[HTML]].
+        </p>
+        <p>
+          The <a>rendering thread</a> uses a
+          specialized rendering loop, described in the section <a href=
+          "#rendering-audio">Rendering an audio graph</a>
+        </p>
+        <p>
+          Communication from the <a>control thread</a>
+          to the <a>rendering thread</a> is done using
+          <a>Control message</a> passing. Communication
+          in the other direction is done using regular event loop tasks.
+        </p>
+        <p>
+          Each <a>AudioContext</a> has a single <dfn>control message
+          queue</dfn>, that is a list of <dfn data-lt="control message">control
+          messages</dfn>, that are a operations running on the <a>control
+          thread</a>.
+        </p>
+
+        <p>
+          <dfn id="queuing">Queuing an control message</dfn> means adding the
+          message to the end of the <a>control message queue</a> of an
+          <a>AudioContext</a>.
+        </p>
+        <p>
+          <a>Control messages</a> in a <a>control message queue</a> are ordered by
+          date of insertion. The <dfn>oldest message</dfn> is therefore the one
+          at the front of the <a>control message queue</a>.
+        </p>
+        <p>
+          <dfn data-lt="swap">Swapping</dfn> a <a>control message queue</a>
+          <var>Q<sub>A</sub></var> with another <a>control message queue</a>
+          <var>Q<sub>B</sub></var> means executing the following steps:
+        </p>
+        <ol>
+          <li> Let <var>Q<sub>C</sub></var> be a new, empty <a>control message
+                queue</a>. </li>
+          <li> Move all the <a>control messages</a> <var>Q<sub>A</sub></var> to
+              <var>Q<sub>C</sub></var>.</li>
+          <li> Move all the <a>control messages</a> <var>Q<sub>B</sub></var> to
+              <var>Q<sub>A</sub></var>.</li>
+          <li> Move all the <a>control messages</a> <var>Q<sub>C</sub></var> to
+              <var>Q<sub>B</sub></var>.</li>
+        </ol>
+        <p class="note">
+          For example, successfuly calling <code>start()</code> on an
+          <a>AudioBufferSourceNode</a> <code>source</code> adds a <a>control
+          message</a> to the <a href="#control-message-queue">control message
+          queue</a> of the <a>AudioContext</a> <code>source.context</code>.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Asynchronous operations
+        </h3>
+        <p>
+          Calling methods on <a>AudioNode</a>s MUST to be done in two phases, a
+          synchronous operation and an asynchronous operation. For each method,
+          some part of the execution happens on the <a>control thread</a> (for
+          example, throwing an exception in case of invalid parameters), and
+          some part happens on the <a>rendering thread</a> (for example,
+          changing the value of an <a>AudioParam</a>).
+        </p>
+        <p>
+          In the description of each operation on <a>AudioNode</a>s and
+          <a>AudioContext</a>s, the synchronous section is marked with a ⌛. All
+          the other operations are executed <a href=
+          "https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">
+          in parallel</a>, as described in [[HTML]].
+        </p>
+        <p>
+          The synchronous section is executed on the <a>control thread</a>, and
+          happens immediately. If it fails, the method execution is aborted,
+          possibly throwing an exception. If it succeeds, a <a>control
+          message</a>, encoding the operation to be executed on the
+          <a>rendering thread</a> is enqueued on the <a>control message
+          queue</a> of this <a>rendering thread</a>.
+        </p>
+        <p>
+          The synchronous and asynchronous sections order with respect to other
+          events MUST be the same: given two operation <em>A</em> and
+          <em>B</em> with respectively synchronous and asynchronous section
+          <em>A<sub>Sync</sub></em> and <em>A<sub>Async</sub></em>, and
+          <em>B<sub>Sync</sub></em> and <em>B<sub>Async</sub></em>, if
+          <em>A</em> happens before <em>B</em>, then <em>A<sub>Sync</sub></em>
+          happens before <em>B<sub>Sync</sub></em>, and
+          <em>A<sub>Async</sub></em> happens before <em>B<sub>Async</sub></em>.
+        </p>
+      </section>
+      <section id="rendering-loop">
+        <h3>
+          Rendering an audio graph
+        </h3>
+        <p>
+        Rendering an audio graph is done by blocks of 128 samples-frames.
+        </p>
+
+        <p>
+        Operations that happens <dfn data-lt="atomic">atomically</dfn> on a given thread, can only
+        be executed when no other <a>atomic</a> operation is
+        running on another thread.
+        </p>
+
+        <p>
+        The algorithm for rendering a block of audio from an <a>AudioContext</a>
+        <em>G</em> with an <a href=#control-message-queue>control message queue</a>
+        <em>Q</em> is as follow:
+        </p>
+        <ol>
+          <li> Let <em>Q<sub>rendering</sub></em> be an empty <a
+            href=#control-message-queue>control message queue</a>.
+          <a>Atomically</a> swap <em>Q<sub>rendering</sub></em> and
+          <em>Q</em></li>
+        <li> Until there is no more event in <em>Q<sub>rendering</sub></em>,
+        execute the following steps:
+        <ol>
+          <li>
+          Execute the asynchronous section of the oldest element of
+          <em>Q<sub>rendering</sub></em>.
+          </li>
+          <li>
+          Remove the oldest element of <em>Q<sub>rendering</sub></em>.
+          <li>Let <em>Q<sub>rendering</sub></em> be an empty <a>control message
+          queue</a>. <a>Atomically</a> <a>swap</a> <em>Q<sub>rendering</sub></em> and
+          <em>Q</em>
+          </li>
+          <li>Until there is no more messages in <em>Q<sub>rendering</sub></em>,
+          execute the following steps:
+            <ol>
+              <li>Execute the asynchronous section of the <a>oldest message</a>
+              of <em>Q<sub>rendering</sub></em>.
+              </li>
+              <li>Remove the <a>oldest message</a> of
+              <em>Q<sub>rendering</sub></em>.  </li>
+            </ol>
+          </li>
+          <li>Order the <a>AudioNode</a>s of the <a>AudioContext</a> to be
+          processed.
+            <ol>
+              <li>Let <em>ordered</em> be an empty list of <a>AudioNode</a>s.
+              It will contain an ordered list of <a>AudioNode</a>s when this
+              ordering algorithm terminates.
+              </li>
+              <li>Let <em>nodes</em> be the set of all nodes belonging to an
+              <a>AudioContext</a>.
+              </li>
+              <li>Let <em>cycle breakers</em> be an empty set of
+              <a>DelayNode</a>s. It will contain all the <a>DelayNode</a>s that
+              are part of a cycle.
+              </li>
+              <li>For each <a>AudioNode</a> <em>node</em> of <em>nodes</em>
+                <ol>
+                  <li>
+                    <em>node</em> is a <a>DelayNode</a> part of a cycle, add it
+                    to <em>cycle breakers</em> and remove it from
+                    <em>nodes</em>.
+                  </li>
+                </ol>
+              </li>
+              <li>If <em>nodes</em> contains cycles, mute all the
+              <a>AudioNode</a>s that are part of this cycle, and remove them
+              from <em>nodes</em>.
+              </li>
+              <li>While there are unmarked <a>AudioNode</a>s in <em>nodes</em>:
+                <ol>
+                  <li>Choose an <a>AudioNode</a> <em>node</em> in
+                  <em>nodes</em>
+                  </li>
+                  <li>
+                    <a>Visit</a> <em>node</em>.
+                  </li>
+                </ol><dfn data-lt="Visit">Visiting a node</dfn> <em>node</em>
+                mean performing the following steps:
+                <ol>
+                  <li>If <em>node</em> is marked, abort these steps.
+                  </li>
+                  <li>For each <a>AudioNode</a> <em>input</em> connect to <em>
+                    node</em>:
+                    <ol>
+                      <li>
+                        <a>Visit</a> <em>input</em>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>Mark <em>node</em>.
+                  </li>
+                  <li>Add <em>node</em> to the beginning of <em>ordered</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>For each <a>DelayNode</a> in a cycle, <a href="availabel">make
+          available for reading</a> a block of audio from the <a>DelayNode</a>
+          buffer.
+          </li>
+          <li>For each <a>AudioNode</a>, in the order determined previously:
+            <ol>
+              <li>If this <a>AudioNode</a> has any <a>AudioNode</a>s connected
+              to it, <a href="#SummingJunction">sum</a> the buffers <a href=
+              "available">made available for reading</a> by all
+              <a>AudioNode</a>s connected to this <a>AudioNode</a>. The
+              resulting buffer is called the <dfn>input buffer</dfn>.
+                <a href="#channel-up-mixing-and-down-mixing">Up or down-mix</a>
+                it to match if number of input channels of this
+                <a>AudioNode</a>.
+              </li>
+              <li>If this <a>AudioNode</a> is a <a>source node</a>, <a href=
+              "computing">compute a block of audio</a>, and <a href=
+              "available">make it available for reading</a>.
+              </li>
+              <li>Else, if this <a>AudioNode</a> is a <a>destination node</a>,
+              <a href="record">record the input</a> of this <a>AudioNode</a>.
+              </li>
+              <li>Else, <a>process</a> the <a>input buffer</a>, and <a href=
+              "available">make available for reading</a> the resulting buffer.
+              </li>
+            </ol>
+          </li>
+        </ol>
+        </li>
+      </ol>
+    <p>
+      <dfn id=available>Making a buffer available for reading</dfn> from an
+      <a>AudioNode</a> means putting it in a state where other <a>AudioNode</a>s
+      connected to this <a>AudioNode</a> can safely read from it.
+      <p class=note>For example, implementations can choose to allocate a new
+      buffer, or have a more elaborate mechanism, reusing an existing buffer
+      that is now unused.
+    </p>
+
+    <p>
+      <dfn id=record>Recording the input</dfn> of an <a>AudioNode</a> means
+      copying the input data of this <a>AudioNode</a> for future usage.
+    </p>
+
+    <p>
+      <dfn id=computing>Computing a block of audio</dfn> means running the
+      algorithm for this <a>AudioNode</a> to produce 128 sample-frames.
+    </p>
+
+    <p>
+      <dfn data-lt=process>Processing an input buffer</dfn> means running the
+      algorithm for an <a>AudioNode</a>, using an <a>input buffer</a> as the
+      input for this algorithm.
+    </p>
       </section>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -111,6 +111,9 @@
     .synchronous:before {
       content: "⌛ ";
     }
+    .synchronous:hover{
+      border-bottom: 1px dotted gray;
+    }
     </style>
   </head>
   <body>
@@ -737,10 +740,9 @@ function setupRoutingGraph() {
           <dd>
             The AudioContext has been released, and can no longer be used to
             process audio. All system audio resources have been released.
-            <span class=synchronous>Attempts to create new Nodes on the
-              AudioContext will throw InvalidStateError</span>. (AudioBuffers
-            may still be created, through
-            <a href=
+            <span class="synchronous">Attempts to create new Nodes on the
+            AudioContext will throw InvalidStateError</span>. (AudioBuffers may
+            still be created, through <a href=
             "#widl-AudioContext-createBuffer-AudioBuffer-unsigned-long-numberOfChannels-unsigned-long-length-float-sampleRate">
             createBuffer</a> or <a href=
             "#widl-AudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-audioData-DecodeSuccessCallback-successCallback-DecodeErrorCallback-errorCallback">
@@ -1072,9 +1074,10 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             Creates an AudioBuffer of the given size. The audio data in the
-            buffer will be zero-initialized (silent). A NotSupportedError
-            exception MUST be thrown if any of the arguments is negative, zero,
-            or outside its nominal range.
+            buffer will be zero-initialized (silent). <span class=
+            "synchronous">A NotSupportedError exception MUST be thrown if any
+            of the arguments is negative, zero, or outside its nominal
+            range.</span>
             <dl class="parameters">
               <dt>
                 unsigned long numberOfChannels
@@ -1283,11 +1286,11 @@ function setupRoutingGraph() {
             This method is DEPRECATED, as it is intended to be replaced by
             createAudioWorker. Creates a
             <a><code>ScriptProcessorNode</code></a> for direct audio processing
-            using JavaScript. An IndexSizeError exception MUST be thrown if
-            <a><code>bufferSize</code></a> or
+            using JavaScript. <span class="synchronous">An IndexSizeError
+            exception MUST be thrown if <a><code>bufferSize</code></a> or
             <a><code>numberOfInputChannels</code></a> or
             <a><code>numberOfOutputChannels</code></a> are outside the valid
-            range.
+            range.</span>
             <dl class="parameters">
               <dt>
                 optional unsigned long bufferSize = 0
@@ -1357,9 +1360,9 @@ function setupRoutingGraph() {
               <dd>
                 The <dfn>maxDelayTime</dfn> parameter is optional and specifies
                 the maximum delay time in seconds allowed for the delay line.
-                If specified, this value MUST be greater than zero and less
-                than three minutes or a NotSupportedError exception MUST be
-                thrown.
+                <span class="synchronous">If specified, this value MUST be
+                greater than zero and less than three minutes or a
+                NotSupportedError exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -1438,8 +1441,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             Creates an <a><code>ChannelSplitterNode</code></a> representing a
-            channel splitter. An IndexSizeError exception MUST be thrown for
-            invalid parameter values.
+            channel splitter. <span class="synchronous">An IndexSizeError
+            exception MUST be thrown for invalid parameter values.</span>
             <dl class="parameters">
               <dt>
                 optional unsigned long numberOfOutputs = 6
@@ -1455,8 +1458,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             Creates a <a><code>ChannelMergerNode</code></a> representing a
-            channel merger. An IndexSizeError exception MUST be thrown for
-            invalid parameter values.
+            channel merger. <span class="synchronous">An IndexSizeError
+            exception MUST be thrown for invalid parameter values.</span>
             <dl class="parameters">
               <dt>
                 optional unsigned long numberOfInputs = 6
@@ -1485,15 +1488,16 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             Creates a <a><code>PeriodicWave</code></a> representing a waveform
-            containing arbitrary harmonic content. The <code>real</code> and
-            <code>imag</code> parameters must be of type
-            <code>Float32Array</code> (described in [[!TYPED-ARRAYS]]) of equal
-            lengths greater than zero or an IndexSizeError exception MUST be
-            thrown. All implementations must support arrays up to at least
-            8192. These parameters specify the Fourier coefficients of a
-            <a href="https://en.wikipedia.org/wiki/Fourier_series">Fourier
-            series</a> representing the partials of a periodic waveform. The
-            created <a><code>PeriodicWave</code></a> will be used with an
+            containing arbitrary harmonic content. <span class=
+            "synchronous">The <code>real</code> and <code>imag</code>
+            parameters must be of type <code>Float32Array</code> (described in
+            [[!TYPED-ARRAYS]]) of equal lengths greater than zero or an
+            IndexSizeError exception MUST be thrown.</span> All implementations
+            must support arrays up to at least 8192. These parameters specify
+            the Fourier coefficients of a <a href=
+            "https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
+            representing the partials of a periodic waveform. The created
+            <a><code>PeriodicWave</code></a> will be used with an
             <a><code>OscillatorNode</code></a> and, by default, will represent
             a <em>normalized</em> time-domain waveform having maximum absolute
             peak value of 1. Another way of saying this is that the generated
@@ -1644,9 +1648,9 @@ function setupRoutingGraph() {
           returned promise with the rendered result as an
           <code>AudioBuffer</code>.
         </p>The OfflineAudioContext is constructed with the same arguments as
-        AudioContext.createBuffer. A NotSupportedException exception MUST be
-        thrown if any of the arguments is negative, zero, or outside its
-        nominal range.
+        AudioContext.createBuffer. <span class="synchronous">A
+        NotSupportedException exception MUST be thrown if any of the arguments
+        is negative, zero, or outside its nominal range.</span>
         <dl class="parameters">
           <dt>
             unsigned long numberOfChannels
@@ -1882,9 +1886,9 @@ function setupRoutingGraph() {
           44.1KHz.
         </p>
         <p>
-          <a>AudioNode</a>s are <em>EventTarget</em>s, as described in <cite><a
-              href= "https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]]. This
-          means that it is possible to dispatch events to
+          <a>AudioNode</a>s are <em>EventTarget</em>s, as described in
+          <cite><a href="https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]].
+          This means that it is possible to dispatch events to
           <a><code>AudioNode</code></a>s the same way that other EventTargets
           accept events.
         </p>
@@ -1953,8 +1957,9 @@ function setupRoutingGraph() {
               <dd>
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
-                connect. If this paremeter is out-of-bound, an IndexSizeError
-                exception MUST be thrown. It is possible to connect an
+                connect. <span class="synchronous">If this paremeter is
+                out-of-bound, an IndexSizeError exception MUST be
+                thrown.</span> It is possible to connect an
                 <a><code>AudioNode</code></a> output to more than one input
                 with multiple calls to connect(). Thus, "fan-out" is supported.
               </dd>
@@ -1964,15 +1969,17 @@ function setupRoutingGraph() {
               <dd>
                 The <code>input</code> parameter is an index describing which
                 input of the destination <a><code>AudioNode</code></a> to
-                connect to. If this parameter is out-of-bounds, an
-                IndexSizeError exception MUST be thrown. It is possible to
-                connect an <a><code>AudioNode</code></a> to another
+                connect to. <span class="synchronous">If this parameter is
+                out-of-bounds, an IndexSizeError exception MUST be
+                thrown.</span> It is possible to connect an
+                <a><code>AudioNode</code></a> to another
                 <a><code>AudioNode</code></a> which creates a <dfn>cycle</dfn>:
                 an <a><code>AudioNode</code></a> may connect to another
                 <a><code>AudioNode</code></a>, which in turn connects back to
                 the first <a><code>AudioNode</code></a>. This is allowed only
                 if there is at least one <a><code>DelayNode</code></a> in the
-                <em>cycle</em> or a NotSupportedError exception MUST be thrown.
+                <em>cycle</em> <span class="synchronous">or a NotSupportedError
+                exception MUST be thrown.</span>
               </dd>
             </dl>
             <p>
@@ -2013,8 +2020,9 @@ function setupRoutingGraph() {
               <dd>
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
-                connect. If the <code>parameter</code> is out-of-bound, an
-                IndexSizeError exception MUST be thrown.
+                connect. <span class="synchronous">If the
+                <code>parameter</code> is out-of-bound, an IndexSizeError
+                exception MUST be thrown.</span>
               </dd>
             </dl>
             <p>
@@ -2078,8 +2086,9 @@ function setupRoutingGraph() {
               <dd>
                 This parameter is an index describing which output of the
                 <a><code>AudioNode</code></a> to disconnect. It disconnects all
-                outgoing connections from the given output. If this parameter
-                is out-of-bounds, an IndexSizeError exception MUST be thrown.
+                outgoing connections from the given output. <span class=
+                "synchronous">If this parameter is out-of-bounds, an
+                IndexSizeError exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2098,9 +2107,10 @@ function setupRoutingGraph() {
               <dd>
                 The <code>destination</code> parameter is the
                 <a><code>AudioNode</code></a> to disconnect. It disconnects all
-                outgoing connections to the given <code>destination</code>. If
-                there is no connection to <code>destination</code>, an
-                InvalidAccessError exception MUST be thrown.
+                outgoing connections to the given <code>destination</code>.
+                <span class="synchronous">If there is no connection to
+                <code>destination</code>, an InvalidAccessError exception MUST
+                be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2119,9 +2129,10 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The <code>destination</code> parameter is the
-                <a><code>AudioNode</code></a> to disconnect. If there is no
-                connection to the <code>destination</code> from the given
-                output, an InvalidAccessError exception MUST be thrown.
+                <a><code>AudioNode</code></a> to disconnect. <span class=
+                "synchronous">If there is no connection to the
+                <code>destination</code> from the given output, an
+                InvalidAccessError exception MUST be thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2129,8 +2140,9 @@ function setupRoutingGraph() {
               <dd>
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
-                disconnect. If this parameter is out-of-bound, an
-                IndexSizeError exception MUST be thrown.
+                disconnect. <span class="synchronous">If this parameter is
+                out-of-bound, an IndexSizeError exception MUST be
+                thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2149,10 +2161,10 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The <code>destination</code> parameter is the
-                <a><code>AudioNode</code></a> to disconnect. If there is no
-                connection to the <code>destination</code> from the given
-                output to the given input, an InvalidAccessError exception MUST
-                be thrown.
+                <a><code>AudioNode</code></a> to disconnect. <span class=
+                "synchronous">If there is no connection to the
+                <code>destination</code> from the given output to the given
+                input, an InvalidAccessError exception MUST be thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2160,8 +2172,9 @@ function setupRoutingGraph() {
               <dd>
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
-                disconnect. If this parameter is out-of-bound, an
-                IndexSizeError exception MUST be thrown.
+                disconnect. <span class="synchronous">If this parameter is
+                out-of-bound, an IndexSizeError exception MUST be
+                thrown.</span>
               </dd>
               <dt>
                 unsigned long input
@@ -2169,8 +2182,9 @@ function setupRoutingGraph() {
               <dd>
                 The <code>input</code> parameter is an index describing which
                 input of the destination <a><code>AudioNode</code></a> to
-                disconnect. If this parameter is out-of-bounds, an
-                IndexSizeError exception MUST be thrown.
+                disconnect. <span class="synchronous">If this parameter is
+                out-of-bounds, an IndexSizeError exception MUST be
+                thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2192,9 +2206,10 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The <code>destination</code> parameter is the
-                <a><code>AudioParam</code></a> to disconnect. If there is no
-                connection to the <code>destination</code>, an
-                InvalidAccessError exception MUST be thrown.
+                <a><code>AudioParam</code></a> to disconnect. <span class=
+                "synchronous">If there is no connection to the
+                <code>destination</code>, an InvalidAccessError exception MUST
+                be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2216,9 +2231,10 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The <code>destination</code> parameter is the
-                <a><code>AudioParam</code></a> to disconnect. If there is no
-                connection to the <code>destination</code>, an
-                InvalidAccessError exception MUST be thrown.
+                <a><code>AudioParam</code></a> to disconnect. <span class=
+                "synchronous">If there is no connection to the
+                <code>destination</code>, an InvalidAccessError exception MUST
+                be thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2226,8 +2242,9 @@ function setupRoutingGraph() {
               <dd>
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
-                disconnect. If the <code>parameter</code> is out-of-bound, an
-                IndexSizeError exception MUST be thrown.
+                disconnect. <span class="synchronous">If the
+                <code>parameter</code> is out-of-bound, an IndexSizeError
+                exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2269,9 +2286,10 @@ function setupRoutingGraph() {
               connections to any inputs to the node. The default value is 2
               except for specific nodes where its value is specially
               determined. This attribute has no effect for nodes with no
-              inputs. If this value is set to zero or to a value greater than
-              the implementation's maximum number of channels the
-              implementation MUST throw a NotSupportedError exception.
+              inputs. <span class="synchronous">If this value is set to zero or
+              to a value greater than the implementation's maximum number of
+              channels the implementation MUST throw a NotSupportedError
+              exception.</span>
             </p>
             <p>
               See the <a href="#channel-up-mixing-and-down-mixing"></a> section
@@ -2427,12 +2445,13 @@ function setupRoutingGraph() {
               <a href="#widl-AudioNode-channelCount">channelCount</a> defaults
               to 2 for a destination in a normal
               <a><code>AudioContext</code></a>, and may be set to any non-zero
-              value less than or equal to <code>maxChannelCount</code>. An
-              <a><code>IndexSizeError</code></a> exception MUST be thrown if
-              this value is not within the valid range. Giving a concrete
-              example, if the audio hardware supports 8-channel output, then we
-              may set <a href="#widl-AudioNode-channelCount">channelCount</a>
-              to 8, and render 8-channels of output.
+              value less than or equal to <code>maxChannelCount</code>.
+              <span class="synchronous">An <a><code>IndexSizeError</code></a>
+              exception MUST be thrown if this value is not within the valid
+              range.</span> Giving a concrete example, if the audio hardware
+              supports 8-channel output, then we may set <a href=
+              "#widl-AudioNode-channelCount">channelCount</a> to 8, and render
+              8-channels of output.
             </p>
             <p>
               For an<a><code>AudioDestinationNode</code></a> in an
@@ -2537,16 +2556,19 @@ function setupRoutingGraph() {
           one or more events of a different type, then it will be placed in the
           list after them, but before events whose times are after the event.
           </li>
-          <li>If setValueCurveAtTime() is called for time \(T\) and duration
-          \(D\) and there are any events having a time greater than \(T\), but
-          less than \(T + D\), then a NotSupportedError exception MUST be
-          thrown. In other words, it's not ok to schedule a value curve during
-          a time period containing other events.
+          <li>
+            <span class="synchronous">If setValueCurveAtTime() is called for
+            time \(T\) and duration \(D\) and there are any events having a
+            time greater than \(T\), but less than \(T + D\), then a
+            NotSupportedError exception MUST be thrown.</span> In other words,
+            it's not ok to schedule a value curve during a time period
+            containing other events.
           </li>
-          <li>Similarly a NotSupportedError exception MUST be thrown if any
-          <em>automation</em> method is called at a time which is inside of the
-          time interval of a <em>SetValueCurve</em> event at time T and
-          duration D.
+          <li>
+            <span class="synchronous">Similarly a NotSupportedError exception
+            MUST be thrown if any <em>automation</em> method is called at a
+            time which is inside of the time interval of a
+            <em>SetValueCurve</em> event at time T and duration D.</span>
           </li>
         </ul>
         <dl title="interface AudioParam" class="idl">
@@ -2556,10 +2578,10 @@ function setupRoutingGraph() {
           <dd>
             <p>
               The parameter's floating-point value. This attribute is
-              initialized to the <code>defaultValue</code>. If
-              <code>value</code> is set during a time when there are any
-              automation events scheduled then it will be ignored and no
-              exception will be thrown.
+              initialized to the <code>defaultValue</code>. <span class=
+              "synchronous">If <code>value</code> is set during a time when
+              there are any automation events scheduled then it will be ignored
+              and no exception will be thrown.</span>
             </p>
             <p>
               The effect of setting this attribute is equivalent to calling
@@ -2596,9 +2618,10 @@ function setupRoutingGraph() {
                 The time in the same time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-AudioContext-currentTime">currentTime</a> attribute at
-                which the parameter changes to the given value. A TypeError
-                exception MUST be thrown if <code>startTime</code> is negative
-                or is not a finite number.
+                which the parameter changes to the given value. <span class=
+                "synchronous">A TypeError exception MUST be thrown if
+                <code>startTime</code> is negative or is not a finite
+                number.</span>
               </dd>
             </dl>
             <p>
@@ -2656,8 +2679,9 @@ function setupRoutingGraph() {
                 The time in the same time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-AudioContext-currentTime">currentTime</a> attribute at
-                which the automation ends. A TypeError exception MUST be thrown
-                if <code>endTime</code> is negative or is not a finite number.
+                which the automation ends. <span class="synchronous">A
+                TypeError exception MUST be thrown if <code>endTime</code> is
+                negative or is not a finite number.</span>
               </dd>
             </dl>
             <p>
@@ -2723,9 +2747,10 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The value the parameter will exponentially ramp to at the given
-                time. A NotSupportedError exception MUST be thrown if this
-                value is less than or equal to 0, or if the value at the time
-                of the previous event is less than or equal to 0.
+                time. <span class="synchronous">A NotSupportedError exception
+                MUST be thrown if this value is less than or equal to 0, or if
+                the value at the time of the previous event is less than or
+                equal to 0.</span>
               </dd>
               <dt>
                 double endTime
@@ -2734,9 +2759,9 @@ function setupRoutingGraph() {
                 The time in the same time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-AudioContext-currentTime">currentTime</a> attribute
-                where the exponential ramp ends. A TypeError exception MUST be
-                thrown if <code>endTime</code> is negative or is not a finite
-                number.
+                where the exponential ramp ends. <span class="synchronous">A
+                TypeError exception MUST be thrown if <code>endTime</code> is
+                negative or is not a finite number.</span>
               </dd>
             </dl>
           </dd>
@@ -2768,9 +2793,10 @@ function setupRoutingGraph() {
                 The time at which the exponential approach will begin, in the
                 same time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
-                "#widl-AudioContext-currentTime">currentTime</a> attribute. A
-                TypeError exception MUST be thrown if <code>start</code> is
-                negative or is not a finite number.
+                "#widl-AudioContext-currentTime">currentTime</a> attribute.
+                <span class="synchronous">A TypeError exception MUST be thrown
+                if <code>start</code> is negative or is not a finite
+                number.</span>
               </dd>
               <dt>
                 float timeConstant
@@ -2778,8 +2804,9 @@ function setupRoutingGraph() {
               <dd>
                 The time-constant value of first-order filter (exponential)
                 approach to the target value. The larger this value is, the
-                slower the transition will be. The value must be strictly
-                positive or a TypeError exception MUST be thrown.
+                slower the transition will be. <span class="synchronous">The
+                value must be strictly positive or a TypeError exception MUST
+                be thrown.</span>
                 <p>
                   More precisely, <em>timeConstant</em> is the time it takes a
                   first-order linear continuous time-invariant system to reach
@@ -2835,9 +2862,10 @@ function setupRoutingGraph() {
                 The start time in the same time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-AudioContext-currentTime">currentTime</a> attribute at
-                which the value curve will be applied. A TypeError exception
-                MUST be thrown if <code>startTime</code> is negative or is not
-                a finite number.
+                which the value curve will be applied. <span class=
+                "synchronous">A TypeError exception MUST be thrown if
+                <code>startTime</code> is negative or is not a finite
+                number.</span>
               </dd>
               <dt>
                 double duration
@@ -2890,9 +2918,10 @@ function setupRoutingGraph() {
                 parameter changes will be cancelled. It is a time in the same
                 time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
-                "#widl-AudioContext-currentTime">currentTime</a> attribute. A
-                TypeError exception MUST be thrown if <code>startTime</code> is
-                negative or is not a finite number.
+                "#widl-AudioContext-currentTime">currentTime</a> attribute.
+                <span class="synchronous">A TypeError exception MUST be thrown
+                if <code>startTime</code> is negative or is not a finite
+                number.</span>
               </dd>
             </dl>
           </dd>
@@ -2903,8 +2932,9 @@ function setupRoutingGraph() {
           </h3>
           <p>
             <dfn>computedValue</dfn> is the final value controlling the audio
-            DSP and is computed by the audio <a>rendering thread</a> during each
-            rendering time quantum. It must be internally computed as follows:
+            DSP and is computed by the audio <a>rendering thread</a> during
+            each rendering time quantum. It must be internally computed as
+            follows:
           </p>
           <ol>
             <li>An <em>intrinsic</em> parameter value will be calculated at
@@ -3140,9 +3170,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 This parameter is an index representing the particular channel
                 to get data for. An index value of 0 represents the first
-                channel. This index value MUST be less than
-                <code>numberOfChannels</code> or an IndexSizeError exception
-                MUST be thrown.
+                channel. <span class="synchronous">This index value MUST be
+                less than <code>numberOfChannels</code> or an IndexSizeError
+                exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -3365,9 +3395,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </dt>
           <dd>
             Schedules a sound to playback at an exact time. <code>start</code>
-            may only be called one time and must be called before
-            <code>stop</code> is called or an InvalidStateError exception MUST
-            be thrown.
+            may only be called one time and <span class="synchronous">must be
+            called before <code>stop</code> is called or an InvalidStateError
+            exception MUST be thrown.</span>
             <dl class="parameters">
               <dt>
                 optional double when = 0
@@ -3380,8 +3410,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 "#widl-AudioContext-currentTime">currentTime</a> attribute. If
                 0 is passed in for this value or if the value is less than
                 <b>currentTime</b>, then the sound will start playing
-                immediately. A TypeError exception MUST be thrown if
-                <code>when</code> is negative.
+                immediately. <span class="synchronous">A TypeError exception
+                MUST be thrown if <code>when</code> is negative.</span>
               </dd>
               <dt>
                 optional double offset = 0
@@ -3390,8 +3420,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 The <dfn id="dfn-offset">offset</dfn> parameter describes the
                 offset time in the buffer (in seconds) where playback will
                 begin. If 0 is passed in for this value, then playback will
-                start from the beginning of the buffer. A TypeError exception
-                MUST be thrown if <code>offset</code> is negative.
+                start from the beginning of the buffer. <span class=
+                "synchronous">A TypeError exception MUST be thrown if
+                <code>offset</code> is negative.</span>
               </dd>
               <dt>
                 optional double duration
@@ -3403,8 +3434,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 total duration of the AudioBuffer minus the <code>offset</code>
                 parameter. Thus if neither <code>offset</code> nor
                 <code>duration</code> are specified then the implied duration
-                is the total duration of the AudioBuffer. An TypeError
-                exception MUST be thrown if <code>duration</code> is negative.
+                is the total duration of the AudioBuffer. <span class=
+                "synchronous">An TypeError exception MUST be thrown if
+                <code>duration</code> is negative.</span>
               </dd>
             </dl>
           </dd>
@@ -3425,15 +3457,16 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 "#widl-AudioContext-currentTime">currentTime</a> attribute. If
                 0 is passed in for this value or if the value is less than
                 <a><code>currentTime</code></a>, then the sound will stop
-                playing immediately. A TypeError exception MUST be thrown if
-                <code>when</code> is negative. If <code>stop</code> is called
-                again after already have been called, the last invocation will
-                be the only one applied; stop times set by previous calls will
-                not be applied, unless the buffer has already stopped prior to
-                any subsequent calls. If the buffer has already stopped,
-                further calls to <code>stop</code> will have no effect. If a
-                stop time is reached prior to the scheduled start time, the
-                sound will not play.
+                playing immediately. <span class="synchronous">A TypeError
+                exception MUST be thrown if <code>when</code> is
+                negative</span>. If <code>stop</code> is called again after
+                already have been called, the last invocation will be the only
+                one applied; stop times set by previous calls will not be
+                applied, unless the buffer has already stopped prior to any
+                subsequent calls. If the buffer has already stopped, further
+                calls to <code>stop</code> will have no effect. If a stop time
+                is reached prior to the scheduled start time, the sound will
+                not play.
               </dd>
             </dl>
           </dd>
@@ -3742,8 +3775,9 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
               remove the correspondingly-named read-only <a>Float32Array</a>s
               from the <a>AudioProcessEvent</a>'s
               <a><code>parameters</code></a> member on subsequent audio
-              processing events. A NotFoundError exception must be thrown if no
-              parameter with that name exists on this <a>AudioWorker</a>.
+              processing events. <span class="synchronous">A NotFoundError
+              exception must be thrown if no parameter with that name exists on
+              this <a>AudioWorker</a></span>.
             </p>
             <p>
               The <code>name</code> parameter identifies the parameter to be
@@ -3948,9 +3982,9 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
                 <a>AudioWorkerNode</a>, and will remove the
                 correspondingly-named read-only <a>Float32Array</a> from the
                 <a>AudioProcessEvent</a>'s <a><code>parameters</code></a>
-                member on subsequent audio processing events. A NotFoundError
-                exception MUST be thrown if no parameter with that name exists
-                on this node.
+                member on subsequent audio processing events. <span class=
+                "synchronous">A NotFoundError exception MUST be thrown if no
+                parameter with that name exists on this node.</span>
               </p>
               <p>
                 The <code>name</code> parameter identifies the parameter to be
@@ -4277,8 +4311,9 @@ onaudioprocess= function (e) {
 </pre>
         <p>
           The <code>channelCountMode</code> cannot be changed from "explicit"
-          and the <code>channelCount</code> cannot be changed. An attempt to
-          change either of these MUST throw an InvalidStateError exception.
+          and the <code>channelCount</code> cannot be changed. <span class=
+          "synchronous">An attempt to change either of these MUST throw an
+          InvalidStateError exception</span>.
         </p>
         <p>
           The <a><code>ScriptProcessorNode</code></a> is constructed with a
@@ -5215,13 +5250,14 @@ onaudioprocess= function (e) {
           <dd>
             A mono, stereo, or 4-channel <a><code>AudioBuffer</code></a>
             containing the (possibly multi-channel) impulse response used by
-            the <a><code>ConvolverNode</code></a>. The <code>AudioBuffer</code>
-            must have 1, 2, or 4 channels or a NotSupportedError exception MUST
-            be thrown. This <a><code>AudioBuffer</code></a> must be of the same
-            sample-rate as the <a><code>AudioContext</code></a> or a
-            NotSupportedError exception MUST be thrown. At the time when this
-            attribute is set, the <em>buffer</em> and the state of the
-            <em>normalize</em> attribute will be used to configure the
+            the <a><code>ConvolverNode</code></a>. <span class=
+            "synchronous">The <code>AudioBuffer</code> must have 1, 2, or 4
+            channels or a NotSupportedError exception MUST be thrown</span>.
+            <span class="synchronous">This <a><code>AudioBuffer</code></a> must
+            be of the same sample-rate as the <a><code>AudioContext</code></a>
+            or a NotSupportedError exception MUST be thrown</span>. At the time
+            when this attribute is set, the <em>buffer</em> and the state of
+            the <em>normalize</em> attribute will be used to configure the
             <a><code>ConvolverNode</code></a> with this impulse response having
             the given normalization. The initial value of this attribute is
             null.
@@ -5464,10 +5500,11 @@ float calculateNormalizationScale(buffer)
             attribute unsigned long fftSize
           </dt>
           <dd>
-            The size of the FFT used for frequency-domain analysis. This must
-            be a power of two in the range 32 to 32768, otherwise an
-            IndexSizeError exception MUST be thrown. The default value is 2048.
-            Note that large FFT sizes can be costly to compute.
+            The size of the FFT used for frequency-domain analysis.
+            <span class="synchronous">This must be a power of two in the range
+            32 to 32768, otherwise an IndexSizeError exception MUST be
+            thrown</span>. The default value is 2048. Note that large FFT sizes
+            can be costly to compute.
           </dd>
           <dt>
             readonly attribute unsigned long frequencyBinCount
@@ -5481,10 +5518,10 @@ float calculateNormalizationScale(buffer)
           <dd>
             <dfn id="minDecibels">minDecibels</dfn> is the minimum power value
             in the scaling range for the FFT analysis data for conversion to
-            unsigned byte values. The default value is -100. If the value of
-            this attribute is set to a value more than or equal to
-            <code><a>maxDecibels</a></code>, an IndexSizeError exception MUST
-            be thrown.
+            unsigned byte values. The default value is -100. <span class=
+            "synchronous">If the value of this attribute is set to a value more
+            than or equal to <code><a>maxDecibels</a></code>, an IndexSizeError
+            exception MUST be thrown.</span>
           </dd>
           <dt>
             attribute float maxDecibels
@@ -5492,19 +5529,20 @@ float calculateNormalizationScale(buffer)
           <dd>
             <dfn id="maxDecibels">maxDecibels</dfn> is the maximum power value
             in the scaling range for the FFT analysis data for conversion to
-            unsigned byte values. The default value is -30. If the value of
-            this attribute is set to a value less than or equal to
-            <code><a>minDecibels</a></code>, an IndexSizeError exception MUST
-            be thrown.
+            unsigned byte values. The default value is -30. <span class=
+            "synchronous">If the value of this attribute is set to a value less
+            than or equal to <code><a>minDecibels</a></code>, an IndexSizeError
+            exception MUST be thrown.</span>
           </dd>
           <dt>
             attribute float smoothingTimeConstant
           </dt>
           <dd>
             A value from 0 -&gt; 1 where 0 represents no time averaging with
-            the last analysis frame. The default value is 0.8. If the value of
-            this attribute is set to a value less than 0 or more than 1, an
-            IndexSizeError exception MUST be thrown.
+            the last analysis frame. The default value is 0.8. <span class=
+            "synchronous">If the value of this attribute is set to a value less
+            than 0 or more than 1, an IndexSizeError exception MUST be
+            thrown.</span>
           </dd>
         </dl>
         <section>
@@ -6793,8 +6831,9 @@ $$
           </dt>
           <dd>
             The shape of the periodic waveform. It may directly be set to any
-            of the type constant values except for "custom". Doing so MUST
-            throw an InvalidStateError exception. The <a href=
+            of the type constant values except for "custom". <span class=
+            "synchronous">Doing so MUST throw an InvalidStateError
+            exception.</span> The <a href=
             "#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">
             <code>setPeriodicWave()</code></a> method can be used to set a
             custom waveform, which results in this attribute being set to
@@ -7183,29 +7222,29 @@ waveform is an odd function with period \(2\pi\).
           and one <a>rendering thread</a>.
         </p>
         <p>
-          The <dfn>control thread</dfn> is the thread from
-          which the <a>AudioContext</a> is instanciated, and from which authors
-          manipulate the audio graph. The <dfn>rendering
-          thread</dfn> is the thread on which the actual audio output is
-          computed, in reaction to the calls from the <a>control thread</a>. It
-          can be a real-time, callback-based audio thread, if computing audio
-          for an <a>AudioContext</a>, or a normal thread if rendering and audio
-          graph offline using an <a>OfflineAudioContext</a>.
+          The <dfn>control thread</dfn> is the thread from which the
+          <a>AudioContext</a> is instanciated, and from which authors
+          manipulate the audio graph. The <dfn>rendering thread</dfn> is the
+          thread on which the actual audio output is computed, in reaction to
+          the calls from the <a>control thread</a>. It can be a real-time,
+          callback-based audio thread, if computing audio for an
+          <a>AudioContext</a>, or a normal thread if rendering and audio graph
+          offline using an <a>OfflineAudioContext</a>.
         </p>
         <p>
-          The <a>control thread</a> uses a traditional
-          event loop, as described in [[HTML]].
+          The <a>control thread</a> uses a traditional event loop, as described
+          in [[HTML]].
         </p>
         <p>
-          The <a>rendering thread</a> uses a
-          specialized rendering loop, described in the section <a href=
-          "#rendering-audio">Rendering an audio graph</a>
+          The <a>rendering thread</a> uses a specialized rendering loop,
+          described in the section <a href="#rendering-audio">Rendering an
+          audio graph</a>
         </p>
         <p>
-          Communication from the <a>control thread</a>
-          to the <a>rendering thread</a> is done using
-          <a>Control message</a> passing. Communication
-          in the other direction is done using regular event loop tasks.
+          Communication from the <a>control thread</a> to the <a>rendering
+          thread</a> is done using <a>Control message</a> passing.
+          Communication in the other direction is done using regular event loop
+          tasks.
         </p>
         <p>
           Each <a>AudioContext</a> has a single <dfn>control message
@@ -7251,7 +7290,7 @@ waveform is an odd function with period \(2\pi\).
         </h3>
         <p>
           Calling methods on <a>AudioNode</a>s MUST to be done in two phases, a
-          synchronous operation and an asynchronous operation. For each method,
+          synchronous section and an asynchronous section. For each method,
           some part of the execution happens on the <a>control thread</a> (for
           example, throwing an exception in case of invalid parameters), and
           some part happens on the <a>rendering thread</a> (for example,
@@ -7288,19 +7327,18 @@ waveform is an odd function with period \(2\pi\).
           Rendering an audio graph
         </h3>
         <p>
-        Rendering an audio graph is done by blocks of 128 samples-frames.
+          Rendering an audio graph is done by blocks of 128 samples-frames.
         </p>
-
         <p>
-        Operations that happens <dfn data-lt="atomic">atomically</dfn> on a given thread, can only
-        be executed when no other <a>atomic</a> operation is
-        running on another thread.
+          Operations that happens <dfn data-lt="atomic">atomically</dfn> on a
+          given thread, can only be executed when no other <a>atomic</a>
+          operation is running on another thread.
         </p>
-
         <p>
-        The algorithm for rendering a block of audio from an <a>AudioContext</a>
-        <em>G</em> with an <a href=#control-message-queue>control message queue</a>
-        <em>Q</em> is as follow:
+          The algorithm for rendering a block of audio from an
+          <a>AudioContext</a> <em>G</em> with an <a href=
+          "#control-message-queue">control message queue</a> <em>Q</em> is as
+          follow:
         </p>
         <ol>
           <li> Let <em>Q<sub>rendering</sub></em> be an empty <a
@@ -7363,7 +7401,7 @@ waveform is an odd function with period \(2\pi\).
                   <em>nodes</em>
                   </li>
                   <li>
-                    <a>Visit</a> <em>node</em>.
+                  <a>Visit</a> <em>node</em>.
                   </li>
                 </ol><dfn data-lt="Visit">Visiting a node</dfn> <em>node</em>
                 mean performing the following steps:
@@ -7386,9 +7424,9 @@ waveform is an odd function with period \(2\pi\).
               </li>
             </ol>
           </li>
-          <li>For each <a>DelayNode</a> in a cycle, <a href="availabel">make
+          <li>For each <a>DelayNode</a> in a cycle, <a href="available">make
           available for reading</a> a block of audio from the <a>DelayNode</a>
-          buffer.
+          buffer, available for reading.
           </li>
           <li>For each <a>AudioNode</a>, in the order determined previously:
             <ol>
@@ -7416,30 +7454,31 @@ waveform is an odd function with period \(2\pi\).
         </ol>
         </li>
       </ol>
-    <p>
-      <dfn id=available>Making a buffer available for reading</dfn> from an
-      <a>AudioNode</a> means putting it in a state where other <a>AudioNode</a>s
-      connected to this <a>AudioNode</a> can safely read from it.
-      <p class=note>For example, implementations can choose to allocate a new
-      buffer, or have a more elaborate mechanism, reusing an existing buffer
-      that is now unused.
-    </p>
-
-    <p>
-      <dfn id=record>Recording the input</dfn> of an <a>AudioNode</a> means
-      copying the input data of this <a>AudioNode</a> for future usage.
-    </p>
-
-    <p>
-      <dfn id=computing>Computing a block of audio</dfn> means running the
-      algorithm for this <a>AudioNode</a> to produce 128 sample-frames.
-    </p>
-
-    <p>
-      <dfn data-lt=process>Processing an input buffer</dfn> means running the
-      algorithm for an <a>AudioNode</a>, using an <a>input buffer</a> as the
-      input for this algorithm.
-    </p>
+        <p>
+          <dfn id="available">Making a buffer available for reading</dfn> from
+          an <a>AudioNode</a> means putting it in a state where other
+          <a>AudioNode</a>s connected to this <a>AudioNode</a> can safely read
+          from it.
+        </p>
+        <p class="note">
+          For example, implementations can choose to allocate a new buffer, or
+          have a more elaborate mechanism, reusing an existing buffer that is
+          now unused.
+        </p>
+        <p>
+          <dfn id="record">Recording the input</dfn> of an <a>AudioNode</a>
+          means copying the input data of this <a>AudioNode</a> for future
+          usage.
+        </p>
+        <p>
+          <dfn id="computing">Computing a block of audio</dfn> means running
+          the algorithm for this <a>AudioNode</a> to produce 128 sample-frames.
+        </p>
+        <p>
+          <dfn data-lt="process">Processing an input buffer</dfn> means running
+          the algorithm for an <a>AudioNode</a>, using an <a>input buffer</a>
+          as the input for this algorithm.
+        </p>
       </section>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -5377,10 +5377,10 @@ float calculateNormalizationScale(buffer)
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
-              following way.  Let \(Y[k]\) be the <a>current frequency data</a>
-              as described in <a
-              href="#fft-windowing-and-smoothing-over-time">FFT windowing and
-              smoothing</a>.  Then the byte value, \(b[k]\), is
+              following way. Let \(Y[k]\) be the <a>current frequency data</a>
+              as described in <a href=
+              "#fft-windowing-and-smoothing-over-time">FFT windowing and
+              smoothing</a>. Then the byte value, \(b[k]\), is
             </p>
             <pre>
               $$
@@ -5438,7 +5438,7 @@ float calculateNormalizationScale(buffer)
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
-              following way.  Let \(x[k]\) be the time-domain data.  Then the
+              following way. Let \(x[k]\) be the time-domain data. Then the
               byte value, \(b[k]\), is
             </p>
             <pre>
@@ -7141,9 +7141,13 @@ waveform is an odd function with period \(2\pi\).
       </section>
     </section>
     <section>
-      <h2> Processing model </h2>
+      <h2>
+        Processing model
+      </h2>
       <section class="informative">
-      <h3> Background </h3>
+        <h3>
+          Background
+        </h3>
         <p>
           Real-time audio systems that require low latency are, often time,
           implemented using <em>callback functions</em>, where the operating
@@ -7171,7 +7175,9 @@ waveform is an odd function with period \(2\pi\).
         </p>
       </section>
       <section>
-        <h3> Control thread and rendering thread </h3>
+        <h3>
+          Control thread and rendering thread
+        </h3>
         <p>
           The Web Audio API MUST be implemented using a <a>control thread</a>,
           and one <a>rendering thread</a>.
@@ -7207,7 +7213,6 @@ waveform is an odd function with period \(2\pi\).
           messages</dfn>, that are a operations running on the <a>control
           thread</a>.
         </p>
-
         <p>
           <dfn id="queuing">Queuing an control message</dfn> means adding the
           message to the end of the <a>control message queue</a> of an


### PR DESCRIPTION
This annotates all the synchronous sections for when exceptions are thrown. It's mostly mechanical changes: grep on "throw", surround with the `<span class="synchronous">`.

Again, this is based on patches in other PRs.