### PR TITLE
Load MathJax from w3.org/scripts instead of CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     class='remove'>
     </script>
     <script src=
-    "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    "https://www.w3.org/scripts/MathJax/2.5.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
     <script class='remove'>
     var respecConfig = {


### PR DESCRIPTION
There is no problem whatsoever right now with specs loading JS from any sources.

In the future, [we may be looking at encouraging editors to use our own copies of certain popular libraries and frameworks](https://github.com/w3c/echidna/issues/233). There are a number of benefits to this, which are currently being discussed; most of them have to do with the system for automatic publication, trying to make it more secure against vulnerabilities; also we want to avoid the proliferation of multiple copies of the same JS files in w3.org space (although that is not an issue when using CDNs, as in this particular case).

When that happens, we will give notice well in advance to groups to update their documents. In any case, it wouldn't hurt, I think, to do the switch when that is trivial.

This is a proposal to have this spec using [our own copy of MathJax 2.5.3](https://www.w3.org/scripts/MathJax/2.5/).