### PR TITLE
Fix #762: Add missing nominal ranges for AudioParams.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3615,7 +3615,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <dd>
             The speed at which to render the audio stream. Its default
             <code>value</code> is 1. This parameter is <a>k-rate</a>. This is a
-            <a>compound parameter</a> with <code>detune</code>.
+            <a>compound parameter</a> with <code>detune</code>.  Its nominal
+            range is \([-100, 100]\).
           </dd>
           <dt>
             readonly attribute AudioParam detune
@@ -3624,7 +3625,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             An additional parameter, in cents, to modulate the speed at which
             is rendered the audio stream. Its default value is 0. This
             parameter is <a>k-rate</a>. This parameter is a <a>compound
-            parameter</a> with <code>playbackRate</code>.
+            parameter</a> with <code>playbackRate</code>.  Its nominal range is
+            \((-\infty, \infty)\).
           </dd>
           <dt>
             attribute boolean loop
@@ -6596,7 +6598,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             The frequency at which the <a><code>BiquadFilterNode</code></a>
             will operate, in Hz. Its default value is 350Hz. It forms a
-            <a>compound parameter</a> with <code>detune</code>.
+            <a>compound parameter</a> with <code>detune</code>.  Its nominal
+            range is [0, <a>Nyquist frequency</a>].
           </dd>
           <dt>
             readonly attribute AudioParam detune
@@ -6604,7 +6607,7 @@ function calculateNormalizationScale(buffer)
           <dd>
             A detune value, in cents, for the frequency. Its default value is
             0. It forms a <a>compound parameter</a> with
-            <code>frequency</code>.
+            <code>frequency</code>. Its nominal range is \((-\infty, \infty)\).
           </dd>
           <dt>
             readonly attribute AudioParam Q
@@ -7256,7 +7259,8 @@ $$
           <dd>
             The frequency (in Hertz) of the periodic waveform. Its default
             <code>value</code> is 440. This parameter is <a>a-rate</a>. It
-            forms a <a>compound parameter</a> with <code>detune</code>.
+            forms a <a>compound parameter</a> with <code>detune</code>. Its
+            nominal range is [0, <a>Nyquist frequency</a>].
           </dd>
           <dt>
             readonly attribute AudioParam detune
@@ -7265,7 +7269,8 @@ $$
             A detuning value (in cents) which will offset the
             <a><code>frequency</code></a> by the given amount. Its default
             <code>value</code> is 0. This parameter is <a>a-rate</a>. It forms
-            a <a>compound parameter</a> with <code>frequency</code>.
+            a <a>compound parameter</a> with <code>frequency</code>.  Its
+            nominal range is \((-\infty, \infty)\).
           </dd>
           <dt>
             void start(optional double when = 0)


### PR DESCRIPTION
Add text to specify the nominal ranges as given in #762.  This should
complete the set of nominal ranges so that AudioParam min/max
attributes can be properly set for each AudioParam.