### PR TITLE
Fix #815: setValueCurve should throw on non-finite elements.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3212,6 +3212,11 @@ function setupRoutingGraph() {
                   attribute is with a Float32Array that has a length less than
                   2.
                 </p>
+                <p>
+                  All elements of the value curve must be finite floating-point
+                  numbers. If any are not, a <code>TypeError</code> exception
+                  must be thrown.
+                </p>
               </dd>
               <dt>
                 double startTime


### PR DESCRIPTION
If the curve contains non-finite values, setValueCurveAtTime must
signal a TypeError.  These values are illegal.