### PR TITLE
Fix #901: Remove incorrect value setter clause.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3473,13 +3473,13 @@ function setupRoutingGraph() {
             each time, which is either the value set directly to the
             <code>value</code> attribute, or, if there are any scheduled
             parameter changes (automation events) with times before or at this
-            time, the value as calculated from these events.  When read,
-            the <code>value</code> attribute always returns the
-            <em>intrinsic</em> value for the current time. If automation events
-            are removed from a given time range, then the <em>intrinsic</em>
-            value will remain unchanged and stay at its previous value until
-            either the <code>value</code> attribute is directly set, or
-            automation events are added for the time range.
+            time, the value as calculated from these events. When read, the
+            <code>value</code> attribute always returns the <em>intrinsic</em>
+            value for the current time. If automation events are removed from a
+            given time range, then the <em>intrinsic</em> value will remain
+            unchanged and stay at its previous value until either the
+            <code>value</code> attribute is directly set, or automation events
+            are added for the time range.
             </li>
             <li>The <em>computedValue</em> is the sum of the <em>intrinsic</em>
             value and the value of the <a href="#input-audioparam-buffer">input

--- a/index.html
+++ b/index.html
@@ -3473,9 +3473,7 @@ function setupRoutingGraph() {
             each time, which is either the value set directly to the
             <code>value</code> attribute, or, if there are any scheduled
             parameter changes (automation events) with times before or at this
-            time, the value as calculated from these events. If the
-            <code>value</code> attribute is set after any automation events
-            have been scheduled, then these events will be removed. When read,
+            time, the value as calculated from these events.  When read,
             the <code>value</code> attribute always returns the
             <em>intrinsic</em> value for the current time. If automation events
             are removed from a given time range, then the <em>intrinsic</em>


### PR DESCRIPTION
Setting the value attribute shouldn't remove events from the timeline;
nobody does that and this conflicts with the idea that the setter is
the same as calling setValueAtTime().