### PR TITLE
Fix #810: Q is used in peaking filter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6594,9 +6594,8 @@ function calculateNormalizationScale(buffer)
             The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor
             has a default value of 1. Its <a>nominal range</a> is \((-\infty,
             \infty)\). This is not used for <a href=
-            "#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a href=
-            "#idl-def-BiquadFilterType.highshelf">highshelf</a>, or <a href=
-            "#idl-def-BiquadFilterType.peaking">peaking</a> filters.
+            "#idl-def-BiquadFilterType.lowshelf">lowshelf</a> or <a href=
+            "#idl-def-BiquadFilterType.highshelf">highshelf</a> filters.
           </dd>
           <dt>
             readonly attribute AudioParam gain


### PR DESCRIPTION
Correct typo in description of Q AudioParam.