### PR TITLE
Fix #946: Use minValue and maxValue

### DIFF
--- a/index.html
+++ b/index.html
@@ -2967,12 +2967,13 @@ function setupRoutingGraph() {
           each sample-frame of the block.
         </p>
         <p>
-          Each <code>AudioParam</code> includes <code>min</code> and
-          <code>max</code> attributes that together form the <a>nominal
-          range</a> for the parameter. In effect, value of the parameter is
-          clamped to the range \([\mathrm{minValue}, \mathrm{maxValue}]\). See
-          the section <a href="#computation-of-value">Computation of Value</a>
-          for full details.
+          Each <code>AudioParam</code> includes <a href=
+          "#widl-AudioParam-minValue"><code>minValue</code></a> and <a href=
+          "#widl-AudioParam-maxValue"><code>maxValue</code></a> attributes that
+          together form the <a>nominal range</a> for the parameter. In effect,
+          value of the parameter is clamped to the range \([\mathrm{minValue},
+          \mathrm{maxValue}]\). See the section <a href=
+          "#computation-of-value">Computation of Value</a> for full details.
         </p>
         <p>
           An <code>AudioParam</code> maintains a time-ordered event list which


### PR DESCRIPTION
Replaces "min" and "max" with "minValue" and "maxValue", respectively.