### PR TITLE
Fix 806: Enforce Unix end-of-line (LF)

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Specify files that should have unix (lf) style end-of-line
+# character.  In particular, all html files, scripts, and the Makefile
+# should have Unix style (LF) end-of-line character
+
+*.html text eol=lf
+*.css text eol=lf
+Makefile text eol=lf
+*.md text eol=lf
+W3C-ED text eol=lf
+respec-w3c-common text eol=lf
+fixup.sed text eol=lf


### PR DESCRIPTION
All html files, scripts, etc. are forced to use Unix (LF) end-of-line
character.