### PR TITLE
Define the term "render quantum" and link back to the definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1972,8 +1972,8 @@ function setupRoutingGraph() {
               rendering <code>length</code> sample-frames of audio into
               <var>buffer</var>.
               </li>
-              <li>For every render quantum, check and suspend the rendering if
-              necessary.
+              <li>For every <a>render quantum</a>, check and suspend the
+              rendering if necessary.
               </li>
               <li>If a suspended context is resumed, continue to render the
               buffer.
@@ -2035,11 +2035,11 @@ function setupRoutingGraph() {
             </p>
             <p>
               Note that the maximum precision of suspension is the size of the
-              render quantum and the specified suspension time will be rounded
-              down to the nearest render quantum boundary. For this reason, it
-              is not allowed to schedule multiple suspends at the same
-              quantized frame. Also scheduling should be done while the context
-              is not running to ensure the precise suspension.
+              <a>render quantum</a> and the specified suspension time will be
+              rounded down to the nearest <a>render quantum</a> boundary. For
+              this reason, it is not allowed to schedule multiple suspends at
+              the same quantized frame. Also scheduling should be done while
+              the context is not running to ensure the precise suspension.
             </p>
             <dl class="parameters">
               <dt>
@@ -2047,8 +2047,8 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 Schedules a suspension of the rendering at the specified time,
-                which is quantized and rounded down to the render quantum size.
-                If the quantized frame number
+                which is quantized and rounded down to the <a>render
+                quantum</a> size. If the quantized frame number
                 <ol>
                   <li>is negative or
                   </li>
@@ -7781,7 +7781,8 @@ odd function with period \(2\pi\).
           Rendering an audio graph
         </h3>
         <p>
-          Rendering an audio graph is done in blocks of 128 samples-frames.
+          Rendering an audio graph is done in blocks of 128 samples-frames. A
+          block of 128 samples-frames is called a <dfn>render quantum</dfn>.
         </p>
         <p>
           Operations that happen <dfn data-lt="atomic">atomically</dfn> on a


### PR DESCRIPTION
This fixes #737.