### PR TITLE
Fix #766: Behavior of automations and nominal ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -3185,6 +3185,26 @@ function setupRoutingGraph() {
             range</a> after having been computed from the different
             <a>AudioParam</a> value they are composed of.
           </p>
+          <p>
+            When automation methods are used, clamping is still applied.
+            However, the automation is run as if there were no clamping at all.
+            Only when the automation values are to be applied to the output is
+            the clamping done as specified above.
+          </p>
+          <p>
+            For example, consider a node \(N\) has an AudioParam \(p\) with a
+            nominal range of \([0, 1]\), and following automation sequence
+          </p>
+          <pre class="highlight example">
+            N.p.setValueAtTime(0, 0);
+            N.p.linearRampToValueAtTime(100, 1);
+            N.p.linearRampToValueAtTime(0, 2)
+          </pre>
+          <p>
+            The initial slope of the curve is 100, until it reaches the maximum
+            value of 1, at which time, the output is held constant. Finally,
+            near time 2, the slope of the curve is -100.
+          </p>
         </section>
         <section>
           <h3 id="example1-AudioParam">


### PR DESCRIPTION
Specify the behavior of automations with nominal ranges.  Automations
are internally computed as if there were no nominal ranges.  Only when
the automation is to be applied is the clamping done.  A simple example is given.