### PR TITLE
Use double quotes for IDL strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1384,7 +1384,7 @@ function setupRoutingGraph() {
         </dl>
         <dl title="dictionary AudioContextOptions" class="idl">
           <dt>
-            AudioContextPlaybackCategory playbackCategory = 'interactive'
+            AudioContextPlaybackCategory playbackCategory = "interactive"
           </dt>
           <dd>
             Identify the type of playback, which affects tradeoffs between


### PR DESCRIPTION
Fix #668 by using "interactive" instead of 'interactive'.