### PR TITLE
Replace 0.7071 with sqrt(0.5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7693,7 +7693,7 @@ Quad up-mix:
           output = 0.25 * (input.L + input.R + input.SL + input.SR);
 
       5.1 -&gt; 1 : 5.1 to mono
-          output = 0.7071 * (input.L + input.R) + input.C + 0.5 * (input.SL + input.SR)
+          output = sqrt(0.5) * (input.L + input.R) + input.C + 0.5 * (input.SL + input.SR)
 
 
   Stereo down-mix:


### PR DESCRIPTION
Fix issue #718.  I think the intent is use sqrt(0.5) and not 0.7071.