### PR TITLE
Mention that AudioNode.connect() returns destination object.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1803,6 +1803,8 @@ function setupRoutingGraph() {
                 another <a><code>AudioContext</code></a>, an InvalidAccessError
                 MUST be thrown. That is, <a><code>AudioNodes</code></a> cannot
                 be shared between <a><code>AudioContext</code></a>s.
+                This method returns the
+                <code>destination</code> <a><code>AudioParam</code></a> object.
               </dd>
               <dt>
                 optional unsigned long output = 0


### PR DESCRIPTION
Fix for https://github.com/WebAudio/web-audio-api/issues/708.