### PR TITLE
Fix #702: Add constructor for OscillatorNode.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7556,7 +7556,9 @@ $$
             A custom periodic wave
           </dd>
         </dl>
-        <dl title="[Constructor(BaseAudioContext context, optional OscillatorOptions options)] interface OscillatorNode : AudioNode" class="idl">
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional OscillatorOptions options)] interface OscillatorNode : AudioNode"
+        class="idl">
           <dt>
             attribute OscillatorType type
           </dt>
@@ -7647,17 +7649,17 @@ $$
           </h2>
           <p>
             This specifies the options to be used when constructing an
-            <a><code>OscillatorNode</code></a>. All of the members are optional;
-            if not specified, the normal default values are used for
+            <a><code>OscillatorNode</code></a>. All of the members are
+            optional; if not specified, the normal default values are used for
             constructing the oscillator.
           </p>
-          <dl title="dictionary OscillatorOptions : AudioNodeOptions"
-          class="idl">
+          <dl title="dictionary OscillatorOptions : AudioNodeOptions" class=
+          "idl">
             <dt>
               OscillatorType type
             </dt>
             <dd>
-              The type of oscillator to be constructed.  If this is set to
+              The type of oscillator to be constructed. If this is set to
               "custom" without also specifying a
               <a><code>periodicWave</code></a>, then an InvalidStateError
               exception MUST be thrown.
@@ -7672,17 +7674,18 @@ $$
               float detune
             </dt>
             <dd>
-              The initial detune value for the <a><code>OscillatorNode</code></a>.
+              The initial detune value for the
+              <a><code>OscillatorNode</code></a>.
             </dd>
             <dt>
               PeriodicWave periodicWave
             </dt>
             <dd>
               The <a><code>PeriodicWave</code></a> for the
-              <a><code>OscillatorNode</code></a>. If this is specified, then the
-              <a><code>type</code></a> member must either be unspecified or set
-              to "custom".  If this is not true, an InvalidStateError exception
-              MUST be thrown.
+              <a><code>OscillatorNode</code></a>. If this is specified, then
+              the <a><code>type</code></a> member must either be unspecified or
+              set to "custom". If this is not true, an InvalidStateError
+              exception MUST be thrown.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -7654,7 +7654,7 @@ $$
           <dl title="dictionary OscillatorOptions : AudioNodeOptions"
           class="idl">
             <dt>
-              Oscillator type
+              OscillatorType type
             </dt>
             <dd>
               The type of oscillator to be constructed.  If this is set to

--- a/index.html
+++ b/index.html
@@ -7556,7 +7556,7 @@ $$
             A custom periodic wave
           </dd>
         </dl>
-        <dl title="interface OscillatorNode : AudioNode" class="idl">
+        <dl title="[Constructor(BaseAudioContext context, optional OscillatorOptions options)] interface OscillatorNode : AudioNode" class="idl">
           <dt>
             attribute OscillatorType type
           </dt>
@@ -7641,6 +7641,51 @@ $$
             </p>
           </dd>
         </dl>
+        <section>
+          <h2>
+            OscillatorOptions
+          </h2>
+          <p>
+            This specifies the options to be used when constructing an
+            <a><code>OscillatorNode</code></a>. All of the members are optional;
+            if not specified, the normal default values are used for
+            constructing the oscillator.
+          </p>
+          <dl title="dictionary OscillatorOptions : AudioNodeChannelOptions"
+          class="idl">
+            <dt>
+              Oscillator type
+            </dt>
+            <dd>
+              The type of oscillator to be constructed.  If this is set to
+              "custom" without also specifying a
+              <a><code>periodicWave</code></a>, then an InvalidStateError
+              exception MUST be thrown.
+            </dd>
+            <dt>
+              float frequency
+            </dt>
+            <dd>
+              The initial frequency for the <a><code>OscillatorNode</code></a>.
+            </dd>
+            <dt>
+              float detune
+            </dt>
+            <dd>
+              The initial detune value for the <a><code>OscillatorNode</code></a>.
+            </dd>
+            <dt>
+              PeriodicWave periodicWave
+            </dt>
+            <dd>
+              The <a><code>PeriodicWave</code></a> for the
+              <a><code>OscillatorNode</code></a>. If this is specified, then the
+              <a><code>type</code></a> member must either be unspecified or set
+              to "custom".  If this is not true, an InvalidStateError exception
+              MUST be thrown.
+            </dd>
+          </dl>
+        </section>
         <section>
           <h2>
             Basic Waveform Phase

--- a/index.html
+++ b/index.html
@@ -7651,7 +7651,7 @@ $$
             if not specified, the normal default values are used for
             constructing the oscillator.
           </p>
-          <dl title="dictionary OscillatorOptions : AudioNodeChannelOptions"
+          <dl title="dictionary OscillatorOptions : AudioNodeOptions"
           class="idl">
             <dt>
               Oscillator type


### PR DESCRIPTION
The appropriate dictionary for the constructor is also defined.