### PR TITLE
Fix #748: remove base audio context constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -738,8 +738,8 @@ function setupRoutingGraph() {
           </dd>
         </dl>
         <dl title="interface BaseAudioContext : EventTarget" class="idl"
-          data-merge=
-          "DecodeSuccessCallback DecodeErrorCallback AudioContextOptions">
+        data-merge=
+        "DecodeSuccessCallback DecodeErrorCallback AudioContextOptions">
           <dt>
             readonly attribute AudioDestinationNode destination
           </dt>
@@ -1645,7 +1645,7 @@ function setupRoutingGraph() {
         </p>
         <dl title=
         '[Constructor(optional AudioContextOptions contextOptions)] interface AudioContext : BaseAudioContext'
-          class='idl'>
+        class='idl'>
           <dt>
             Constructor
           </dt>

--- a/index.html
+++ b/index.html
@@ -737,10 +737,9 @@ function setupRoutingGraph() {
             output latency. Lowest power consumption.
           </dd>
         </dl>
-        <dl title=
-        "[Constructor(optional AudioContextOptions contextOptions)] interface BaseAudioContext : EventTarget"
-        class="idl" data-merge=
-        "DecodeSuccessCallback DecodeErrorCallback AudioContextOptions">
+        <dl title="interface BaseAudioContext : EventTarget" class="idl"
+          data-merge=
+          "DecodeSuccessCallback DecodeErrorCallback AudioContextOptions">
           <dt>
             readonly attribute AudioDestinationNode destination
           </dt>
@@ -1644,7 +1643,9 @@ function setupRoutingGraph() {
           use cases, only a single <a><code>AudioContext</code></a> is used per
           document.
         </p>
-        <dl title='interface AudioContext : BaseAudioContext' class='idl'>
+        <dl title=
+        '[Constructor(optional AudioContextOptions contextOptions)] interface AudioContext : BaseAudioContext'
+          class='idl'>
           <dt>
             Constructor
           </dt>


### PR DESCRIPTION
Move the BaseAudioContext constructor to AudioContext where it belongs since BaseAudioContext is not constructible.
