### PR TITLE
Clarify AnalyserNode dowmixing more.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2122,16 +2122,16 @@ function setupRoutingGraph() {
             <a><code>AudioWorkerNode</code></a>.
           </dd>
           <dt>
-            attribute unsigned long <dfn>channelCount</dfn>
+            attribute unsigned long channelCount
           </dt>
           <dd>
             <p>
-              The number of channels used when up-mixing and down-mixing
-              connections to any inputs to the node. The default value is 2
-              except for specific nodes where its value is specially
-              determined. This attribute has no effect for nodes with no
-              inputs. If this value is set to zero or to a value greater than
-              the implementation's maximum number of channels the
+              <dfn>channelCount</dfn> is the number of channels used when
+              up-mixing and down-mixing connections to any inputs to the node.
+              The default value is 2 except for specific nodes where its value
+              is specially determined. This attribute has no effect for nodes
+              with no inputs. If this value is set to zero or to a value
+              greater than the implementation's maximum number of channels the
               implementation MUST throw a NotSupportedError exception.
             </p>
             <p>
@@ -2144,9 +2144,10 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Determines how channels will be counted when up-mixing and
-              down-mixing connections to any inputs to the node. This attribute
-              has no effect for nodes with no inputs.
+              <dfn>channelCountMode</dfn> determines how channels will be
+              counted when up-mixing and down-mixing connections to any inputs
+              to the node. This attribute has no effect for nodes with no
+              inputs.
             </p>
             <p>
               See the <a href="#channel-up-mixing-and-down-mixing"></a> section
@@ -2158,9 +2159,10 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Determines how individual channels will be treated when up-mixing
-              and down-mixing connections to any inputs to the node. This
-              attribute has no effect for nodes with no inputs.
+              <dfn>channelInterpetation</dfn> determines how individual
+              channels will be treated when up-mixing and down-mixing
+              connections to any inputs to the node. This attribute has no
+              effect for nodes with no inputs.
             </p>
             <p>
               See the <a href="#channel-up-mixing-and-down-mixing"></a> section
@@ -5501,7 +5503,10 @@ function calculateNormalizationScale(buffer)
           <ol>
             <li>
               <a href="#channel-up-mixing-and-down-mixing">Down-mix</a> all
-              channels of the time domain input data to mono.
+              channels of the time domain input data to mono assuming a
+              <a>channelCount</a> of 1, <a>channelCountMode</a> of "max" and
+              <a>channelInterpetation</a> of "speakers". This is independent of
+              the settings for the <a>AnalyserNode</a> itself.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the


### PR DESCRIPTION
Fix #719.

Explicitly state the values of the channelCount, mode, and
interpretation to be used for downmixing in the AnalyserNode and state
that these are independent of the AnalyserNode itself.

Also added dfn entries for `channelCount`, `channelCountMode`, and `channelInterpretation`