### PR TITLE
Fix #697: AudioNode channel options dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -2733,6 +2733,29 @@ function setupRoutingGraph() {
           </dd>
         </dl>
         <section>
+          <h2>Dictionaries</h2>
+          <dl title="dictionary AudioNodeChannelOptions" class="idl">
+            <dt>
+              unsigned long channelCount
+            </dt>
+            <dd>
+              Desired number of channels for the <a>channelCount</a> attribute.
+            </dd>
+            <dt>
+              ChannelCountMode channelCountMode
+            </dt>
+            <dd>
+              Desired mode for the <a>channelCountMode</a> attribute.
+            </dd>
+            <dt>
+              ChannelIntepretation channelInterpretation
+            </dt>
+            <dd>
+              Desired mode for the <a>channelCountMode</a> attribute.
+            </dd>
+          </dl>
+        </section>
+        <section>
           <h3 id="lifetime-AudioNode" class="informative">
             Lifetime
           </h3>

--- a/index.html
+++ b/index.html
@@ -2736,7 +2736,7 @@ function setupRoutingGraph() {
           <h2>
             Dictionaries
           </h2>
-          <dl title="dictionary AudioNodeChannelOptions" class="idl">
+          <dl title="dictionary AudioNodeOptions" class="idl">
             <dt>
               unsigned long channelCount
             </dt>

--- a/index.html
+++ b/index.html
@@ -2733,7 +2733,9 @@ function setupRoutingGraph() {
           </dd>
         </dl>
         <section>
-          <h2>Dictionaries</h2>
+          <h2>
+            Dictionaries
+          </h2>
           <dl title="dictionary AudioNodeChannelOptions" class="idl">
             <dt>
               unsigned long channelCount


### PR DESCRIPTION
Add the AudioNodeChannelOptions dictionary that can be inherited by
most dictionaries for the AudioNode constructors.