### PR TITLE
Fix #823: Refine definition of baseLatency

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,12 +858,13 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              The actual processing latency of the AudioContext. This
-              represents the number of seconds of processing latency incurred
-              by the AudioContext in handling audio through the graph. It does
-              not include any additional latency that might be caused by any
-              other processing between the output of the
-              <a>AudioDestinationNode</a> and the audio hardware.
+              This represents the number of seconds of processing latency
+              incurred by the <a>AudioContext</a> passing the audio from the
+              <a>AudioDestinationNode</a> to the audio subsystem. It does not
+              include any additional latency that might be caused by any other
+              processing between the output of the <a>AudioDestinationNode</a>
+              and the audio hardware and specifically does not include any
+              latency incurred the the audio graph itself.
             </p>
             <p>
               For example, if the audio context is running at 44.1 kHz and the


### PR DESCRIPTION
Clarify what baseLatency is.  In particular it is not the audio graph
latency.