### PR TITLE
Update link for fetching algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3497,9 +3497,8 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
             <em>silence</em> instead of the normal output of the
             <code>HTMLMediaElement</code> if it has been created using an
             <code>HTMLMediaElement</code> for which the execution of the 
-            <!--a href=
-            "http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-enabled-fetch"-->
-             <a>fetch algorithm</a> labeled the resource as <a href=
+            <a href="https://fetch.spec.whatwg.org/#fetching">
+            fetch algorithm</a> labeled the resource as <a href=
             "http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cross-origin">
             CORS-cross-origin</a>.
           </p>


### PR DESCRIPTION
Removes a warning from respec about a linkless <a> element for fetch algorithm.

Not sure if this is the right link; I don't know what the original link went to and can't check because the old link no longer works.