### PR TITLE
Clarify downmixing of the AnalyserNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5490,7 +5490,9 @@ function calculateNormalizationScale(buffer)
           data</dfn> are computed, the following operations are to be
           performed:
           <ol>
-            <li>Down-mix all channels of the time domain input data to mono.
+            <li>
+              <a href="#channel-up-mixing-and-down-mixing">Down-mix</a> all channels of the time
+              domain input data to mono.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the

--- a/index.html
+++ b/index.html
@@ -5491,8 +5491,8 @@ function calculateNormalizationScale(buffer)
           performed:
           <ol>
             <li>
-              <a href="#channel-up-mixing-and-down-mixing">Down-mix</a> all channels of the time
-              domain input data to mono.
+              <a href="#channel-up-mixing-and-down-mixing">Down-mix</a> all
+              channels of the time domain input data to mono.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the


### PR DESCRIPTION
Adds link to the downmixing section to clarify exactly how the
downmixing to mono is done.

Fix #719