### PR TITLE
Fix #673: Add min/max attribute to AudioParam

### DIFF
--- a/index.html
+++ b/index.html
@@ -2355,8 +2355,8 @@ function setupRoutingGraph() {
         <p>
           Each <code>AudioParam</code> includes <code>min</code> and
           <code>max</code> attributes that together form the <a>nominal
-          range</a> for the parameter.  In effect, value of the parameter is
-          clamped to the range \([\mathrm{min}, \mathrm{max}]\).  See the
+          range</a> for the parameter. In effect, value of the parameter is
+          clamped to the range \([\mathrm{min}, \mathrm{max}]\). See the
           section <a href="#computation-of-value">Computation of Value</a> for
           full details.
         </p>
@@ -2453,15 +2453,17 @@ function setupRoutingGraph() {
             readonly attribute float min
           </dt>
           <dd>
-            The nominal minimum value that the parameter can take.  Together with <code>max</code>,
-            this forms the <a>nominal range</a> for this parameter.
+            The nominal minimum value that the parameter can take. Together
+            with <code>max</code>, this forms the <a>nominal range</a> for this
+            parameter.
           </dd>
           <dt>
             readonly attribute float max
           </dt>
           <dd>
-            The nominal maximum value that the parameter can take.  Together with <code>min</code>,
-            this forms the <a>nominal range</a> for this parameter.
+            The nominal maximum value that the parameter can take. Together
+            with <code>min</code>, this forms the <a>nominal range</a> for this
+            parameter.
           </dd>
           <dt>
             AudioParam setValueAtTime(float value, double startTime)

--- a/index.html
+++ b/index.html
@@ -2353,6 +2353,14 @@ function setupRoutingGraph() {
           each sample-frame of the block.
         </p>
         <p>
+          Each <code>AudioParam</code> includes <code>min</code> and
+          <code>max</code> attributes that together form the <a>nominal
+          range</a> for the parameter.  In effect, value of the parameter is
+          clamped to the range \([\mathrm{min}, \mathrm{max}]\).  See the
+          section <a href="#computation-of-value">Computation of Value</a> for
+          full details.
+        </p>
+        <p>
           An <code>AudioParam</code> maintains a time-ordered event list which
           is initially empty. The times are in the time coordinate system of
           the <a><code>AudioContext</code></a>'s <a href=
@@ -2440,6 +2448,20 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             Initial value for the <code>value</code> attribute.
+          </dd>
+          <dt>
+            readonly attribute float min
+          </dt>
+          <dd>
+            The nominal minimum value that the parameter can take.  Together with <code>max</code>,
+            this forms the <a>nominal range</a> for this parameter.
+          </dd>
+          <dt>
+            readonly attribute float max
+          </dt>
+          <dd>
+            The nominal maximum value that the parameter can take.  Together with <code>min</code>,
+            this forms the <a>nominal range</a> for this parameter.
           </dd>
           <dt>
             AudioParam setValueAtTime(float value, double startTime)


### PR DESCRIPTION
Puts back the readonly min and max attributes for an AudioParam to
make introspection of the actual nominal range of the AudioParam
possible.

This is a follow on of the discussion in #620.