### PR TITLE
Fix #797: Widen nominal range of playbackRate

### DIFF
--- a/index.html
+++ b/index.html
@@ -3774,7 +3774,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             The speed at which to render the audio stream. Its default
             <code>value</code> is 1. This parameter is <a>k-rate</a>. This is a
             <a>compound parameter</a> with <code>detune</code>. Its nominal
-            range is \([-100, 100]\).
+            range is \([-\infty, \infty]\).
           </dd>
           <dt>
             readonly attribute AudioParam detune


### PR DESCRIPTION
The playbackRate is widened to +/- infinity.