### PR TITLE
Fix #918: fix typo in statechange

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,7 +943,7 @@ function setupRoutingGraph() {
                       <code>suspended</code>.
                       </li>
                       <li>Queue a task to fire a simple event named
-                      <code>statechanged</code> at the <a>AudioContext</a>
+                      <code>statechange</code> at the <a>AudioContext</a>
                       </li>
                     </ol>
                   </li>

--- a/index.html
+++ b/index.html
@@ -5993,8 +5993,8 @@ the event handler.
             <a><code>StereoPannerNode</code></a>. All members are optional; if
             not specified, the normal default is used in constructing the node.
           </p>
-          <dl title="dictionary StereoPannerOptions : AudioNodeChannelOptions"
-          class="idl">
+          <dl title="dictionary StereoPannerOptions : AudioNodeOptions" class=
+          "idl">
             <dt>
               float pan
             </dt>

--- a/index.html
+++ b/index.html
@@ -3641,8 +3641,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             <a><code>GainNode</code></a>. All members are optional; if not
             specified, the normal defaults are used in constructing the node.
           </p>
-          <dl title="dictionary GainOptions : AudioNodeChannelOptions" class=
-          "idl">
+          <dl title="dictionary GainOptions : AudioNodeOptions" class="idl">
             <dt>
               float gain
             </dt>

--- a/index.html
+++ b/index.html
@@ -7866,8 +7866,8 @@ $$
             <a><code>WaveShaperNode</code></a>. All members are optional; if
             not specified, the normal default is used in constructing the node.
           </p>
-          <dl title="dictionary WaveShaperOptions : AudioNodeChannelOptions"
-          class="idl">
+          <dl title="dictionary WaveShaperOptions : AudioNodeOptions" class=
+          "idl">
             <dt>
               sequence&lt;float&gt; curve
             </dt>

--- a/index.html
+++ b/index.html
@@ -5427,8 +5427,9 @@ the event handler.
             </p>
           </dd>
         </dl>
-        <dl title="interface PannerNode : AudioNode" class="idl">
-          <!--<dt>// Default for stereo is HRTF</dt>-->
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional PannerOptions options)]interface PannerNode : AudioNode"
+        class="idl">
           <dt>
             attribute PanningModelType panningModel
           </dt>
@@ -5622,6 +5623,127 @@ the event handler.
             </p>
           </dd>
         </dl>
+        <section>
+          <h2>
+            PannerOptions
+          </h2>
+          <p>
+            This specifies options for constructing a
+            <a><code>PannerNode</code></a>. All members are optional; if not
+            specified, the normal default is used in constructing the node.
+          </p>
+          <dl title="dictionary PannerOptions : AudioNodeChannelOptions" class=
+          "idl">
+            <dt>
+              PanningModelType panningModel
+            </dt>
+            <dd>
+              The panning model to use for the node.
+            </dd>
+            <dt>
+              DistanceModelType distanceModel
+            </dt>
+            <dd>
+              The distance model to use for the node.
+            </dd>
+            <dt>
+              float positionX
+            </dt>
+            <dd>
+              The initial X value for the <a href=
+              "#widl-PannerNode-positionX"><code>positionX</code></a>
+              AudioParam.
+            </dd>
+            <dt>
+              float positionY
+            </dt>
+            <dd>
+              The initial Y value for the <a href=
+              "#widl-PannerNode-positionY"><code>positionY</code></a>
+              AudioParam.
+            </dd>
+            <dt>
+              float positionZ
+            </dt>
+            <dd>
+              The initial Z value for the <a href=
+              "#widl-PannerNode-positionZ"><code>positionZ</code></a>
+              AudioParam.
+            </dd>
+            <dt>
+              float orientationX
+            </dt>
+            <dd>
+              The initial X value for the <a href=
+              "#widl-PannerNode-orientationX"><code>orientationX</code></a>
+              AudioParam.
+            </dd>
+            <dt>
+              float orientationY
+            </dt>
+            <dd>
+              The initial Y value for the <a href=
+              "#widl-PannerNode-orientationY"><code>orientationY</code></a>
+              AudioParam.
+            </dd>
+            <dt>
+              float orientationZ
+            </dt>
+            <dd>
+              The initial Z value for the <a href=
+              "#widl-PannerNode-orientationZ"><code>orientationZ</code></a>
+              AudioParam.
+            </dd>
+            <dt>
+              double refDistance
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-PannerNode-refDistance"><code>refDistance</code></a>
+              attribute of the node.
+            </dd>
+            <dt>
+              double maxDistance
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-PannerNode-maxDistance"><code>maxDistance</code></a>
+              attribute of the node.
+            </dd>
+            <dt>
+              double rolloffFactor
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-PannerNode-rolloffFactor"><code>rolloffFactor</code></a>
+              attribute of the node.
+            </dd>
+            <dt>
+              double coneInnerAngle
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-PannerNode-coneInnerAngle"><code>coneInnerAngle</code></a>
+              attribute of the node.
+            </dd>
+            <dt>
+              double coneOuterAngle
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-PannerNode-coneOuterAngle"><code>coneOuterAngle</code></a>
+              attribute of the node.
+            </dd>
+            <dt>
+              double coneOuterGain
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-PannerNode-coneOuterGain"><code>coneOuterGain</code></a>
+              attribute of the node.
+            </dd>
+          </dl>
+        </section>
         <section class="informative">
           <h3 id="panner-channel-limitations">
             Channel Limitations

--- a/index.html
+++ b/index.html
@@ -5631,8 +5631,7 @@ the event handler.
             <a><code>PannerNode</code></a>. All members are optional; if not
             specified, the normal default is used in constructing the node.
           </p>
-          <dl title="dictionary PannerOptions : AudioNodeChannelOptions" class=
-          "idl">
+          <dl title="dictionary PannerOptions : AudioNodeOptions" class="idl">
             <dt>
               PanningModelType panningModel
             </dt>

--- a/index.html
+++ b/index.html
@@ -3617,7 +3617,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           "#widl-GainNode-gain"><code>gain</code></a>
           <a><code>AudioParam</code></a>.
         </p>
-        <dl title="interface GainNode : AudioNode" class="idl">
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional GainOptions options)]interface GainNode : AudioNode"
+        class="idl">
           <dt>
             readonly attribute AudioParam gain
           </dt>
@@ -3630,6 +3632,26 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             </p>
           </dd>
         </dl>
+        <section>
+          <h2>
+            GainOptions
+          </h2>
+          <p>
+            This specifies options to use in constructing a
+            <a><code>GainNode</code></a>. All members are optional; if not
+            specified, the normal defaults are used in constructing the node.
+          </p>
+          <dl title="dictionary GainOptions : AudioNodeChannelOptions" class=
+          "idl">
+            <dt>
+              float gain
+            </dt>
+            <dd>
+              The initial gain value for the <a href=
+              "#widl-GainNode-gain"><code>gain</code></a> AudioParam.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2 id="DelayNode">

--- a/index.html
+++ b/index.html
@@ -5971,7 +5971,9 @@ the event handler.
           The output of this node is hard-coded to stereo (2 channels) and
           cannot be configured.
         </p>
-        <dl title="interface StereoPannerNode : AudioNode" class="idl">
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional StereoPannerOptions options)]interface StereoPannerNode : AudioNode"
+        class="idl">
           <dt>
             readonly attribute AudioParam pan
           </dt>
@@ -5984,6 +5986,26 @@ the event handler.
             </p>
           </dd>
         </dl>
+        <section>
+          <h2>
+            StereoPannerOptions
+          </h2>
+          <p>
+            This specifies the options to use in constructing a
+            <a><code>StereoPannerNode</code></a>. All members are optional; if
+            not specified, the normal default is used in constructing the node.
+          </p>
+          <dl title="dictionary StereoPannerOptions : AudioNodeChannelOptions"
+          class="idl">
+            <dt>
+              float pan
+            </dt>
+            <dd>
+              The initial value for the <a href=
+              "#widl-StereoPannerNode-pan"><code>pan</code></a> AudioParam.
+            </dd>
+          </dl>
+        </section>
         <section class="informative">
           <h3>
             Channel Limitations

--- a/index.html
+++ b/index.html
@@ -7777,8 +7777,9 @@ $$
             Oversample four times
           </dd>
         </dl>
-        <dl title="interface WaveShaperNode : AudioNode" class="idl"
-        data-merge="OverSampleType">
+        <dl title=
+        "[Constructor(BaseAudioContext context, optional WaveShaperOptions options)]interface WaveShaperNode : AudioNode"
+        class="idl" data-merge="OverSampleType">
           <dt>
             attribute Float32Array? curve
           </dt>
@@ -7858,6 +7859,31 @@ $$
             </p>
           </dd>
         </dl>
+        <section>
+          <h2>
+            WaveShaperOptions
+          </h2>
+          <p>
+            This specifies the options for constructing a
+            <a><code>WaveShaperNode</code></a>. All members are optional; if
+            not specified, the normal default is used in constructing the node.
+          </p>
+          <dl title="dictionary WaveShaperOptions : AudioNodeChannelOptions"
+          class="idl">
+            <dt>
+              sequence&lt;float&gt; curve
+            </dt>
+            <dd>
+              The shaping curve for the waveshaping effect.
+            </dd>
+            <dt>
+              OverSampleType oversample
+            </dt>
+            <dd>
+              The type of oversampling to use for the shaping curve.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
"statechanged" -> "statechange" which is the correct event name.