### PR TITLE
Fix #769 by correcting the formulas

### DIFF
--- a/index.html
+++ b/index.html
@@ -6578,7 +6578,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor
             has a default value of 1. Its <a>nominal range</a> is (0,
-            \(\infty\)).
+            \(\infty\)). For the lowpass and highpass filters, <a>Q</a> is in
+            dB. For all other filter types, <a>Q</a> is a linear value.
           </dd>
           <dt>
             readonly attribute AudioParam gain
@@ -6708,7 +6709,8 @@ $$
   A        &amp;= 10^{\frac{G}{40}} \\
   \omega_0 &amp;= 2\pi\frac{f_0}{F_s} \\
   \alpha_Q &amp;= \frac{\sin\omega_0}{2Q} \\
-  \alpha_B &amp;= \frac{\sin\omega_0}{2} \sqrt{\frac{4-\sqrt{16-\frac{16}{G^2}}}{2}} \\
+  Q_{L}  &amp;= 10^{\frac{Q}{20}} \\
+  \alpha_B &amp;= \frac{\sin\omega_0}{2} \sqrt{\frac{4-\sqrt{16-\frac{16}{Q_L^2}}}{2}} \\
   S        &amp;= 1 \\
   \alpha_S &amp;= \frac{\sin\omega_0}{2}\sqrt{\left(A+\frac{1}{A}\right)\left(\frac{1}{S}-1\right)+2}
 \end{align*}


### PR DESCRIPTION
The formulas for the lowpass and highpass filters are wrong; they
depend on Q, not G. Update the formulas to match what browsers
actually do.

Also updated the description of Q to say that Q is in dB for lowpass
and highpass filters and linear for all others.  Because that's what's
really happening.