### PR TITLE
Fix #830 by converting 'outputTimeStamp' attribute to method

### DIFF
--- a/index.html
+++ b/index.html
@@ -1728,21 +1728,21 @@ function setupRoutingGraph() {
             </p>
           </dd>
           <dt>
-            readonly attribute AudioTimeStamp outputTimeStamp
+            AudioTimestamp getOutputTimestamp()
           </dt>
           <dd>
             <p>
-              Holds an <a><code>AudioTimeStamp</code></a> instance containing
-              two correlated context's audio stream position values: the
-              <a href=
-              "#widl-AudioTimeStamp-contextTime"><code>contextTime</code></a>
+              Returns a new <a><code>AudioTimestamp</code></a> instance
+              containing two correlated context's audio stream position values:
+              the <a href=
+              "#widl-AudioTimestamp-contextTime"><code>contextTime</code></a>
               member contains the time of the sample frame which is currently
               being rendered by the audio output device (i.e., output audio
               stream position), in the same units and origin as context's
               <a href=
               "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>;
               the <a href=
-              "#widl-AudioTimeStamp-performanceTime"><code>performanceTime</code></a>
+              "#widl-AudioTimestamp-performanceTime"><code>performanceTime</code></a>
               member contains the time estimating the moment when the sample
               frame corresponding to the stored <code>contextTime</code> value
               was rendered by the audio output device, in the same units and
@@ -1751,28 +1751,28 @@ function setupRoutingGraph() {
             </p>
             <p>
               If the context's rendering graph has not yet processed a block of
-              audio, then <a><code>outputTimeStamp</code></a> holds an
-              <code>AudioTimeStamp</code> instance with both members containing
-              zero.
+              audio, then <a><code>getOutputTimestamp</code></a> call returns
+              an <code>AudioTimestamp</code> instance with both members
+              containing zero.
             </p>
             <p>
               After the context's rendering graph has started processing of
               blocks of audio, its <a href=
               "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>
               attribute value always exceeds the <a href=
-              "#widl-AudioTimeStamp-contextTime"><code>contextTime</code></a>
+              "#widl-AudioTimestamp-contextTime"><code>contextTime</code></a>
               value obtained from <a href=
-              "#widl-AudioContext-outputTimeStamp"><code>outputTimeStamp</code></a>
-              attribute.
+              "#widl-AudioContext-getOutputTimestamp-AudioTimestamp"><code>getOutputTimestamp</code></a>
+              method call.
             </p>
             <p>
-              The value of <a><code>outputTimeStamp</code></a> attribute can be
-              used to get performance time estimation for the slightly later
-              context's time value:
+              The value returned from <a><code>getOutputTimestamp</code></a>
+              method can be used to get performance time estimation for the
+              slightly later context's time value:
             </p>
             <pre class="example">
             function outputPerformanceTime(contextTime) {
-                var timestamp = context.outputTimeStamp;
+                var timestamp = context.getOutputTimestamp();
                 var elapsedTime = contextTime - timestamp.contextTime;
                 return timestamp.performanceTime + elapsedTime * 1000;
             }
@@ -1788,10 +1788,10 @@ function setupRoutingGraph() {
               The difference between the values of context's <a href=
               "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>
               and the <a href=
-              "#widl-AudioTimeStamp-contextTime"><code>contextTime</code></a>
+              "#widl-AudioTimestamp-contextTime"><code>contextTime</code></a>
               obtained from <a href=
-              "#widl-AudioContext-outputTimeStamp"><code>outputTimeStamp</code></a>
-              attribute value cannot be considered as a reliable output latency
+              "#widl-AudioContext-getOutputTimestamp-AudioTimestamp"><code>getOutputTimestamp</code></a>
+              method call cannot be considered as a reliable output latency
               estimation because <a href=
               "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>
               may be incremented at non-uniform time intervals, so <a href=
@@ -1857,7 +1857,7 @@ function setupRoutingGraph() {
             </p>
           </dd>
         </dl>
-        <dl title="dictionary AudioTimeStamp" class="idl">
+        <dl title="dictionary AudioTimestamp" class="idl">
           <dt>
             double contextTime
           </dt>


### PR DESCRIPTION
Whereas 'AudioContext.outputTimeStamp' attribute is returning a new object every time it should be converted to a method.