### PR TITLE
Directly pipe curl to tar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 sudo: false
 install:
- - curl https://cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz -o cmake-3.3.1-Linux-x86_64.tar.gz && tar xzf cmake-3.3.1-Linux-x86_64.tar.gz && rm -f cmake-3.3.1-Linux-x86_64.tar.gz
+ - curl https://cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz | tar xzf -
  - make cmake="$PWD/cmake-3.3.1-Linux-x86_64/bin/cmake" install_tidy
 script:
   - make check


### PR DESCRIPTION
Don't actually need to save the tar file anywhere.  Just pipe the
output of curl to tar to unpack it.