### PR TITLE
Fix #762: Rename min/max attributes to minValue/maxValue

### DIFF
--- a/index.html
+++ b/index.html
@@ -2818,9 +2818,9 @@ function setupRoutingGraph() {
           Each <code>AudioParam</code> includes <code>min</code> and
           <code>max</code> attributes that together form the <a>nominal
           range</a> for the parameter. In effect, value of the parameter is
-          clamped to the range \([\mathrm{minValue}, \mathrm{maxValue}]\). See the
-          section <a href="#computation-of-value">Computation of Value</a> for
-          full details.
+          clamped to the range \([\mathrm{minValue}, \mathrm{maxValue}]\). See
+          the section <a href="#computation-of-value">Computation of Value</a>
+          for full details.
         </p>
         <p>
           An <code>AudioParam</code> maintains a time-ordered event list which
@@ -2919,16 +2919,16 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             The nominal minimum value that the parameter can take. Together
-            with <code>maxValue</code>, this forms the <a>nominal range</a> for this
-            parameter.
+            with <code>maxValue</code>, this forms the <a>nominal range</a> for
+            this parameter.
           </dd>
           <dt>
             readonly attribute float maxValue
           </dt>
           <dd>
             The nominal maximum value that the parameter can take. Together
-            with <code>minValue</code>, this forms the <a>nominal range</a> for this
-            parameter.
+            with <code>minValue</code>, this forms the <a>nominal range</a> for
+            this parameter.
           </dd>
           <dt>
             AudioParam setValueAtTime(float value, double startTime)

--- a/index.html
+++ b/index.html
@@ -2665,7 +2665,7 @@ function setupRoutingGraph() {
           Each <code>AudioParam</code> includes <code>min</code> and
           <code>max</code> attributes that together form the <a>nominal
           range</a> for the parameter. In effect, value of the parameter is
-          clamped to the range \([\mathrm{min}, \mathrm{max}]\). See the
+          clamped to the range \([\mathrm{minValue}, \mathrm{maxValue}]\). See the
           section <a href="#computation-of-value">Computation of Value</a> for
           full details.
         </p>
@@ -2762,19 +2762,19 @@ function setupRoutingGraph() {
             Initial value for the <code>value</code> attribute.
           </dd>
           <dt>
-            readonly attribute float min
+            readonly attribute float minValue
           </dt>
           <dd>
             The nominal minimum value that the parameter can take. Together
-            with <code>max</code>, this forms the <a>nominal range</a> for this
+            with <code>maxValue</code>, this forms the <a>nominal range</a> for this
             parameter.
           </dd>
           <dt>
-            readonly attribute float max
+            readonly attribute float maxValue
           </dt>
           <dd>
             The nominal maximum value that the parameter can take. Together
-            with <code>min</code>, this forms the <a>nominal range</a> for this
+            with <code>minValue</code>, this forms the <a>nominal range</a> for this
             parameter.
           </dd>
           <dt>


### PR DESCRIPTION
The AudioParam nominal range attributes min/max are renamed to
minValue and maxValue.