### PR TITLE
Use TeX formulas for SpatialPanner distance models

### DIFF
--- a/index.html
+++ b/index.html
@@ -4813,8 +4813,10 @@ the event handler.
             A linear distance model which calculates <em>distanceGain</em>
             according to:
             <pre>
-            1 - rolloffFactor * (distance - refDistance) / (maxDistance - refDistance)
-</pre>
+            $$
+              1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}}
+            $$
+            </pre>
           </dd>
           <dt>
             inverse
@@ -4823,8 +4825,10 @@ the event handler.
             An inverse distance model which calculates <em>distanceGain</em>
             according to:
             <pre>
-            refDistance / (refDistance + rolloffFactor * (distance - refDistance))
-</pre>
+              $$
+                \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})}
+              $$
+            </pre>
           </dd>
           <dt>
             exponential
@@ -4833,8 +4837,10 @@ the event handler.
             An exponential distance model which calculates
             <em>distanceGain</em> according to:
             <pre>
-pow(distance / refDistance, -rolloffFactor)
-</pre>
+              $$
+                \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f}
+              $$
+            </pre>
           </dd>
         </dl>
         <dl title="interface SpatialPannerNode : AudioNode" class="idl">


### PR DESCRIPTION
Copy the formulas from PannerNode's distance models to the
SpatialPanner to display nice TeX-style formulas.

Fix #735