### PR TITLE
Fix #794: Move AudioContextOptions to AudioContext section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3212,6 +3212,11 @@ function setupRoutingGraph() {
                   attribute is with a Float32Array that has a length less than
                   2.
                 </p>
+                <p>
+                  All elements of the value curve must be finite floating-point
+                  numbers. If any are not, a <code>TypeError</code> exception
+                  must be thrown.
+                </p>
               </dd>
               <dt>
                 double startTime

--- a/index.html
+++ b/index.html
@@ -3211,11 +3211,6 @@ function setupRoutingGraph() {
                   attribute is with a Float32Array that has a length less than
                   2.
                 </p>
-                <p>
-                  All elements of the value curve must be finite floating-point
-                  numbers. If any are not, a <code>TypeError</code> exception
-                  must be thrown.
-                </p>
               </dd>
               <dt>
                 double startTime

--- a/index.html
+++ b/index.html
@@ -761,8 +761,7 @@ function setupRoutingGraph() {
           </dd>
         </dl>
         <dl title="interface BaseAudioContext : EventTarget" class="idl"
-        data-merge=
-        "DecodeSuccessCallback DecodeErrorCallback AudioContextOptions">
+        data-merge="DecodeSuccessCallback DecodeErrorCallback">
           <dt>
             readonly attribute AudioDestinationNode destination
           </dt>
@@ -1583,26 +1582,6 @@ function setupRoutingGraph() {
             The error that occurred while decoding.
           </dd>
         </dl>
-        <dl title="dictionary AudioContextOptions" class="idl">
-          <dt>
-            (AudioContextLatencyCategory or double) latencyHint = "interactive"
-          </dt>
-          <dd>
-            <p>
-              Identify the type of playback, which affects tradeoffs between
-              audio output latency and power consumption.
-            </p>
-            <p>
-              The preferred value of the <code>latencyHint</code> is a value
-              from <a>AudioContextLatencyCategory</a>. However, a double can
-              also be specified for the number of seconds of latency for finer
-              control to balance latency and power consumption. It is at the
-              browser's discretion to interpret the number appropriately. The
-              actual latency used is given by AudioContext's <a href=
-              "#widl-BaseAudioContext-baseLatency">baseLatency</a> attribute.
-            </p>
-          </dd>
-        </dl>
         <section>
           <h3 id="lifetime-AudioContext" class="informative">
             Lifetime
@@ -1762,6 +1741,26 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             Creates a <a><code>MediaStreamAudioDestinationNode</code></a>
+          </dd>
+        </dl>
+        <dl title="dictionary AudioContextOptions" class="idl">
+          <dt>
+            (AudioContextLatencyCategory or double) latencyHint = "interactive"
+          </dt>
+          <dd>
+            <p>
+              Identify the type of playback, which affects tradeoffs between
+              audio output latency and power consumption.
+            </p>
+            <p>
+              The preferred value of the <code>latencyHint</code> is a value
+              from <a>AudioContextLatencyCategory</a>. However, a double can
+              also be specified for the number of seconds of latency for finer
+              control to balance latency and power consumption. It is at the
+              browser's discretion to interpret the number appropriately. The
+              actual latency used is given by AudioContext's <a href=
+              "#widl-BaseAudioContext-baseLatency">baseLatency</a> attribute.
+            </p>
           </dd>
         </dl>
       </section>


### PR DESCRIPTION
The definition of AudioContextOptions was in the BaseAudioContext
section.  But this dictionary is only applicable for AudioContexts.
Move it to the AudioContext section.
