### PR TITLE
Specify initial event for linear and exponential ramp.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2426,8 +2426,7 @@ function setupRoutingGraph() {
               $$
                 v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 - T_0}
               $$
-            
-</pre>
+            </pre>
             <p>
               Where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
               <code>value</code> parameter passed into this method.
@@ -2435,6 +2434,14 @@ function setupRoutingGraph() {
             <p>
               If there are no more events after this LinearRampToValue event
               then for \(t \geq T_1\), \(v(t) = V_1\).
+            </p>
+            <p>
+              If there is no event preceding this event, the linear ramp
+              behaves as if <code>setValueAtTime(value, currentTime)</code>
+              were called where <code>value</code> is the current value of the
+              attribute and <code>currentTime</code> is the context <a href=
+              "#widl-AudioContext-currentTime">currentTime</a> at the time
+              <code>linearRampToValueAtTime</code> is called.
             </p>
           </dd>
           <dt>
@@ -2458,8 +2465,7 @@ function setupRoutingGraph() {
               $$
                 v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t - T_0}{T_1 - T_0}
               $$
-            
-</pre>
+            </pre>
             <p>
               where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
               <code>value</code> parameter passed into this method. It is an
@@ -2474,6 +2480,14 @@ function setupRoutingGraph() {
             <p>
               If there are no more events after this ExponentialRampToValue
               event then for \(t \geq T_1\), \(v(t) = V_1\).
+            </p>
+            <p>
+              If there is no event preceding this event, the exponential ramp
+              behaves as if <code>setValueAtTime(value, currentTime)</code>
+              were called where <code>value</code> is the current value of the
+              attribute and <code>currentTime</code> is the context <a href=
+              "#widl-AudioContext-currentTime">currentTime</a> at the time
+              <code>exponentialRampToValueAtTime</code> is called.
             </p>
             <dl class="parameters">
               <dt>


### PR DESCRIPTION
If there is no event preceding a linearRampToValueAtTime or
exponentialRampToValueAtTime, specify that these behave as if a
setValueAtTime were inserted at the context currentTime with the
current attribute value at the time of the call.

Fix #130.