### PR TITLE
Use unsigned long for AudioBuffer length and numberOfChannels.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2989,7 +2989,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             The sample-rate for the PCM audio data in samples per second.
           </dd>
           <dt>
-            readonly attribute long length
+            readonly attribute unsigned long length
           </dt>
           <dd>
             Length of the PCM audio data in sample-frames.
@@ -3001,7 +3001,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             Duration of the PCM audio data in seconds.
           </dd>
           <dt>
-            readonly attribute long numberOfChannels
+            readonly attribute unsigned long numberOfChannels
           </dt>
           <dd>
             The number of discrete audio channels.


### PR DESCRIPTION
Change type for length and numberOfChannels from long to unsigned
long.

Fix #747