### PR TITLE
Fix #701: Add constructor for IIRFilterNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -7296,7 +7296,7 @@ $$
           The number of channels of the output always equals the number of
           channels of the input.
         </p>
-        <dl title="interface IIRFilterNode : AudioNode" class="idl">
+        <dl title="[Constructor(BaseAudioContext context, IIRFilterOptions options)] interface IIRFilterNode : AudioNode" class="idl">
           <dt>
             void getFrequencyResponse()
           </dt>
@@ -7332,6 +7332,33 @@ $$
             </dl>
           </dd>
         </dl>
+        <section>
+          <h2>
+            IIRFilterOptions
+          </h2>
+          <p>
+            The <code>IIRFilterOptions</code> dictionary is used to specify the
+            filter coefficients of the <a><code>IIRFilterNode</code></a>.
+          </p>
+          <dl title="dictionary IIRFilterOptions : AudioNodeChannelOptions" class="idl">
+            <dt>
+              sequence&lt;double&gt; feedforward
+            </dt>
+            <dd>
+              The feedforward coefficients for the
+              <a><code>IIRFilterNode</code></a>.  This member is required.  If
+              not specifed, a NotFoundError MUST be thrown.
+            </dd>
+            <dt>
+              sequence&lt;double&gt; feedback
+            </dt>
+            <dd>
+              The feedback coefficients for the
+              <a><code>IIRFilterNode</code></a>.  This member is required.  If
+              not specifed, a NotFoundError MUST be thrown.
+            </dd>
+          </dl>
+        </section>
         <section>
           <h3>
             Filter Definition

--- a/index.html
+++ b/index.html
@@ -7296,7 +7296,9 @@ $$
           The number of channels of the output always equals the number of
           channels of the input.
         </p>
-        <dl title="[Constructor(BaseAudioContext context, IIRFilterOptions options)] interface IIRFilterNode : AudioNode" class="idl">
+        <dl title=
+        "[Constructor(BaseAudioContext context, IIRFilterOptions options)] interface IIRFilterNode : AudioNode"
+        class="idl">
           <dt>
             void getFrequencyResponse()
           </dt>
@@ -7340,13 +7342,14 @@ $$
             The <code>IIRFilterOptions</code> dictionary is used to specify the
             filter coefficients of the <a><code>IIRFilterNode</code></a>.
           </p>
-          <dl title="dictionary IIRFilterOptions : AudioNodeChannelOptions" class="idl">
+          <dl title="dictionary IIRFilterOptions : AudioNodeChannelOptions"
+          class="idl">
             <dt>
               sequence&lt;double&gt; feedforward
             </dt>
             <dd>
               The feedforward coefficients for the
-              <a><code>IIRFilterNode</code></a>.  This member is required.  If
+              <a><code>IIRFilterNode</code></a>. This member is required. If
               not specifed, a NotFoundError MUST be thrown.
             </dd>
             <dt>
@@ -7354,7 +7357,7 @@ $$
             </dt>
             <dd>
               The feedback coefficients for the
-              <a><code>IIRFilterNode</code></a>.  This member is required.  If
+              <a><code>IIRFilterNode</code></a>. This member is required. If
               not specifed, a NotFoundError MUST be thrown.
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -6397,23 +6397,7 @@ function calculateNormalizationScale(buffer)
           "matrix mixing" where individual gain control of each channel is
           desired.
         </p>
-        <dl title=
-        "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelSplitterNode : AudioNode"
-        class="idl"></dl>
-      </section>
-      <section>
-        <h2>
-          ChannelSplitterOptions
-        </h2>
-        <dl title="dictionary ChannelSplitterOptions : AudioNodeChannelOptions"
-        class="idl">
-          <dt>
-            unsigned long numberOfOutputs = 6
-          </dt>
-          <dd>
-            The number outputs for the <a><code>ChannelSplitterNode</code></a>.
-          </dd>
-        </dl>
+        <dl title="interface ChannelSplitterNode : AudioNode" class="idl"></dl>
       </section>
       <section>
         <h2>
@@ -6474,23 +6458,7 @@ function calculateNormalizationScale(buffer)
             A diagram of ChannelMerger
           </figcaption>
         </figure>
-        <dl title=
-        "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelMergerNode : AudioNode"
-        class="idl"></dl>
-      </section>
-      <section>
-        <h2>
-          ChannelMergerOptions
-        </h2>
-        <dl title="dictionary ChannelMergerOptions : AudioNodeChannelOptions"
-        class="idl">
-          <dt>
-            unsigned long numberOfInputs = 6
-          </dt>
-          <dd>
-            The number inputs for the <a><code>ChannelSplitterNode</code></a>.
-          </dd>
-        </dl>
+        <dl title="interface ChannelMergerNode : AudioNode" class="idl"></dl>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -7366,7 +7366,7 @@ $$
             The <code>IIRFilterOptions</code> dictionary is used to specify the
             filter coefficients of the <a><code>IIRFilterNode</code></a>.
           </p>
-          <dl title="dictionary IIRFilterOptions : AudioNodeChannelOptions"
+          <dl title="dictionary IIRFilterOptions : AudioNodeOptions"
           class="idl">
             <dt>
               sequence&lt;double&gt; feedforward


### PR DESCRIPTION
The appropriate dictionary for the constructor is also defined.