### PR TITLE
Fix #751: Scalar PannerNode attributes are doubles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4646,28 +4646,28 @@ the event handler.
             <a><code>"inverse"</code></a>.
           </dd>
           <dt>
-            attribute float refDistance
+            attribute double refDistance
           </dt>
           <dd>
             A reference distance for reducing volume as source move further
             from the listener. The default value is 1.
           </dd>
           <dt>
-            attribute float maxDistance
+            attribute double maxDistance
           </dt>
           <dd>
             The maximum distance between source and listener, after which the
             volume will not be reduced any further. The default value is 10000.
           </dd>
           <dt>
-            attribute float rolloffFactor
+            attribute double rolloffFactor
           </dt>
           <dd>
             Describes how quickly the volume is reduced as source moves away
             from listener. The default value is 1.
           </dd><!--<dt> // Directional sound cone </dt>-->
           <dt>
-            attribute float coneInnerAngle
+            attribute double coneInnerAngle
           </dt>
           <dd>
             A parameter for directional audio sources, this is an angle, in
@@ -4675,7 +4675,7 @@ the event handler.
             default value is 360, and the value is used modulo 360.
           </dd>
           <dt>
-            attribute float coneOuterAngle
+            attribute double coneOuterAngle
           </dt>
           <dd>
             A parameter for directional audio sources, this is an angle, in
@@ -4684,7 +4684,7 @@ the event handler.
             360 and the value is used modulo 360.
           </dd>
           <dt>
-            attribute float coneOuterGain
+            attribute double coneOuterGain
           </dt>
           <dd>
             A parameter for directional audio sources, this is the gain outside
@@ -4935,28 +4935,28 @@ the event handler.
             <a><code>"inverse"</code></a>.
           </dd>
           <dt>
-            attribute float refDistance
+            attribute double refDistance
           </dt>
           <dd>
             A reference distance for reducing volume as source move further
             from the listener. The default value is 1.
           </dd>
           <dt>
-            attribute float maxDistance
+            attribute double maxDistance
           </dt>
           <dd>
             The maximum distance between source and listener, after which the
             volume will not be reduced any further. The default value is 10000.
           </dd>
           <dt>
-            attribute float rolloffFactor
+            attribute double rolloffFactor
           </dt>
           <dd>
             Describes how quickly the volume is reduced as source moves away
             from listener. The default value is 1.
           </dd>
           <dt>
-            attribute float coneInnerAngle
+            attribute double coneInnerAngle
           </dt>
           <dd>
             A parameter for directional audio sources, this is an angle, in
@@ -4964,7 +4964,7 @@ the event handler.
             default value is 360.
           </dd>
           <dt>
-            attribute float coneOuterAngle
+            attribute double coneOuterAngle
           </dt>
           <dd>
             A parameter for directional audio sources, this is an angle, in
@@ -4973,7 +4973,7 @@ the event handler.
             360.
           </dd>
           <dt>
-            attribute float coneOuterGain
+            attribute double coneOuterGain
           </dt>
           <dd>
             A parameter for directional audio sources, this is the amount of


### PR DESCRIPTION
The scalar attributes such as refDistance, maxDistance, rolloffFactor,
and the cone angles for the PannerNode (and SpatialPannerNode) are
changed from float to double because Chrome, Firefox, and Safari
actually implement them as doubles in both the IDL files and the
internal implementation.