### PR TITLE
In automation methods, when startTime is < AudioContext.currentTime, clamp to AudioContext.currentTime.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3163,7 +3163,10 @@ function setupRoutingGraph() {
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute.
                 <span class="synchronous">A TypeError exception MUST be thrown
                 if <code>start</code> is negative or is not a finite
-                number.</span>
+                number.</span> If <var>startTime</var> is less than <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
+                clamped to <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>.
               </dd>
               <dt>
                 float timeConstant
@@ -3249,7 +3252,10 @@ function setupRoutingGraph() {
                 at which the value curve will be applied. <span class=
                 "synchronous">A TypeError exception MUST be thrown if
                 <code>startTime</code> is negative or is not a finite
-                number.</span>
+                number.</span>. If <var>startTime</var> is less than <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
+                clamped to <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>.
               </dd>
               <dt>
                 double duration
@@ -3317,7 +3323,10 @@ function setupRoutingGraph() {
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute.
                 <span class="synchronous">A TypeError exception MUST be thrown
                 if <code>startTime</code> is negative or is not a finite
-                number.</span>
+                number.</span> If <var>startTime</var> is less than <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
+                clamped to <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>.
               </dd>
             </dl>
           </dd>


### PR DESCRIPTION
This fixes #713.