### PR TITLE
Fix #903: Clarify Oscillator.start()/stop()

### DIFF
--- a/index.html
+++ b/index.html
@@ -7599,21 +7599,43 @@ $$
             </p>
           </dd>
           <dt>
-            void start(optional double when = 0)
+            void start()
           </dt>
           <dd>
             <p>
-              Defined the same as the <code>when</code> parameter of the
-              <a><code>AudioBufferSourceNode</code></a>
+              Schedules a sound to playback at an exact time.
+              <code>start</code> may only be called one time and <span class=
+              "synchronous">must be called before <code>stop</code> is called
+              or an InvalidStateError exception MUST be thrown.</span>
             </p>
+            <dl class="parameters">
+              <dt>
+                optional double when = 0
+              </dt>
+              <dd>
+                Defined the same as the <code>when</code> parameter of the <a
+                href="http://localhost:7100/#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration"><code>start()</code></a>
+                method of the <a>AudioBufferSourceNode</a>
+              </dd>
+            </dl>
           </dd>
           <dt>
             void stop(optional double when = 0)
           </dt>
           <dd>
             <p>
-              Defined as in <a><code>AudioBufferSourceNode</code></a>.
+              Schedules a sound to stop playback at an exact time.
             </p>
+            <dl class="parameters">
+              <dt>
+                optional double when = 0
+              </dt>
+              <dd>
+                Defined the same as the <code>when</code> parameter of the <a
+                href="http://localhost:7100/#widl-AudioBufferSourceNode-stop-void-double-when"><code>stop()</code></a>
+                method of the <a>AudioBufferSourceNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             void setPeriodicWave(PeriodicWave periodicWave)

--- a/index.html
+++ b/index.html
@@ -7603,36 +7603,45 @@ $$
           </dt>
           <dd>
             <p>
-              Schedules a sound to playback at an exact time.
-              <code>start</code> may only be called one time and <span class=
-              "synchronous">must be called before <code>stop</code> is called
-              or an InvalidStateError exception MUST be thrown.</span>
+              Schedules a sound to playback at an exact time. This behaves
+              exactly the same as the <a href=
+              "#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration">
+              <code>start()</code></a> method for an
+              <a>AudioBufferSourceNode</a> except the optional
+              <code>offset</code> and <code>duration</code> parameters are not
+              allowed.
             </p>
             <dl class="parameters">
               <dt>
                 optional double when = 0
               </dt>
               <dd>
-                Defined the same as the <code>when</code> parameter of the <a
-                href="http://localhost:7100/#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration"><code>start()</code></a>
-                method of the <a>AudioBufferSourceNode</a>
+                Defined the same as the <code>when</code> parameter of the
+                <a href=
+                "#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration">
+                <code>start()</code></a> method of the
+                <a>AudioBufferSourceNode</a>.
               </dd>
             </dl>
           </dd>
           <dt>
-            void stop(optional double when = 0)
+            void stop()
           </dt>
           <dd>
             <p>
-              Schedules a sound to stop playback at an exact time.
+              Schedules a sound to stop playback at an exact time. This behaves
+              exactly the same as the <a href=
+              "#widl-AudioBufferSourceNode-stop-void-double-when"><code>stop()</code></a>
+              method for an <a>AudioBufferSourceNode</a>
             </p>
             <dl class="parameters">
               <dt>
                 optional double when = 0
               </dt>
               <dd>
-                Defined the same as the <code>when</code> parameter of the <a
-                href="http://localhost:7100/#widl-AudioBufferSourceNode-stop-void-double-when"><code>stop()</code></a>
+                Defined the same as the <code>when</code> parameter of the
+                <a href=
+                "#widl-AudioBufferSourceNode-stop-void-double-when"><code>stop()</code></a>
                 method of the <a>AudioBufferSourceNode</a>.
               </dd>
             </dl>


### PR DESCRIPTION
Clarify the text for start and stop methods along with the description
of the parameters for these methods.
    
Mostly just reference the corresponding methods/parameters from
AudioBufferSource.
