### PR TITLE
Fix #821: specify behavior of setValueCurveAtTime

### DIFF
--- a/index.html
+++ b/index.html
@@ -3250,6 +3250,15 @@ function setupRoutingGraph() {
               the value will remain constant at the final curve value, until
               there is another automation event (if any).
             </p>
+            <p>
+              An implicit call to <code><a href=
+              "#widl-AudioParam-setValueAtTime-AudioParam-float-value-double-startTime">
+              setValueAtTime</a></code> is made at time \(T_0 + T_D\) with
+              value \(V[N-1]\) so that following automations will start from
+              the end of the <code><a href=
+              "#widl-AudioParam-setValueCurveAtTime-AudioParam-Float32Array-values-double-startTime-double-duration">
+              setValueCurveAtTime</a></code> event.
+            </p>
           </dd>
           <dt>
             AudioParam cancelScheduledValues(double startTime)


### PR DESCRIPTION
setValueCurveAtTime is modified so that an implicit call to
setValueAtTime is made at the end of the curve duration.  This makes
any following automation events start from the end of the
setValueCurveAtTime event with the last value of the curve.

Without this, a linearRamp following setValueCurve would replace
setValueCurve.  This is not the desired behavior.