### PR TITLE
Fix #700: Add constructor for ChannelMergerNode and ChannelSplitterNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6397,7 +6397,20 @@ function calculateNormalizationScale(buffer)
           "matrix mixing" where individual gain control of each channel is
           desired.
         </p>
-        <dl title="interface ChannelSplitterNode : AudioNode" class="idl"></dl>
+        <dl title="[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelSplitterNode : AudioNode" class="idl"></dl>
+      </section>
+      <section>
+        <h2>
+          ChannelSplitterOptions
+        </h2>
+        <dl title="dictionary ChannelSplitterOptions : AudioNodeChannelOptions" class="idl">
+          <dt>
+            unsigned long numberOfOutputs = 6
+          </dt>
+          <dd>
+            The number outputs for the <a><code>ChannelSplitterNode</code></a>.
+          </dd>
+        </dl>
       </section>
       <section>
         <h2>
@@ -6458,7 +6471,20 @@ function calculateNormalizationScale(buffer)
             A diagram of ChannelMerger
           </figcaption>
         </figure>
-        <dl title="interface ChannelMergerNode : AudioNode" class="idl"></dl>
+        <dl title="[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelMergerNode : AudioNode" class="idl"></dl>
+      </section>
+      <section>
+        <h2>
+          ChannelMergerOptions
+        </h2>
+        <dl title="dictionary ChannelMergerOptions : AudioNodeChannelOptions" class="idl">
+          <dt>
+            unsigned long numberOfInputs = 6
+          </dt>
+          <dd>
+            The number inputs for the <a><code>ChannelSplitterNode</code></a>.
+          </dd>
+        </dl>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -6427,7 +6427,7 @@ function calculateNormalizationScale(buffer)
         <h2>
           ChannelSplitterOptions
         </h2>
-        <dl title="dictionary ChannelSplitterOptions : AudioNodeChannelOptions"
+        <dl title="dictionary ChannelSplitterOptions : AudioNodeOptions"
         class="idl">
           <dt>
             unsigned long numberOfOutputs = 6
@@ -6504,7 +6504,7 @@ function calculateNormalizationScale(buffer)
         <h2>
           ChannelMergerOptions
         </h2>
-        <dl title="dictionary ChannelMergerOptions : AudioNodeChannelOptions"
+        <dl title="dictionary ChannelMergerOptions : AudioNodeOptions"
         class="idl">
           <dt>
             unsigned long numberOfInputs = 6

--- a/index.html
+++ b/index.html
@@ -6422,20 +6422,21 @@ function calculateNormalizationScale(buffer)
         <dl title=
         "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelSplitterNode : AudioNode"
         class="idl"></dl>
-      </section>
-      <section>
-        <h2>
-          ChannelSplitterOptions
-        </h2>
-        <dl title="dictionary ChannelSplitterOptions : AudioNodeOptions"
-        class="idl">
-          <dt>
-            unsigned long numberOfOutputs = 6
-          </dt>
-          <dd>
-            The number outputs for the <a><code>ChannelSplitterNode</code></a>.
-          </dd>
-        </dl>
+        <section>
+          <h2>
+            ChannelSplitterOptions
+          </h2>
+          <dl title="dictionary ChannelSplitterOptions : AudioNodeOptions"
+          class="idl">
+            <dt>
+              unsigned long numberOfOutputs = 6
+            </dt>
+            <dd>
+              The number outputs for the
+              <a><code>ChannelSplitterNode</code></a>.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2>
@@ -6499,20 +6500,21 @@ function calculateNormalizationScale(buffer)
         <dl title=
         "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelMergerNode : AudioNode"
         class="idl"></dl>
-      </section>
-      <section>
-        <h2>
-          ChannelMergerOptions
-        </h2>
-        <dl title="dictionary ChannelMergerOptions : AudioNodeOptions"
-        class="idl">
-          <dt>
-            unsigned long numberOfInputs = 6
-          </dt>
-          <dd>
-            The number inputs for the <a><code>ChannelSplitterNode</code></a>.
-          </dd>
-        </dl>
+        <section>
+          <h2>
+            ChannelMergerOptions
+          </h2>
+          <dl title="dictionary ChannelMergerOptions : AudioNodeOptions" class=
+          "idl">
+            <dt>
+              unsigned long numberOfInputs = 6
+            </dt>
+            <dd>
+              The number inputs for the
+              <a><code>ChannelSplitterNode</code></a>.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -6397,13 +6397,16 @@ function calculateNormalizationScale(buffer)
           "matrix mixing" where individual gain control of each channel is
           desired.
         </p>
-        <dl title="[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelSplitterNode : AudioNode" class="idl"></dl>
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelSplitterNode : AudioNode"
+        class="idl"></dl>
       </section>
       <section>
         <h2>
           ChannelSplitterOptions
         </h2>
-        <dl title="dictionary ChannelSplitterOptions : AudioNodeChannelOptions" class="idl">
+        <dl title="dictionary ChannelSplitterOptions : AudioNodeChannelOptions"
+        class="idl">
           <dt>
             unsigned long numberOfOutputs = 6
           </dt>
@@ -6471,13 +6474,16 @@ function calculateNormalizationScale(buffer)
             A diagram of ChannelMerger
           </figcaption>
         </figure>
-        <dl title="[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelMergerNode : AudioNode" class="idl"></dl>
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelMergerNode : AudioNode"
+        class="idl"></dl>
       </section>
       <section>
         <h2>
           ChannelMergerOptions
         </h2>
-        <dl title="dictionary ChannelMergerOptions : AudioNodeChannelOptions" class="idl">
+        <dl title="dictionary ChannelMergerOptions : AudioNodeChannelOptions"
+        class="idl">
           <dt>
             unsigned long numberOfInputs = 6
           </dt>


### PR DESCRIPTION
Fix #700.

Add constructors and define the options dictionary for each
constructor.