### PR TITLE
Support chaining on AudioNode.connect() and AudioParam automation methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -1745,20 +1745,21 @@ function setupRoutingGraph() {
 </pre>
           </dd>
           <dt>
-            AudioParam connect()
+            void connect()
           </dt>
           <dd>
             Connects the <a><code>AudioNode</code></a> to an
             <a><code>AudioParam</code></a>, controlling the parameter value
-            with an audio-rate signal. The <code>destination</code> is also
-            returned by this method in order to enable easy chaining.
+            with an audio-rate signal.
             <dl class="parameters">
               <dt>
                 AudioParam destination
               </dt>
               <dd>
                 The <code>destination</code> parameter is the
-                <a><code>AudioParam</code></a> to connect to.
+                <a><code>AudioParam</code></a> to connect to. This method does
+                not return <code>destination</code>
+                <a><code>AudioParam</code></a> object.
               </dd>
               <dt>
                 optional unsigned long output = 0
@@ -2331,7 +2332,7 @@ function setupRoutingGraph() {
             Initial value for the <code>value</code> attribute.
           </dd>
           <dt>
-            void setValueAtTime(float value, double startTime)
+            AudioParam setValueAtTime(float value, double startTime)
           </dt>
           <dd>
             <p>
@@ -2388,9 +2389,13 @@ function setupRoutingGraph() {
               "#widl-AudioParam-exponentialRampToValueAtTime-void-float-value-double-endTime">
               exponentialRampToValueAtTime</a></code>, respectively.
             </p>
+            <p>
+              This method returns the current <a>AudioParam</a> object for easy
+              chaining.
+            </p>
           </dd>
           <dt>
-            void linearRampToValueAtTime(float value, double endTime)
+            AudioParam linearRampToValueAtTime(float value, double endTime)
           </dt>
           <dd>
             <p>
@@ -2436,9 +2441,14 @@ function setupRoutingGraph() {
               If there are no more events after this LinearRampToValue event
               then for \(t \geq T_1\), \(v(t) = V_1\).
             </p>
+            <p>
+              This method returns the current <a>AudioParam</a> object for easy
+              chaining.
+            </p>
           </dd>
           <dt>
-            void exponentialRampToValueAtTime(float value, double endTime)
+            AudioParam exponentialRampToValueAtTime(float value, double
+            endTime)
           </dt>
           <dd>
             <p>
@@ -2497,9 +2507,13 @@ function setupRoutingGraph() {
                 number.
               </dd>
             </dl>
+            <p>
+              This method returns the current <a>AudioParam</a> object for easy
+              chaining.
+            </p>
           </dd>
           <dt>
-            void setTargetAtTime(float target, double startTime, float
+            AudioParam setTargetAtTime(float target, double startTime, float
             timeConstant)
           </dt>
           <dd>
@@ -2564,10 +2578,14 @@ function setupRoutingGraph() {
               \(V_1\) is equal to the <code>target</code> parameter, and
               \(\tau\) is the <code>timeConstant</code> parameter.
             </p>
+            <p>
+              This method returns the current <a>AudioParam</a> object for easy
+              chaining.
+            </p>
           </dd>
           <dt>
-            void setValueCurveAtTime(Float32Array values, double startTime,
-            double duration)
+            AudioParam setValueCurveAtTime(Float32Array values, double
+            startTime, double duration)
           </dt>
           <dd>
             <p>
@@ -2628,9 +2646,13 @@ function setupRoutingGraph() {
               the value will remain constant at the final curve value, until
               there is another automation event (if any).
             </p>
+            <p>
+              This method returns the current <a>AudioParam</a> object for easy
+              chaining.
+            </p>
           </dd>
           <dt>
-            void cancelScheduledValues(double startTime)
+            AudioParam cancelScheduledValues(double startTime)
           </dt>
           <dd>
             <p>
@@ -2654,6 +2676,10 @@ function setupRoutingGraph() {
                 negative or is not a finite number.
               </dd>
             </dl>
+            <p>
+              This method returns the current <a>AudioParam</a> object for easy
+              chaining.
+            </p>
           </dd>
         </dl>
         <section>

--- a/index.html
+++ b/index.html
@@ -1754,9 +1754,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> that has been created using
                 another <a><code>AudioContext</code></a>, an InvalidAccessError
                 MUST be thrown. That is, <a><code>AudioNodes</code></a> cannot
-                be shared between <a><code>AudioContext</code></a>. The
-                <code>destination</code> is also returned by
-                <code>connect</code> in order to enable easy chaining.
+                be shared between <a><code>AudioContext</code></a>.
               </dd>
               <dt>
                 optional unsigned long output = 0
@@ -2450,10 +2448,6 @@ function setupRoutingGraph() {
               "#widl-AudioParam-exponentialRampToValueAtTime-void-float-value-double-endTime">
               exponentialRampToValueAtTime</a></code>, respectively.
             </p>
-            <p>
-              This method returns the current <a>AudioParam</a> object for easy
-              chaining.
-            </p>
           </dd>
           <dt>
             AudioParam linearRampToValueAtTime(float value, double endTime)
@@ -2502,10 +2496,6 @@ function setupRoutingGraph() {
             <p>
               If there are no more events after this LinearRampToValue event
               then for \(t \geq T_1\), \(v(t) = V_1\).
-            </p>
-            <p>
-              This method returns the current <a>AudioParam</a> object for easy
-              chaining.
             </p>
           </dd>
           <dt>
@@ -2569,10 +2559,6 @@ function setupRoutingGraph() {
                 number.
               </dd>
             </dl>
-            <p>
-              This method returns the current <a>AudioParam</a> object for easy
-              chaining.
-            </p>
           </dd>
           <dt>
             AudioParam setTargetAtTime(float target, double startTime, float
@@ -2640,10 +2626,6 @@ function setupRoutingGraph() {
               \(V_1\) is equal to the <code>target</code> parameter, and
               \(\tau\) is the <code>timeConstant</code> parameter.
             </p>
-            <p>
-              This method returns the current <a>AudioParam</a> object for easy
-              chaining.
-            </p>
           </dd>
           <dt>
             AudioParam setValueCurveAtTime(Float32Array values, double
@@ -2708,10 +2690,6 @@ function setupRoutingGraph() {
               the value will remain constant at the final curve value, until
               there is another automation event (if any).
             </p>
-            <p>
-              This method returns the current <a>AudioParam</a> object for easy
-              chaining.
-            </p>
           </dd>
           <dt>
             AudioParam cancelScheduledValues(double startTime)
@@ -2738,10 +2716,6 @@ function setupRoutingGraph() {
                 is negative or is not a finite number.
               </dd>
             </dl>
-            <p>
-              This method returns the current <a>AudioParam</a> object for easy
-              chaining.
-            </p>
           </dd>
         </dl>
         <section>

--- a/index.html
+++ b/index.html
@@ -1754,7 +1754,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> that has been created using
                 another <a><code>AudioContext</code></a>, an InvalidAccessError
                 MUST be thrown. That is, <a><code>AudioNodes</code></a> cannot
-                be shared between <a><code>AudioContext</code></a>.
+                be shared between <a><code>AudioContext</code></a>s.
               </dd>
               <dt>
                 optional unsigned long output = 0


### PR DESCRIPTION
- Revert: AudioNode.connect(AudioParam) does not return anything. (see #650)
- Also changed the weird location of 'parameters' in the method description.