### PR TITLE
Fix #330: analyser uses most recent samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -5789,10 +5789,11 @@ function calculateNormalizationScale(buffer)
             <p>
               Copies the <a>current frequency data</a> into the passed
               floating-point array. If the array has fewer elements than the
-              <a><code>frequencyBinCount</code></a>, the excess elements will
-              be dropped. If the array has more elements than the
-              <a><code>frequencyBinCount</code></a>, the excess elements will
-              be ignored.
+              <a><code>frequencyBinCount</code></a>, the excess elements will be
+              dropped. If the array has more elements than the
+              <a><code>frequencyBinCount</code></a>, the excess elements will be
+              ignored. The most recent <a><code>fftSize</code></a>
+              frames are used in computing the frequency data.
             </p>
             <p>
               The frequency data are in dB units.
@@ -5817,7 +5818,8 @@ function calculateNormalizationScale(buffer)
               <a><code>frequencyBinCount</code></a>, the excess elements will
               be dropped. If the array has more elements than the
               <a><code>frequencyBinCount</code></a>, the excess elements will
-              be ignored.
+              be ignored. The most recent <a><code>fftSize</code></a>
+              frames are used in computing the frequency data.
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
@@ -5859,7 +5861,9 @@ function calculateNormalizationScale(buffer)
               the passed floating-point array. If the array has fewer elements
               than the value of <a><code>fftSize</code></a>, the excess
               elements will be dropped. If the array has more elements than
-              <a><code>fftSize</code></a>, the excess elements will be ignored.
+              <a><code>fftSize</code></a>, the excess elements will be
+              ignored. The most recent <a><code>fftSize</code></a>
+              frames are returned (after downmixing).
             </p>
             <dl class="parameters">
               <dt>
@@ -5876,11 +5880,13 @@ function calculateNormalizationScale(buffer)
           </dt>
           <dd>
             <p>
-              Copies the current down-mixed time-domain (waveform) data into
-              the passed unsigned byte array. If the array has fewer elements
-              than the value of <a><code>fftSize</code></a>, the excess
-              elements will be dropped. If the array has more elements than
-              <a><code>fftSize</code></a>, the excess elements will be ignored.
+              Copies the current down-mixed time-domain (waveform) data into the
+              passed unsigned byte array. If the array has fewer elements than
+              the value of <a><code>fftSize</code></a>, the excess elements will
+              be dropped. If the array has more elements than
+              <a><code>fftSize</code></a>, the excess elements will be
+              ignored. The most recent <a><code>ffftSize</code></a> frames are
+              used in computing the byte data.
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
@@ -5967,7 +5973,9 @@ function calculateNormalizationScale(buffer)
               channels of the time domain input data to mono assuming a
               <a>channelCount</a> of 1, <a>channelCountMode</a> of "max" and
               <a>channelInterpetation</a> of "speakers". This is independent of
-              the settings for the <a>AnalyserNode</a> itself.
+              the settings for the <a>AnalyserNode</a> itself. The most recent
+              <a><code>fftSize</code><a> frames are used for the down-mixing
+              operation.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the

--- a/index.html
+++ b/index.html
@@ -5789,11 +5789,11 @@ function calculateNormalizationScale(buffer)
             <p>
               Copies the <a>current frequency data</a> into the passed
               floating-point array. If the array has fewer elements than the
-              <a><code>frequencyBinCount</code></a>, the excess elements will be
-              dropped. If the array has more elements than the
-              <a><code>frequencyBinCount</code></a>, the excess elements will be
-              ignored. The most recent <a><code>fftSize</code></a>
-              frames are used in computing the frequency data.
+              <a><code>frequencyBinCount</code></a>, the excess elements will
+              be dropped. If the array has more elements than the
+              <a><code>frequencyBinCount</code></a>, the excess elements will
+              be ignored. The most recent <a><code>fftSize</code></a> frames
+              are used in computing the frequency data.
             </p>
             <p>
               The frequency data are in dB units.
@@ -5818,8 +5818,8 @@ function calculateNormalizationScale(buffer)
               <a><code>frequencyBinCount</code></a>, the excess elements will
               be dropped. If the array has more elements than the
               <a><code>frequencyBinCount</code></a>, the excess elements will
-              be ignored. The most recent <a><code>fftSize</code></a>
-              frames are used in computing the frequency data.
+              be ignored. The most recent <a><code>fftSize</code></a> frames
+              are used in computing the frequency data.
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
@@ -5861,9 +5861,9 @@ function calculateNormalizationScale(buffer)
               the passed floating-point array. If the array has fewer elements
               than the value of <a><code>fftSize</code></a>, the excess
               elements will be dropped. If the array has more elements than
-              <a><code>fftSize</code></a>, the excess elements will be
-              ignored. The most recent <a><code>fftSize</code></a>
-              frames are returned (after downmixing).
+              <a><code>fftSize</code></a>, the excess elements will be ignored.
+              The most recent <a><code>fftSize</code></a> frames are returned
+              (after downmixing).
             </p>
             <dl class="parameters">
               <dt>
@@ -5880,13 +5880,13 @@ function calculateNormalizationScale(buffer)
           </dt>
           <dd>
             <p>
-              Copies the current down-mixed time-domain (waveform) data into the
-              passed unsigned byte array. If the array has fewer elements than
-              the value of <a><code>fftSize</code></a>, the excess elements will
-              be dropped. If the array has more elements than
-              <a><code>fftSize</code></a>, the excess elements will be
-              ignored. The most recent <a><code>ffftSize</code></a> frames are
-              used in computing the byte data.
+              Copies the current down-mixed time-domain (waveform) data into
+              the passed unsigned byte array. If the array has fewer elements
+              than the value of <a><code>fftSize</code></a>, the excess
+              elements will be dropped. If the array has more elements than
+              <a><code>fftSize</code></a>, the excess elements will be ignored.
+              The most recent <a><code>ffftSize</code></a> frames are used in
+              computing the byte data.
             </p>
             <p>
               The values stored in the unsigned byte array are computed in the
@@ -5974,7 +5974,7 @@ function calculateNormalizationScale(buffer)
               <a>channelCount</a> of 1, <a>channelCountMode</a> of "max" and
               <a>channelInterpetation</a> of "speakers". This is independent of
               the settings for the <a>AnalyserNode</a> itself. The most recent
-              <a><code>fftSize</code><a> frames are used for the down-mixing
+              <a><code>fftSize</code></a>frames are used for the down-mixing
               operation.
             </li>
             <li>


### PR DESCRIPTION
Specify that the Analyser node uses the most recent fftSize frames when computing the output.