### PR TITLE
Specify omni-directional source for PannerNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -8119,7 +8119,7 @@ if (pan &lt;= 0) {
     return v;
   }
 
-  if (dotProduct(source.orientation, source.orientation) == 0 || ((source.coneInnerAngle == 0) &amp;& (source.coneOuterAngle == 0)))
+  if (dotProduct(source.orientation, source.orientation) == 0 || ((source.coneInnerAngle == 360) &amp;& (source.coneOuterAngle == 360)))
       return 1; // no cone specified - unity gain
 
   // Normalized source-listener vector
@@ -8135,8 +8135,8 @@ if (pan &lt;= 0) {
   var absAngle = Math.abs(angle);
 
   // Divide by 2 here since API is entire angle (not half-angle)
-  var absInnerAngle = Math.abs(source.coneInnerAngle) / 2;
-  var absOuterAngle = Math.abs(source.coneOuterAngle) / 2;
+  var absInnerAngle = Math.abs(source.coneInnerAngle % 360) / 2;
+  var absOuterAngle = Math.abs(source.coneOuterAngle % 360) / 2;
   var gain = 1;
 
   if (absAngle &lt;= absInnerAngle)

--- a/index.html
+++ b/index.html
@@ -4646,9 +4646,9 @@ the event handler.
           <dd>
             A parameter for directional audio sources, this is an angle, in
             degrees, inside of which there will be no volume reduction. The
-            default value is 360, and the value is used modulo 360.  However, if
-            this angle is 360 and the <a><code>coneOuterAngle</code></a> is also
-            360, the source is omni-directional so no cone effects are applied.
+            default value is 0, and the value is used modulo 360.  However, if
+            this angle is 0 and the <a><code>coneOuterAngle</code></a> is also
+            0, the source is omni-directional so no cone effects are applied.
           </dd>
           <dt>
             attribute float coneOuterAngle
@@ -4656,9 +4656,9 @@ the event handler.
           <dd>
             A parameter for directional audio sources, this is an angle, in
             degrees, outside of which the volume will be reduced to a constant
-            value of <a><code>coneOuterGain</code></a>. The default value is 360
-            and the value is used modulo 360.  However, if this angle is 360 and
-            the <a><code>coneInnerAngle</code></a> is also 360, the source is
+            value of <a><code>coneOuterGain</code></a>. The default value is 0
+            and the value is used modulo 360.  However, if this angle is 0 and
+            the <a><code>coneInnerAngle</code></a> is also 0, the source is
             omni-directional so no cone effects are applied.
           </dd>
           <dt>
@@ -8124,7 +8124,7 @@ if (pan &lt;= 0) {
     return v;
   }
 
-  if (dotProduct(source.orientation, source.orientation) == 0 || ((source.coneInnerAngle == 360) &amp;& (source.coneOuterAngle == 360)))
+  if (dotProduct(source.orientation, source.orientation) == 0 || ((source.coneInnerAngle == 0) &amp;& (source.coneOuterAngle == 0)))
       return 1; // no cone specified - unity gain
 
   // Normalized source-listener vector
@@ -8139,7 +8139,8 @@ if (pan &lt;= 0) {
   var angle = 180 * Math.acos(dotProduct) / Math.PI;
   var absAngle = Math.abs(angle);
 
-  // Divide by 2 here since API is entire angle (not half-angle)
+  // Angles are modulo 360 and divide by 2 here since API is entire angle (not
+  // half-angle).
   var absInnerAngle = Math.abs(source.coneInnerAngle % 360) / 2;
   var absOuterAngle = Math.abs(source.coneOuterAngle % 360) / 2;
   var gain = 1;

--- a/index.html
+++ b/index.html
@@ -4641,7 +4641,9 @@ the event handler.
           <dd>
             A parameter for directional audio sources, this is an angle, in
             degrees, inside of which there will be no volume reduction. The
-            default value is 360, and the value is used modulo 360.
+            default value is 360, and the value is used modulo 360.  However, if
+            this angle is 360 and the <a><code>coneOuterAngle</code></a> is also
+            360, the source is omni-directional so no cone effects are applied.
           </dd>
           <dt>
             attribute float coneOuterAngle
@@ -4649,8 +4651,10 @@ the event handler.
           <dd>
             A parameter for directional audio sources, this is an angle, in
             degrees, outside of which the volume will be reduced to a constant
-            value of <a><code>coneOuterGain</code></a>. The default value is
-            360 and the value is used modulo 360.
+            value of <a><code>coneOuterGain</code></a>. The default value is 360
+            and the value is used modulo 360.  However, if this angle is 360 and
+            the <a><code>coneInnerAngle</code></a> is also 360, the source is
+            omni-directional so no cone effects are applied.
           </dd>
           <dt>
             attribute float coneOuterGain


### PR DESCRIPTION
Fix #682 by specifying that if the cone inner and outer angles are
both 360 deg, the source is omni-directional and no cone effects are
applied.