### PR TITLE
Fix #907: Define initial up and forward vectors correctly.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5597,9 +5597,27 @@ the event handler.
           listening to the audio scene. All <a><code>PannerNode</code></a>
           objects spatialize in relation to the
           <a><code>BaseAudioContext</code></a>'s <a href=
-          "#widl-BaseAudioContext-listener">listener</a>. See <a href=
-          "#Spatialization">the Spatialization/Panning section</a> for more
-          details about spatialization.
+          "#widl-BaseAudioContext-listener">listener</a>. See
+          <a>Spatialization/Panning</a> for more details about spatialization.
+        </p>
+        <p>
+          The <code>positionX, positionY, positionZ</code> parameters represent
+          the location of the listener in 3D Cartesian coordinate space.
+          <a><code>PannerNode</code></a> objects use this position relative to
+          individual audio sources for spatialization.
+        </p>
+        <p>
+          The <code>forwardX, forwardY, forwardZ</code> parameters represent a
+          direction vector in 3D space. Both a <code>forward</code> vector and
+          an <code>up</code> vector are used to determine the orientation of
+          the listener. In simple human terms, the <code>forward</code> vector
+          represents which direction the person's nose is pointing. The
+          <code>up</code> vector represents the direction the top of a person's
+          head is pointing. These values are expected to be linearly
+          independent (at right angles to each other), and unpredictable
+          behavior may result if they are not. For normative requirements of
+          how these values are to be interpreted, see the
+          <a>Spatialization/Panning</a> section.
         </p>
         <dl title="interface AudioListener" class="idl">
           <dt>
@@ -5608,10 +5626,8 @@ the event handler.
           <dd>
             <p>
               Sets the x coordinate position of the audio listener in a 3D
-              Cartesian coordinate space. <a><code>PannerNode</code></a>
-              objects use this position relative to individual audio sources
-              for spatialization. The default value is 0. This parameter is
-              a-rate.
+              Cartesian coordinate space. The default value is 0. This
+              parameter is a-rate.
             </p>
           </dd>
           <dt>
@@ -5639,22 +5655,6 @@ the event handler.
           </dt>
           <dd>
             <p>
-              The <code>forwardX, forwardY, forwardZ</code> parameters
-              represent a direction vector in 3D space. Both a
-              <code>forward</code> vector and an <code>up</code> vector are
-              used to determine the orientation of the listener. In simple
-              human terms, the <code>forward</code> vector represents which
-              direction the person's nose is pointing. The <code>up</code>
-              vector represents the direction the top of a person's head is
-              pointing. These values are expected to be linearly independent
-              (at right angles to each other), and unpredictable behavior may
-              result if they are not. For normative requirements of how these
-              values are to be interpreted, see the <a href=
-              "#Spatialization">spatialization section</a>.
-            </p>
-          </dd>
-          <dd>
-            <p>
               Sets the x coordinate component of the forward direction the
               listener is pointing in 3D Cartesian coordinate space. The
               default value is 0. This parameter is a-rate.
@@ -5677,20 +5677,13 @@ the event handler.
             <p>
               Sets the z coordinate component of the forward direction the
               listener is pointing in 3D Cartesian coordinate space. The
-              default value is 0. This parameter is a-rate.
+              default value is -1. This parameter is a-rate.
             </p>
           </dd>
           <dt>
             readonly attribute AudioParam upX
           </dt>
           <dd>
-            <p>
-              The <code>upX, upY, upZ</code> parameters represent a direction
-              vector in 3D space, indicating the direction of "up" to the
-              listener. For normative requirements of how these values are to
-              be interpreted, see the <a href="#Spatialization">spatialization
-              section</a>.
-            </p>
             <p>
               Sets the x coordinate component of the up direction the listener
               is pointing in 3D Cartesian coordinate space. The default value
@@ -5704,7 +5697,7 @@ the event handler.
             <p>
               Sets the y coordinate component of the up direction the listener
               is pointing in 3D Cartesian coordinate space. The default value
-              is 0. This parameter is a-rate.
+              is 1. This parameter is a-rate.
             </p>
           </dd>
           <dt>
@@ -8903,7 +8896,7 @@ Quad up-mix:
     </section>
     <section>
       <h2 id="Spatialization">
-        Spatialization / Panning
+        <dfn>Spatialization/Panning</dfn>
       </h2>
       <section>
         <h3 id="Spatialization-background">


### PR DESCRIPTION
Set the initial values for the up and forward vectors correctly.  This
was a mistake introduced in adding the up and forward AudioParams.

Also took the opportunity to move some of the descriptive text out of
forwardX and upX to the introduction paragraph to describe forward
and up vectors better.  They didn't really belong there anyway.  And
this makes the description of each component uniform so it's easier to
read and find the default values.

Finally, add a dfn entry for the Spatialization/Panning section so
that it's easier to refer to.  Updated links in the listener section
appropriately.