### PR TITLE
Truncate float to integer for Analyser.getByte.*Data

### DIFF
--- a/index.html
+++ b/index.html
@@ -5358,11 +5358,12 @@ function calculateNormalizationScale(buffer)
             </p>
             <pre>
                   $$
-                    b[k] = \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
-                     \left(Y[k] - \mbox{dB}_{min}\right)
+                    b[k] = \left\lfloor
+                        \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
+                        \left(Y[k] - \mbox{dB}_{min}\right)
+                      \right\rfloor
                   $$
-              
-</pre>
+	    </pre>
             <p>
               where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code> and
               \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If
@@ -5418,10 +5419,9 @@ function calculateNormalizationScale(buffer)
             </p>
             <pre>
               $$
-                b[k] = 128(1 + x[k]).
+                b[k] = \left\lfloor 128(1 + x[k]) \right\rfloor.
               $$
-              
-</pre>
+	    </pre>
             <p>
               If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is clipped
               to lie in that range.

--- a/index.html
+++ b/index.html
@@ -5363,7 +5363,7 @@ function calculateNormalizationScale(buffer)
                         \left(Y[k] - \mbox{dB}_{min}\right)
                       \right\rfloor
                   $$
-	    </pre>
+            </pre>
             <p>
               where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code> and
               \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If
@@ -5421,7 +5421,7 @@ function calculateNormalizationScale(buffer)
               $$
                 b[k] = \left\lfloor 128(1 + x[k]) \right\rfloor.
               $$
-	    </pre>
+            </pre>
             <p>
               If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is clipped
               to lie in that range.


### PR DESCRIPTION
Explicitly say that the byte data is computed from the floating point
data by truncating the float to an integer.

Fix #722