### PR TITLE
Fix #852: Add new sections for AudioContextOptions and AudioTimestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1861,44 +1861,60 @@ function setupRoutingGraph() {
             Creates a <a><code>MediaStreamAudioDestinationNode</code></a>
           </dd>
         </dl>
-        <dl title="dictionary AudioContextOptions" class="idl">
-          <dt>
-            (AudioContextLatencyCategory or double) latencyHint = "interactive"
-          </dt>
-          <dd>
-            <p>
-              Identify the type of playback, which affects tradeoffs between
-              audio output latency and power consumption.
-            </p>
-            <p>
-              The preferred value of the <code>latencyHint</code> is a value
-              from <a>AudioContextLatencyCategory</a>. However, a double can
-              also be specified for the number of seconds of latency for finer
-              control to balance latency and power consumption. It is at the
-              browser's discretion to interpret the number appropriately. The
-              actual latency used is given by AudioContext's <a href=
-              "#widl-BaseAudioContext-baseLatency">baseLatency</a> attribute.
-            </p>
-          </dd>
-        </dl>
-        <dl title="dictionary AudioTimestamp" class="idl">
-          <dt>
-            double contextTime
-          </dt>
-          <dd>
-            Represents a point in the time coordinate system of
-            BaseAudioContext's <a href=
-            "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>.
-          </dd>
-          <dt>
-            DOMHighResTimeStamp performanceTime
-          </dt>
-          <dd>
-            Represents a point in the time coordinate system of a
-            <code>Performance</code> interface implementation (described in
-            [[!hr-time-2]]).
-          </dd>
-        </dl>
+        <section>
+          <h3>
+            AudioContextOptions
+          </h3>
+          <p>
+            The <a><code>AudioContextOptions</code></a> dictionary is used to
+            specify a requested latency for an <a>AudioContext</a>.
+          </p>
+          <dl title="dictionary AudioContextOptions" class="idl">
+            <dt>
+              (AudioContextLatencyCategory or double) latencyHint =
+              "interactive"
+            </dt>
+            <dd>
+              <p>
+                Identify the type of playback, which affects tradeoffs between
+                audio output latency and power consumption.
+              </p>
+              <p>
+                The preferred value of the <code>latencyHint</code> is a value
+                from <a>AudioContextLatencyCategory</a>. However, a double can
+                also be specified for the number of seconds of latency for
+                finer control to balance latency and power consumption. It is
+                at the browser's discretion to interpret the number
+                appropriately. The actual latency used is given by
+                AudioContext's <a href=
+                "#widl-BaseAudioContext-baseLatency">baseLatency</a> attribute.
+              </p>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            AudioTimestamp
+          </h3>
+          <dl title="dictionary AudioTimestamp" class="idl">
+            <dt>
+              double contextTime
+            </dt>
+            <dd>
+              Represents a point in the time coordinate system of
+              BaseAudioContext's <a href=
+              "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>.
+            </dd>
+            <dt>
+              DOMHighResTimeStamp performanceTime
+            </dt>
+            <dd>
+              Represents a point in the time coordinate system of a
+              <code>Performance</code> interface implementation (described in
+              [[!hr-time-2]]).
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2 id="OfflineAudioContext">


### PR DESCRIPTION
Not sure if this is the best solution, but by adding new sections for
each of these dictionaries, the WebIDL fragment shows up in the
correct section next to the dictionary instead of being placed in the
preceeding section.