### PR TITLE
Fix #870: Construct AudioBuffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -3739,7 +3739,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>OfflineAudioContext</code></a> and an
           <a><code>AudioContext</code></a>.
         </p>
-        <dl title="[Constructor(BaseAudioContext context, AudioBufferOptions options)]interface AudioBuffer" class="idl">
+        <dl title=
+        "[Constructor(BaseAudioContext context, AudioBufferOptions options)]interface AudioBuffer"
+        class="idl">
           <dt>
             readonly attribute float sampleRate
           </dt>
@@ -3932,36 +3934,37 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           since the <a>AudioNode</a> will continue to use the data previously
           acquired.
         </p>
-	<section>
-	  <h2>
-	    AudioBufferOptions
-	  </h2>
-	  <p>
-	    This specifies the options to use in constructing an <a><code>AudioBuffer</code></a>.
-	    All members are required.  A NotFoundError exception MUST be thrown if any of the
-	    required members are not specified.
-	  </p>
-	  <dl title="dictionary AudioBufferOptions" class="idl">
-	    <dt>
-	      unsigned long numberOfChannels
-	    </dt>
-	    <dd>
-	      The number of channels for the buffer
-	    </dd>
-	    <dt>
-	      unsigned long length
-	    </dt>
-	    <dd>
-	      The length in sample frames of the buffer.
-	    </dd>
-	    <dt>
-	      float sampleRate
-	    </dt>
-	    <dd>
-	      The sample rate in Hz for the buffer.
-	    </dd>
-	  </dl>
-	</section>
+        <section>
+          <h2>
+            AudioBufferOptions
+          </h2>
+          <p>
+            This specifies the options to use in constructing an
+            <a><code>AudioBuffer</code></a>. All members are required. A
+            NotFoundError exception MUST be thrown if any of the required
+            members are not specified.
+          </p>
+          <dl title="dictionary AudioBufferOptions" class="idl">
+            <dt>
+              unsigned long numberOfChannels
+            </dt>
+            <dd>
+              The number of channels for the buffer
+            </dd>
+            <dt>
+              unsigned long length
+            </dt>
+            <dd>
+              The length in sample frames of the buffer.
+            </dd>
+            <dt>
+              float sampleRate
+            </dt>
+            <dd>
+              The sample rate in Hz for the buffer.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2 id="AudioBufferSourceNode">

--- a/index.html
+++ b/index.html
@@ -3739,7 +3739,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>OfflineAudioContext</code></a> and an
           <a><code>AudioContext</code></a>.
         </p>
-        <dl title="interface AudioBuffer" class="idl">
+        <dl title="[Constructor(BaseAudioContext context, AudioBufferOptions options)]interface AudioBuffer" class="idl">
           <dt>
             readonly attribute float sampleRate
           </dt>
@@ -3932,6 +3932,36 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           since the <a>AudioNode</a> will continue to use the data previously
           acquired.
         </p>
+	<section>
+	  <h2>
+	    AudioBufferOptions
+	  </h2>
+	  <p>
+	    This specifies the options to use in constructing an <a><code>AudioBuffer</code></a>.
+	    All members are required.  A NotFoundError exception MUST be thrown if any of the
+	    required members are not specified.
+	  </p>
+	  <dl title="dictionary AudioBufferOptions" class="idl">
+	    <dt>
+	      unsigned long numberOfChannels
+	    </dt>
+	    <dd>
+	      The number of channels for the buffer
+	    </dd>
+	    <dt>
+	      unsigned long length
+	    </dt>
+	    <dd>
+	      The length in sample frames of the buffer.
+	    </dd>
+	    <dt>
+	      float sampleRate
+	    </dt>
+	    <dd>
+	      The sample rate in Hz for the buffer.
+	    </dd>
+	  </dl>
+	</section>
       </section>
       <section>
         <h2 id="AudioBufferSourceNode">


### PR DESCRIPTION
Add constructor for AudioBuffer and define an appropriate dictionary.  The dictionary is required and so are all the members.
