### PR TITLE
Fix biquad q range

### DIFF
--- a/index.html
+++ b/index.html
@@ -6438,8 +6438,8 @@ function calculateNormalizationScale(buffer)
           </dt>
           <dd>
             The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor
-            has a default value of 1. Its <a>nominal range</a> is (0,
-            \(\infty\)). This is not used for <a href=
+            has a default value of 1. Its <a>nominal range</a> is \((-\infty,
+            \infty)\). This is not used for <a href=
             "#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a href=
             "#idl-def-BiquadFilterType.highshelf">highshelf</a>, or <a href=
             "#idl-def-BiquadFilterType.peaking">peaking</a> filters.


### PR DESCRIPTION
Fix #798.  The nominal range for the Biquad Q parameter is -infinity to +infinity.