### PR TITLE
Scale the FFT by 1/N in the AnalyserNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5548,10 +5548,9 @@ function calculateNormalizationScale(buffer)
           </p>
           <pre>
             $$
-              X[k] = \sum_{n = 0}^{N - 1} \hat{x}[n] e^{\frac{-2\pi i k n}{N}}
+              X[k] = \frac{1}{N} \sum_{n = 0}^{N - 1} \hat{x}[n]\, e^{\frac{-2\pi i k n}{N}}
             $$
-          
-</pre>
+          </pre>
           <p>
             for \(k = 0, \dots, N/2-1\).
           </p>


### PR DESCRIPTION
Apply a scale factor to the FFT so that a 0 dbFS sine wave is 0 dBfs.

Chrome does this; I didn't check anywhere else, but it makes sense
that the FFT output should have the same amplitude as the input,
instead of leaving the FFT unscaled.

Fix #725.