### PR TITLE
Fix #909: Clarify setPosition/setOrientation text

### DIFF
--- a/index.html
+++ b/index.html
@@ -5723,8 +5723,10 @@ the event handler.
           <dd>
             <p>
               This method is DEPRECATED. It is equivalent to setting
-              <code>positionX</code>, <code>positionY</code>, and
-              <code>positionZ</code> AudioParams directly.
+              <code>positionX.value</code>, <code>positionY.value</code>, and
+              <code>positionZ.value</code> directly with the given
+              <code>x</code>, <code>y</code>, and <code>z</code> values,
+              respectively.
             </p>
             <p>
               Sets the position of the listener in a 3D cartesian coordinate
@@ -5746,9 +5748,12 @@ the event handler.
           <dd>
             <p>
               This method is DEPRECATED. It is equivalent to setting
-              <code>orientationX</code>, <code>orientationY</code>,
-              <code>orientationZ</code>, <code>upX</code>, <code>upY</code>,
-              and <code>upZ</code> AudioParams directly.
+              <code>orientationX.value</code>, <code>orientationY.value</code>,
+              <code>orientationZ.value</code>, <code>upX.value</code>,
+              <code>upY.value</code>, and <code>upZ.value</code> directly with
+              the given <code>x</code>, <code>y</code>, <code>z</code>,
+              <code>xUp</code>, <code>yUp</code>, and <code>zUp</code> values,
+              respectively.
             </p>
             <p>
               Describes which direction the listener is pointing in the 3D


### PR DESCRIPTION
Clarify the text for setPosition/setOrientation to say that we're
setting the values of the corresponding AudioParam's, not the
AudioParam itself.