### PR TITLE
Fix #749: merge spatial panner into panner

### DIFF
--- a/index.html
+++ b/index.html
@@ -3587,10 +3587,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             readonly attribute AudioParam detune
           </dt>
           <dd>
-            An additional parameter to modulate the speed at which is rendered
-            the audio stream. Its default value is 0. This parameter is
-            <a>k-rate</a>. This parameter is a <a>compound parameter</a> with
-            <code>playbackRate</code>.
+            An additional parameter, in cents, to modulate the speed at which
+            is rendered the audio stream. Its default value is 0. This
+            parameter is <a>k-rate</a>. This parameter is a <a>compound
+            parameter</a> with <code>playbackRate</code>.
           </dd>
           <dt>
             attribute boolean loop
@@ -7222,7 +7222,7 @@ $$
             readonly attribute AudioParam detune
           </dt>
           <dd>
-            A detuning value (in Cents) which will offset the
+            A detuning value (in cents) which will offset the
             <a><code>frequency</code></a> by the given amount. Its default
             <code>value</code> is 0. This parameter is <a>a-rate</a>. It forms
             a <a>compound parameter</a> with <code>frequency</code>.

--- a/index.html
+++ b/index.html
@@ -4965,7 +4965,6 @@ the event handler.
             Describes the Z component of the vector of the direction the audio
             source is pointing in 3D cartesian coordinate space. The default
             value is 0. This parameter is a-rate.
-          </dd>
           </dd><!--<dt> // Distance model and attributes </dt>-->
           <dt>
             attribute DistanceModelType distanceModel

--- a/index.html
+++ b/index.html
@@ -578,12 +578,6 @@ function setupRoutingGraph() {
           <a><code>AudioNode</code></a> which applies a dynamically adjustable
           variable delay.
           </li>
-          <li>A <a><code>SpatialPannerNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for positioning audio in 3D space.
-          </li>
-          <li>A <a><code>SpatialListener</code></a> interface, which works with
-          a <a>SpatialPannerNode</a> for spatialization.
-          </li>
           <li>A <a><code>StereoPannerNode</code></a> interface, an
           <a><code>AudioNode</code></a> for equal-power positioning of audio
           input in a stereo stream.
@@ -622,15 +616,6 @@ function setupRoutingGraph() {
           of their replacements:
         </p>
         <ul>
-          <li>A <a><code>PannerNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for spatializing / positioning audio in
-          3D space. This has been replaced by
-          <a><code>SpatialPannerNode</code></a>, and
-          <a><code>StereoPannerNode</code></a> for simpler scenarios.
-          </li>
-          <li>An <a><code>AudioListener</code></a> interface, which works with
-          a <a>PannerNode</a> for spatialization.
-          </li>
           <li>A <a><code>ScriptProcessorNode</code></a> interface, an <a><code>
             AudioNode</code></a> for generating or processing audio directly in
             JavaScript.
@@ -819,16 +804,6 @@ function setupRoutingGraph() {
             <p>
               An <a href="#AudioListener"><code>AudioListener</code></a> which
               is used for 3D <a href="#Spatialization">spatialization</a>.
-            </p>
-          </dd>
-          <dt>
-            readonly attribute SpatialListener spatialListener
-          </dt>
-          <dd>
-            <p>
-              A <a href="#AudioListener"><code>SpatialListener</code></a> which
-              is used for 3D <a href="#Spatialization">spatialization</a> with
-              the <a>SpatialPannerNode</a>
             </p>
           </dd>
           <dt>
@@ -1404,15 +1379,7 @@ function setupRoutingGraph() {
             PannerNode createPanner()
           </dt>
           <dd>
-            This method is DEPRECATED, as it is intended to be replaced by
-            createSpatialPanner or createStereoPanner, depending on the
-            scenario. Creates a <a><code>PannerNode</code></a>.
-          </dd>
-          <dt>
-            SpatialPannerNode createSpatialPanner()
-          </dt>
-          <dd>
-            Creates a <a><code>SpatialPannerNode</code></a>.
+            Creates a <a><code>PannerNode</code></a>.
           </dd>
           <dt>
             StereoPannerNode createStereoPanner()
@@ -4948,61 +4915,57 @@ the event handler.
             <a><code>"equalpower"</code></a>.
           </dd><!--<dt> // Uses a 3D cartesian coordinate system </dt>-->
           <dt>
-            void setPosition(float x, float y, float z)
+            readonly attribute AudioParam positionX
           </dt>
           <dd>
-            <p>
-              Sets the position of the audio source relative to the
-              <a><code>listener</code></a> attribute. A 3D cartesian coordinate
-              system is used.
-            </p>
-            <p>
-              The <code>x, y, z</code> parameters represent the coordinates in
-              3D space.
-            </p>
-            <p>
-              The default value is (0,0,0)
-            </p>
+            Sets the x coordinate position of the audio source in a 3D
+            Cartesian system. The default value is 0. This parameter is a-rate.
           </dd>
           <dt>
-            void setOrientation(float x, float y, float z)
+            readonly attribute AudioParam positionY
           </dt>
           <dd>
-            <p>
-              Describes which direction the audio source is pointing in the 3D
-              cartesian coordinate space. Depending on how directional the
-              sound is (controlled by the <b>cone</b> attributes), a sound
-              pointing away from the listener can be very quiet or completely
-              silent.
-            </p>
-            <p>
-              The <code>x, y, z</code> parameters represent a direction vector
-              in 3D space.
-            </p>
-            <p>
-              The default value is (1,0,0)
-            </p>
+            Sets the y coordinate position of the audio source in a 3D
+            Cartesian system. The default value is 0. This parameter is a-rate.
           </dd>
           <dt>
-            void setVelocity(float x, float y, float z)
+            readonly attribute AudioParam positionZ
           </dt>
           <dd>
-            <p>
-              Sets the velocity vector of the audio source. This vector
-              controls both the direction of travel and the speed in 3D space.
-              This velocity relative to the listener's velocity is used to
-              determine how much doppler shift (pitch change) to apply. The
-              units used for this vector is <em>meters / second</em> and is
-              independent of the units used for position and orientation
-              vectors.
-            </p>
-            <p>
-              The <code>x, y, z</code> parameters describe a direction vector
-              indicating direction of travel and intensity.
-            </p>
-            <p>
-              The default value is (0,0,0)
-            </p>
+            Sets the z coordinate position of the audio source in a 3D
+            Cartesian system. The default value is 0. This parameter is a-rate.
+          </dd>
+          <dt>
+            readonly attribute AudioParam orientationX
+          </dt>
+          <dd>
+            The <code>orientationX, orientationY, orientationZ</code>
+            parameters represent a direction vector in 3D space.
+          </dd>
+          <dd>
+            Describes the x component of the vector of the direction the audio
+            source is pointing in 3D Cartesian coordinate space. Depending on
+            how directional the sound is (controlled by the <b>cone</b>
+            attributes), a sound pointing away from the listener can be very
+            quiet or completely silent. The default value is 1. This parameter
+            is a-rate.
+          </dd>
+          <dt>
+            readonly attribute AudioParam orientationY
+          </dt>
+          <dd>
+            Describes the y component of the vector of the direction the audio
+            source is pointing in 3D cartesian coordinate space. The default
+            value is 0. This parameter is a-rate.
+          </dd>
+          <dt>
+            readonly attribute AudioParam orientationZ
+          </dt>
+          <dd>
+            Describes the Z component of the vector of the direction the audio
+            source is pointing in 3D cartesian coordinate space. The default
+            value is 0. This parameter is a-rate.
+          </dd>
           </dd><!--<dt> // Distance model and attributes </dt>-->
           <dt>
             attribute DistanceModelType distanceModel
@@ -5060,6 +5023,72 @@ the event handler.
             InvalidStateError MUST be thrown if the parameter is outside this
             range.
           </dd>
+          <dt>
+            void setPosition(float x, float y, float z)
+          </dt>
+          <dd>
+            <p>
+              This method is DEPRECATED.  It is equivalent to setting
+              <code>positionX</code>, <code>positionY</code>, and
+              <code>positionZ</code> AudioParams directly.
+            </p>
+            <p>
+              Sets the position of the audio source relative to the
+              <a><code>listener</code></a> attribute. A 3D cartesian coordinate
+              system is used.
+            </p>
+            <p>
+              The <code>x, y, z</code> parameters represent the coordinates in
+              3D space.
+            </p>
+            <p>
+              The default value is (0,0,0)
+            </p>
+          </dd>
+          <dt>
+            void setOrientation(float x, float y, float z)
+          </dt>
+          <dd>
+            <p>
+              This method is DEPRECATED.  It is equivalent to setting
+              <code>orientationX</code>, <code>orientationY</code>, and
+              <code>orientationZ</code> AudioParams directly.
+            </p>
+            <p>
+              Describes which direction the audio source is pointing in the 3D
+              cartesian coordinate space. Depending on how directional the
+              sound is (controlled by the <b>cone</b> attributes), a sound
+              pointing away from the listener can be very quiet or completely
+              silent.
+            </p>
+            <p>
+              The <code>x, y, z</code> parameters represent a direction vector
+              in 3D space.
+            </p>
+            <p>
+              The default value is (1,0,0)
+            </p>
+          </dd>
+          <dt>
+            void setVelocity(float x, float y, float z)
+          </dt>
+          <dd>
+            <p>
+              Sets the velocity vector of the audio source. This vector
+              controls both the direction of travel and the speed in 3D space.
+              This velocity relative to the listener's velocity is used to
+              determine how much doppler shift (pitch change) to apply. The
+              units used for this vector is <em>meters / second</em> and is
+              independent of the units used for position and orientation
+              vectors.
+            </p>
+            <p>
+              The <code>x, y, z</code> parameters describe a direction vector
+              indicating direction of travel and intensity.
+            </p>
+            <p>
+              The default value is (0,0,0)
+            </p>
         </dl>
         <section class="informative">
           <h3 id="panner-channel-limitations">
@@ -5077,8 +5106,7 @@ the event handler.
           The AudioListener Interface
         </h2>
         <p>
-          This interface is DEPRECATED, as it will be replaced by the
-          <a><code>SpatialListener</code></a>. This interface represents the
+          This interface represents the
           position and orientation of the person listening to the audio scene.
           All <a><code>PannerNode</code></a> objects spatialize in relation to
           the <a><code>BaseAudioContext</code></a>'s <a href=
@@ -5088,287 +5116,11 @@ the event handler.
         </p>
         <dl title="interface AudioListener" class="idl">
           <dt>
-            void setPosition(float x, float y, float z)
-          </dt>
-          <dd>
-            <p>
-              Sets the position of the listener in a 3D cartesian coordinate
-              space. <a><code>PannerNode</code></a> objects use this position
-              relative to individual audio sources for spatialization.
-            </p>
-            <p>
-              The <code>x, y, z</code> parameters represent the coordinates in
-              3D space.
-            </p>
-            <p>
-              The default value is (0,0,0)
-            </p>
-          </dd>
-          <dt>
-            void setOrientation(float x, float y, float z, float xUp, float
-            yUp, float zUp)
-          </dt>
-          <dd>
-            <p>
-              Describes which direction the listener is pointing in the 3D
-              cartesian coordinate space. Both a <b>front</b> vector and an
-              <b>up</b> vector are provided. In simple human terms, the
-              <b>front</b> vector represents which direction the person's nose
-              is pointing. The <b>up</b> vector represents the direction the
-              top of a person's head is pointing. These values are expected to
-              be linearly independent (at right angles to each other). For
-              normative requirements of how these values are to be interpreted,
-              see the <a href="#Spatialization">spatialization section</a>.
-            </p>
-            <p>
-              The <code>x, y, z</code> parameters represent a <b>front</b>
-              direction vector in 3D space, with the default value being
-              (0,0,-1).
-            </p>
-            <p>
-              The <code>xUp, yUp, zUp</code> parameters represent an <b>up</b>
-              direction vector in 3D space, with the default value being
-              (0,1,0).
-            </p>
-          </dd>
-        </dl>
-      </section>
-      <section>
-        <h2>
-          The SpatialPannerNode Interface
-        </h2>
-        <p>
-          This interface represents a processing node which <a href=
-          "#Spatialization">positions</a> an incoming audio stream in
-          three-dimensional space. The spatialization is in relation to the
-          <a>AudioContext</a>'s <a><code>SpatialListener</code></a>
-          (<code>listener</code> attribute).
-        </p>
-        <p>
-          It should be explicitly noticed that the auditory effects of this
-          spatialization may not work well unless the SpatialPanner is directly
-          connected to the destination node; subsequent processing (after the
-          SpatialPanner, before the destination) may disrupt the effects.
-        </p>
-        <pre>
-    numberOfInputs  : 1
-    numberOfOutputs : 1
-    channelCount = 2;
-    channelCountMode = "clamped-max";
-    channelInterpretation = "speakers";
-</pre>
-        <p>
-          The input of this node is either mono (1 channel) or stereo (2
-          channels) and cannot be increased. Connections from nodes with more
-          channels will be <a href=
-          "#channel-up-mixing-and-down-mixing">up-mixed or down-mixed
-          appropriately</a>, but a NotSupportedError MUST be thrown if an
-          attempt is made to set channelCount to a value greater than 2 or if
-          channelCountMode is set to "max". The output of this node will be
-          stereo (2 channels) and currently cannot be configured.
-        </p>
-        <p>
-          The <a><code>PanningModelType</code></a> enum determines which
-          spatialization algorithm will be used to position the audio in 3D
-          space. The default is <code>"equal-power"</code>.
-        </p>
-        <dl title="enum PanningModelType" class="idl">
-          <dt>
-            equalpower
-          </dt>
-          <dd>
-            A simple and efficient spatialization algorithm using equal-power
-            panning.
-          </dd>
-          <dt>
-            HRTF
-          </dt>
-          <dd>
-            A higher quality spatialization algorithm using a convolution with
-            measured impulse responses from human subjects. This panning method
-            renders stereo output.
-          </dd>
-        </dl>
-        <p>
-          The <a><code>DistanceModelType</code></a> enum determines which
-          algorithm will be used to reduce the volume of an audio source as it
-          moves away from the listener. The default is "inverse".
-        </p>
-        <dl title="enum DistanceModelType" class="idl">
-          <dt>
-            linear
-          </dt>
-          <dd>
-            A linear distance model which calculates <em>distanceGain</em>
-            according to:
-            <pre>
-            $$
-              1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}}
-            $$
-            </pre>
-          </dd>
-          <dt>
-            inverse
-          </dt>
-          <dd>
-            An inverse distance model which calculates <em>distanceGain</em>
-            according to:
-            <pre>
-              $$
-                \frac{d_{ref}}{d_{ref} + f (\max(d, d_{ref}) - d_{ref})}
-              $$
-            </pre>
-          </dd>
-          <dt>
-            exponential
-          </dt>
-          <dd>
-            An exponential distance model which calculates
-            <em>distanceGain</em> according to:
-            <pre>
-              $$
-                \left(\frac{\max(d, d_{ref})}{d_{ref}}\right)^{-f}
-              $$
-            </pre>
-          </dd>
-        </dl>
-        <dl title="interface SpatialPannerNode : AudioNode" class="idl">
-          <dt>
-            attribute PanningModelType panningModel
-          </dt>
-          <dd>
-            Specifies the panning model used by this
-            <a><code>PannerNode</code></a>. Defaults to
-            <a><code>"equal-power"</code></a>.
-          </dd>
-          <dt>
-            readonly attribute AudioParam positionX
-          </dt>
-          <dd>
-            Sets the x coordinate position of the audio source in a 3D
-            Cartesian system. The default value is 0. This parameter is a-rate.
-          </dd>
-          <dt>
-            readonly attribute AudioParam positionY
-          </dt>
-          <dd>
-            Sets the y coordinate position of the audio source in a 3D
-            Cartesian system. The default value is 0. This parameter is a-rate.
-          </dd>
-          <dt>
-            readonly attribute AudioParam positionZ
-          </dt>
-          <dd>
-            Sets the z coordinate position of the audio source in a 3D
-            Cartesian system. The default value is 0. This parameter is a-rate.
-          </dd>
-          <dt>
-            readonly attribute AudioParam orientationX
-          </dt>
-          <dd>
-            The <code>orientationX, orientationY, orientationZ</code>
-            parameters represent a direction vector in 3D space.
-          </dd>
-          <dd>
-            Describes the x component of the vector of the direction the audio
-            source is pointing in 3D Cartesian coordinate space. Depending on
-            how directional the sound is (controlled by the <b>cone</b>
-            attributes), a sound pointing away from the listener can be very
-            quiet or completely silent. The default value is 1. This parameter
-            is a-rate.
-          </dd>
-          <dt>
-            readonly attribute AudioParam orientationY
-          </dt>
-          <dd>
-            Describes the y component of the vector of the direction the audio
-            source is pointing in 3D cartesian coordinate space. The default
-            value is 0. This parameter is a-rate.
-          </dd>
-          <dt>
-            readonly attribute AudioParam orientationZ
-          </dt>
-          <dd>
-            Describes the Z component of the vector of the direction the audio
-            source is pointing in 3D cartesian coordinate space. The default
-            value is 0. This parameter is a-rate.
-          </dd>
-          <dt>
-            attribute DistanceModelType distanceModel
-          </dt>
-          <dd>
-            Specifies the distance model used by this
-            <a><code>PannerNode</code></a>. Defaults to
-            <a><code>"inverse"</code></a>.
-          </dd>
-          <dt>
-            attribute double refDistance
-          </dt>
-          <dd>
-            A reference distance for reducing volume as source move further
-            from the listener. The default value is 1.
-          </dd>
-          <dt>
-            attribute double maxDistance
-          </dt>
-          <dd>
-            The maximum distance between source and listener, after which the
-            volume will not be reduced any further. The default value is 10000.
-          </dd>
-          <dt>
-            attribute double rolloffFactor
-          </dt>
-          <dd>
-            Describes how quickly the volume is reduced as source moves away
-            from listener. The default value is 1.
-          </dd>
-          <dt>
-            attribute double coneInnerAngle
-          </dt>
-          <dd>
-            A parameter for directional audio sources, this is an angle, in
-            degrees, inside of which there will be no volume reduction. The
-            default value is 360.
-          </dd>
-          <dt>
-            attribute double coneOuterAngle
-          </dt>
-          <dd>
-            A parameter for directional audio sources, this is an angle, in
-            degrees, outside of which the volume will be reduced to a constant
-            value of <a><code>coneOuterGain</code></a>. The default value is
-            360.
-          </dd>
-          <dt>
-            attribute double coneOuterGain
-          </dt>
-          <dd>
-            A parameter for directional audio sources, this is the amount of
-            volume reduction outside of the <a><code>coneOuterAngle</code></a>.
-            The default value is 0.
-          </dd>
-        </dl>
-      </section>
-      <section>
-        <h2 id="SpatialListener">
-          The SpatialListener Interface
-        </h2>
-        <p>
-          This interface represents the position and orientation of the person
-          listening to the audio scene. All
-          <a><code>SpatialPannerNode</code></a> objects spatialize in relation
-          to the <a><code>AudioContext</code></a>'s
-          <a><code>SpatialListener</code></a>. See <a href=
-          "#Spatialization">the Spatialization/Panning section</a> for more
-          details about spatialization.
-        </p>
-        <dl title="interface SpatialListener" class="idl">
-          <dt>
             readonly attribute AudioParam positionX
           </dt>
           <dd>
             Sets the x coordinate position of the audio listener in a 3D
-            Cartesian coordinate space. <a><code>SpatialPannerNode</code></a>
+            Cartesian coordinate space. <a><code>PannerNode</code></a>
             objects use this position relative to individual audio sources for
             spatialization. The default value is 0. This parameter is a-rate.
           </dd>
@@ -5455,6 +5207,61 @@ the event handler.
             Sets the z coordinate component of the up direction the listener is
             pointing in 3D Cartesian coordinate space. The default value is 0.
             This parameter is a-rate.
+          </dd>
+          <dt>
+            void setPosition(float x, float y, float z)
+          </dt>
+          <dd>
+            <p>
+              This method is DEPRECATED.  It is equivalent to setting
+              <code>positionX</code>, <code>positionY</code>, and
+              <code>positionZ</code> AudioParams directly.
+            </p>
+            <p>
+              Sets the position of the listener in a 3D cartesian coordinate
+              space. <a><code>PannerNode</code></a> objects use this position
+              relative to individual audio sources for spatialization.
+            </p>
+            <p>
+              The <code>x, y, z</code> parameters represent the coordinates in
+              3D space.
+            </p>
+            <p>
+              The default value is (0,0,0)
+            </p>
+          </dd>
+          <dt>
+            void setOrientation(float x, float y, float z, float xUp, float
+            yUp, float zUp)
+          </dt>
+          <dd>
+            <p>
+              This method is DEPRECATED.  It is equivalent to setting
+              <code>orientationX</code>, <code>orientationY</code>,
+              <code>orientationZ</code>, <code>upX</code>, <code>upY</code>, and
+              <code>upZ</code> AudioParams directly.
+            </p>
+            <p>
+              Describes which direction the listener is pointing in the 3D
+              cartesian coordinate space. Both a <b>front</b> vector and an
+              <b>up</b> vector are provided. In simple human terms, the
+              <b>front</b> vector represents which direction the person's nose
+              is pointing. The <b>up</b> vector represents the direction the
+              top of a person's head is pointing. These values are expected to
+              be linearly independent (at right angles to each other). For
+              normative requirements of how these values are to be interpreted,
+              see the <a href="#Spatialization">spatialization section</a>.
+            </p>
+            <p>
+              The <code>x, y, z</code> parameters represent a <b>front</b>
+              direction vector in 3D space, with the default value being
+              (0,0,-1).
+            </p>
+            <p>
+              The <code>xUp, yUp, zUp</code> parameters represent an <b>up</b>
+              direction vector in 3D space, with the default value being
+              (0,1,0).
+            </p>
           </dd>
         </dl>
       </section>

--- a/index.html
+++ b/index.html
@@ -5027,7 +5027,7 @@ the event handler.
           </dt>
           <dd>
             <p>
-              This method is DEPRECATED.  It is equivalent to setting
+              This method is DEPRECATED. It is equivalent to setting
               <code>positionX</code>, <code>positionY</code>, and
               <code>positionZ</code> AudioParams directly.
             </p>
@@ -5049,7 +5049,7 @@ the event handler.
           </dt>
           <dd>
             <p>
-              This method is DEPRECATED.  It is equivalent to setting
+              This method is DEPRECATED. It is equivalent to setting
               <code>orientationX</code>, <code>orientationY</code>, and
               <code>orientationZ</code> AudioParams directly.
             </p>
@@ -5088,6 +5088,7 @@ the event handler.
             <p>
               The default value is (0,0,0)
             </p>
+          </dd>
         </dl>
         <section class="informative">
           <h3 id="panner-channel-limitations">
@@ -5105,10 +5106,10 @@ the event handler.
           The AudioListener Interface
         </h2>
         <p>
-          This interface represents the
-          position and orientation of the person listening to the audio scene.
-          All <a><code>PannerNode</code></a> objects spatialize in relation to
-          the <a><code>BaseAudioContext</code></a>'s <a href=
+          This interface represents the position and orientation of the person
+          listening to the audio scene. All <a><code>PannerNode</code></a>
+          objects spatialize in relation to the
+          <a><code>BaseAudioContext</code></a>'s <a href=
           "#widl-BaseAudioContext-listener">listener</a>. See <a href=
           "#Spatialization">the Spatialization/Panning section</a> for more
           details about spatialization.
@@ -5119,8 +5120,8 @@ the event handler.
           </dt>
           <dd>
             Sets the x coordinate position of the audio listener in a 3D
-            Cartesian coordinate space. <a><code>PannerNode</code></a>
-            objects use this position relative to individual audio sources for
+            Cartesian coordinate space. <a><code>PannerNode</code></a> objects
+            use this position relative to individual audio sources for
             spatialization. The default value is 0. This parameter is a-rate.
           </dd>
           <dt>
@@ -5212,7 +5213,7 @@ the event handler.
           </dt>
           <dd>
             <p>
-              This method is DEPRECATED.  It is equivalent to setting
+              This method is DEPRECATED. It is equivalent to setting
               <code>positionX</code>, <code>positionY</code>, and
               <code>positionZ</code> AudioParams directly.
             </p>
@@ -5235,10 +5236,10 @@ the event handler.
           </dt>
           <dd>
             <p>
-              This method is DEPRECATED.  It is equivalent to setting
+              This method is DEPRECATED. It is equivalent to setting
               <code>orientationX</code>, <code>orientationY</code>,
-              <code>orientationZ</code>, <code>upX</code>, <code>upY</code>, and
-              <code>upZ</code> AudioParams directly.
+              <code>orientationZ</code>, <code>upX</code>, <code>upY</code>,
+              and <code>upZ</code> AudioParams directly.
             </p>
             <p>
               Describes which direction the listener is pointing in the 3D


### PR DESCRIPTION
Merge the SpatialPannerNode into the PannerNode, undeprecating the
PannerNode.  The SpatialListener is also merged into the
AudioListener, which is undeprecated as well.
    
The setPosition and setOrientation methods for both the PannerNode and
AudioListener are also deprecated because they can be done using the
corresponding AudioParams.
