### PR TITLE
759 biquad gain is db

### DIFF
--- a/index.html
+++ b/index.html
@@ -3587,10 +3587,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             readonly attribute AudioParam detune
           </dt>
           <dd>
-            An additional parameter to modulate the speed at which is rendered
-            the audio stream. Its default value is 0. This parameter is
-            <a>k-rate</a>. This parameter is a <a>compound parameter</a> with
-            <code>playbackRate</code>.
+            An additional parameter, in cents, to modulate the speed at which
+            is rendered the audio stream. Its default value is 0. This
+            parameter is <a>k-rate</a>. This parameter is a <a>compound
+            parameter</a> with <code>playbackRate</code>.
           </dd>
           <dt>
             attribute boolean loop
@@ -7222,7 +7222,7 @@ $$
             readonly attribute AudioParam detune
           </dt>
           <dd>
-            A detuning value (in Cents) which will offset the
+            A detuning value (in cents) which will offset the
             <a><code>frequency</code></a> by the given amount. Its default
             <code>value</code> is 0. This parameter is <a>a-rate</a>. It forms
             a <a>compound parameter</a> with <code>frequency</code>.

--- a/index.html
+++ b/index.html
@@ -6578,14 +6578,20 @@ function calculateNormalizationScale(buffer)
           <dd>
             The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor
             has a default value of 1. Its <a>nominal range</a> is (0,
-            \(\infty\)).
+            \(\infty\)).  This is not used for <a
+            href="#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a
+            href="#idl-def-BiquadFilterType.highshelf">highshelf</a>, or <a
+            href="#idl-def-BiquadFilterType.peaking">peaking</a> filters.
           </dd>
           <dt>
             readonly attribute AudioParam gain
           </dt>
           <dd>
-            The gain has a default value of 0. Its <a>nominal range</a> is
-            [-40, 40].
+            The gain has a default value of 0. Its <a>nominal range</a> is [-40,
+            40]. Its value is in dB units.  The gain is only used for <a
+            href="#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a
+            href="#idl-def-BiquadFilterType.highshelf">highshelf</a>, and <a
+            href="#idl-def-BiquadFilterType.peaking">peaking</a> filters.
           </dd>
           <dt>
             void getFrequencyResponse()

--- a/index.html
+++ b/index.html
@@ -6578,20 +6578,20 @@ function calculateNormalizationScale(buffer)
           <dd>
             The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor
             has a default value of 1. Its <a>nominal range</a> is (0,
-            \(\infty\)).  This is not used for <a
-            href="#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a
-            href="#idl-def-BiquadFilterType.highshelf">highshelf</a>, or <a
-            href="#idl-def-BiquadFilterType.peaking">peaking</a> filters.
+            \(\infty\)). This is not used for <a href=
+            "#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a href=
+            "#idl-def-BiquadFilterType.highshelf">highshelf</a>, or <a href=
+            "#idl-def-BiquadFilterType.peaking">peaking</a> filters.
           </dd>
           <dt>
             readonly attribute AudioParam gain
           </dt>
           <dd>
-            The gain has a default value of 0. Its <a>nominal range</a> is [-40,
-            40]. Its value is in dB units.  The gain is only used for <a
-            href="#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a
-            href="#idl-def-BiquadFilterType.highshelf">highshelf</a>, and <a
-            href="#idl-def-BiquadFilterType.peaking">peaking</a> filters.
+            The gain has a default value of 0. Its <a>nominal range</a> is
+            [-40, 40]. Its value is in dB units. The gain is only used for
+            <a href="#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a href=
+            "#idl-def-BiquadFilterType.highshelf">highshelf</a>, and <a href=
+            "#idl-def-BiquadFilterType.peaking">peaking</a> filters.
           </dd>
           <dt>
             void getFrequencyResponse()


### PR DESCRIPTION
Fix #759.

Also documented that the gain parameter is only used for some filters and that the Q parameter is not used for some filters.