### PR TITLE
Make setting the `value` attribute of an `AudioParam` strictly equivalent of calling setValueAtTime with AudioContext.currentTime.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2886,10 +2886,7 @@ function setupRoutingGraph() {
           <dd>
             <p>
               The parameter's floating-point value. This attribute is
-              initialized to the <code>defaultValue</code>. <span class=
-              "synchronous">If <code>value</code> is set during a time when
-              there are any automation events scheduled then it will be ignored
-              and no exception will be thrown.</span>
+              initialized to the <code>defaultValue</code>.
             </p>
             <p>
               The effect of setting this attribute is equivalent to calling


### PR DESCRIPTION
This fixes #828.