### PR TITLE
Fix #912: Fix text for stop() for AudioBufferSourceNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4087,7 +4087,14 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </dt>
           <dd>
             <p>
-              Schedules a sound to stop playback at an exact time.
+              Schedules a sound to stop playback at an exact time. If
+              <code>stop</code> is called again after already having been
+              called, the last invocation will be the only one applied; stop
+              times set by previous calls will not be applied, unless the
+              buffer has already stopped prior to any subsequent calls. If the
+              buffer has already stopped, further calls to <code>stop</code>
+              will have no effect. If a stop time is reached prior to the
+              scheduled start time, the sound will not play.
             </p>
             <dl class="parameters">
               <dt>
@@ -4104,14 +4111,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>,
                 then the sound will stop playing immediately. <span class=
                 "synchronous">A TypeError exception MUST be thrown if
-                <code>when</code> is negative</span>. If <code>stop</code> is
-                called again after already have been called, the last
-                invocation will be the only one applied; stop times set by
-                previous calls will not be applied, unless the buffer has
-                already stopped prior to any subsequent calls. If the buffer
-                has already stopped, further calls to <code>stop</code> will
-                have no effect. If a stop time is reached prior to the
-                scheduled start time, the sound will not play.
+                <code>when</code> is negative</span>.
               </dd>
             </dl>
           </dd>


### PR DESCRIPTION
The description of the when parameter described what happens with
multiple calls to stop().  This is wrong.  Move this text to the
paragraph describing the stop() method.