### PR TITLE
Don't fail if spec-generator doesn't include MathJax

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,11 +96,13 @@
 
     // This allow wrapping mathjax formulas in <pre> so the LaTeX code is not
     // auto wrapped and keeps a nice formatting.
-    MathJax.Hub.Config({
-      tex2jax: {
-         skipTags: ["script","noscript","style","textarea","code"]
-      }
-    });
+    if (window.MathJax !== undefined) {
+      MathJax.Hub.Config({
+        tex2jax: {
+           skipTags: ["script","noscript","style","textarea","code"]
+        }
+      });
+    }
     </script>
   </head>
   <body>


### PR DESCRIPTION
This will allow https://github.com/w3c/spec-generator/ to disable MathJax when generating the document for automatic publication.
