### PR TITLE
Fix #763:  detune is in cents.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3587,10 +3587,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             readonly attribute AudioParam detune
           </dt>
           <dd>
-            An additional parameter to modulate the speed at which is rendered
-            the audio stream. Its default value is 0. This parameter is
-            <a>k-rate</a>. This parameter is a <a>compound parameter</a> with
-            <code>playbackRate</code>.
+            An additional parameter, in cents, to modulate the speed at which
+            is rendered the audio stream. Its default value is 0. This
+            parameter is <a>k-rate</a>. This parameter is a <a>compound
+            parameter</a> with <code>playbackRate</code>.
           </dd>
           <dt>
             attribute boolean loop
@@ -7222,7 +7222,7 @@ $$
             readonly attribute AudioParam detune
           </dt>
           <dd>
-            A detuning value (in Cents) which will offset the
+            A detuning value (in cents) which will offset the
             <a><code>frequency</code></a> by the given amount. Its default
             <code>value</code> is 0. This parameter is <a>a-rate</a>. It forms
             a <a>compound parameter</a> with <code>frequency</code>.


### PR DESCRIPTION
We were missing this description for AudioBufferSource detune.