### PR TITLE
Fix #932: specify default type for BiquadFilter

### DIFF
--- a/index.html
+++ b/index.html
@@ -7293,9 +7293,9 @@ function calculateNormalizationScale(buffer)
           </dt>
           <dd>
             <p>
-              The type of this <a><code>BiquadFilterNode</code></a>. The exact
-              meaning of the other parameters depend on the value of the
-              <a><code>type</code></a> attribute.
+              The type of this <a><code>BiquadFilterNode</code></a>. Its default
+              value is "lowpass". The exact meaning of the other parameters
+              depend on the value of the <a><code>type</code></a> attribute.
             </p>
           </dd>
           <dt>

--- a/index.html
+++ b/index.html
@@ -7293,9 +7293,10 @@ function calculateNormalizationScale(buffer)
           </dt>
           <dd>
             <p>
-              The type of this <a><code>BiquadFilterNode</code></a>. Its default
-              value is "lowpass". The exact meaning of the other parameters
-              depend on the value of the <a><code>type</code></a> attribute.
+              The type of this <a><code>BiquadFilterNode</code></a>. Its
+              default value is "lowpass". The exact meaning of the other
+              parameters depend on the value of the <a><code>type</code></a>
+              attribute.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
Specify the default type for a BiquadFilter in the description of the
type attribute.