### PR TITLE
Fix respec warnings.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4683,10 +4683,10 @@ the event handler.
           <a><code>SpatialListener</code></a>. This interface represents the
           position and orientation of the person listening to the audio scene.
           All <a><code>PannerNode</code></a> objects spatialize in relation to
-          the <a><code>BaseAudioContext</code></a>'s <a
-          href="#widl-BaseAudioContext-listener">listener</a>. See
-<a href="#Spatialization">the Spatialization/Panning section</a> for more
-details about spatialization.
+          the <a><code>BaseAudioContext</code></a>'s <a href=
+          "#widl-BaseAudioContext-listener">listener</a>. See <a href=
+          "#Spatialization">the Spatialization/Panning section</a> for more
+          details about spatialization.
         </p>
         <dl title="interface AudioListener" class="idl">
           <dt>
@@ -4954,8 +4954,8 @@ pow(distance / refDistance, -rolloffFactor)
           listening to the audio scene. All
           <a><code>SpatialPannerNode</code></a> objects spatialize in relation
           to the <a><code>AudioContext</code></a>'s
-          <a><code>SpatialListener</code></a>.  See <a
-          href="#Spatialization">the Spatialization/Panning section</a> for more
+          <a><code>SpatialListener</code></a>. See <a href=
+          "#Spatialization">the Spatialization/Panning section</a> for more
           details about spatialization.
         </p>
         <dl title="interface SpatialListener" class="idl">
@@ -6525,8 +6525,9 @@ $$
           </h3>
           <p>
             Let \(b_m\) be the <code>feedforward</code> coefficients and
-            \(a_n\) be the <code>feedback</code> coefficients specified by 
-            <a href="#widl-BaseAudioContext-createIIRFilter-IIRFilterNode-sequence-double--feedforward-sequence-double--feedback">
+            \(a_n\) be the <code>feedback</code> coefficients specified by
+            <a href=
+            "#widl-BaseAudioContext-createIIRFilter-IIRFilterNode-sequence-double--feedforward-sequence-double--feedback">
             createIIRFilter</a>. Then the transfer function of the general IIR
             filter is given by
           </p>
@@ -6913,8 +6914,8 @@ odd function with period \(2\pi\).
           The PeriodicWave Interface
         </h2>
         <p>
-          PeriodicWave represents an arbitrary periodic waveform to be used with
-          an <a><code>OscillatorNode</code></a>. Please see <a href=
+          PeriodicWave represents an arbitrary periodic waveform to be used
+          with an <a><code>OscillatorNode</code></a>. Please see <a href=
           "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
           createPeriodicWave()</a> and <a href=
           "#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">
@@ -7014,7 +7015,7 @@ odd function with period \(2\pi\).
           </p>
           <p>
             In the following descriptions, let \(a\) be the array of real
-            coefficients and \(b\) be the array of imaginary coefficients for 
+            coefficients and \(b\) be the array of imaginary coefficients for
             <a href=
             "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
             createPeriodicWave()</a>. In all cases \(a[n] = 0\) for all \(n\)

--- a/index.html
+++ b/index.html
@@ -1328,10 +1328,10 @@ function setupRoutingGraph() {
               As <a>PeriodicWave</a> objects maintain their own copies of these
               arrays, any modification of the arrays uses as the
               <code>real</code> and <code>imag</code> parameters after the call
-              to <!--a href=
-              "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag"-->
-               <a><code>createPeriodicWave()</code></a> will have no effect on
-              the <a>PeriodicWave</a> object.
+              to <a href=
+              "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
+              createPeriodicWave()</a> will have no effect on the
+              <a>PeriodicWave</a> object.
             </p>
             <dl class="parameters">
               <dt>
@@ -4683,8 +4683,8 @@ the event handler.
           <a><code>SpatialListener</code></a>. This interface represents the
           position and orientation of the person listening to the audio scene.
           All <a><code>PannerNode</code></a> objects spatialize in relation to
-          the <a><code>BaseAudioContext</code></a>'s <!--a href=
-          "widl-AudioContext-listener"--><a><code>listener</code></a>. See
+          the <a><code>BaseAudioContext</code></a>'s <a
+          href="#widl-BaseAudioContext-listener">listener</a>. See
 <a href="#Spatialization">the Spatialization/Panning section</a> for more
 details about spatialization.
         </p>
@@ -4953,10 +4953,10 @@ pow(distance / refDistance, -rolloffFactor)
           This interface represents the position and orientation of the person
           listening to the audio scene. All
           <a><code>SpatialPannerNode</code></a> objects spatialize in relation
-          to the <a><code>AudioContext</code></a>'s <!--a href=
-          "widl-AudioContext-spatialListener"--><a><code>spatialListener</code></a>.
-See <a href="#Spatialization">the Spatialization/Panning section</a> for more
-details about spatialization.
+          to the <a><code>AudioContext</code></a>'s
+          <a><code>SpatialListener</code></a>.  See <a
+          href="#Spatialization">the Spatialization/Panning section</a> for more
+          details about spatialization.
         </p>
         <dl title="interface SpatialListener" class="idl">
           <dt>
@@ -6526,10 +6526,9 @@ $$
           <p>
             Let \(b_m\) be the <code>feedforward</code> coefficients and
             \(a_n\) be the <code>feedback</code> coefficients specified by 
-            <!--a href=
-            "#widl-BaseAudioContext-createIIRFilter-IIRFilterNode-Float32Array-feedforward-Float32Array-feedback"-->
-             <a><code>createIIRFilter</code></a>. Then the transfer function of
-            the general IIR filter is given by
+            <a href="#widl-BaseAudioContext-createIIRFilter-IIRFilterNode-sequence-double--feedforward-sequence-double--feedback">
+            createIIRFilter</a>. Then the transfer function of the general IIR
+            filter is given by
           </p>
           <pre>
             $$
@@ -6914,10 +6913,10 @@ odd function with period \(2\pi\).
           The PeriodicWave Interface
         </h2>
         <p>
-          PeriodicWave represents an arbitrary periodic waveform to be used
-          with an <a><code>OscillatorNode</code></a>. Please see <!--a href=
-          "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag"-->
-           <a>createPeriodicWave()</a> and <a href=
+          PeriodicWave represents an arbitrary periodic waveform to be used with
+          an <a><code>OscillatorNode</code></a>. Please see <a href=
+          "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
+          createPeriodicWave()</a> and <a href=
           "#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">
           setPeriodicWave()</a> and for more details.
         </p>
@@ -6943,9 +6942,9 @@ odd function with period \(2\pi\).
             Waveform Generation
           </h2>
           <p>
-            The <!--a href=
-            "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag"-->
-             <a>createPeriodicWave()</a> method takes two arrays to specify the
+            The <a href=
+            "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
+            createPeriodicWave()</a> method takes two arrays to specify the
             Fourier coefficients of the PeriodicWave. Let \(a\) and \(b\)
             represent the real and imaginary arrays of length \(L\). Then the
             basic time-domain waveform, \(x(t)\), can be computed using:
@@ -7016,12 +7015,11 @@ odd function with period \(2\pi\).
           <p>
             In the following descriptions, let \(a\) be the array of real
             coefficients and \(b\) be the array of imaginary coefficients for 
-            <!--a href=
-            "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag"-->
-             <a><code>createPeriodicWave()</code></a>. In all cases \(a[n] =
-            0\) for all \(n\) because the waveforms are odd functions. Also,
-            \(b[0] = 0\) in all cases. Hence, only \(b[n]\) for \(n \ge 1\) is
-            specified below.
+            <a href=
+            "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
+            createPeriodicWave()</a>. In all cases \(a[n] = 0\) for all \(n\)
+            because the waveforms are odd functions. Also, \(b[0] = 0\) in all
+            cases. Hence, only \(b[n]\) for \(n \ge 1\) is specified below.
           </p>
           <dl>
             <dt>


### PR DESCRIPTION
Use correct links for
 o createIIRFIlter (commented out in aa3b6f45).
 o AudioContext.listener (commented out in 8cc56fe7).
 o createPeriodicWave (commented out in 31c4806).

Link for fetch algorithm is still broken.