### PR TITLE
Fix #961: add markup for AudioBufferSourceNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4037,12 +4037,22 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>AudioWorkletNode</code></a> to implement playback.
         </p>
         <p>
-          The start() method is used to schedule when sound playback will
-          happen. The start() method may not be issued multiple times. The
+          The <a href=
+          "#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration">
+          <code>start()</code></a> method is used to schedule when sound
+          playback will happen. The <a href=
+          "#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration">
+          <code>start()</code></a> method may not be issued multiple times. The
           playback will stop automatically when the buffer's audio data has
-          been completely played (if the <code>loop</code> attribute is false),
-          or when the stop() method has been called and the specified time has
-          been reached. Please see more details in the start() and stop()
+          been completely played (if the <a href=
+          "#widl-AudioBufferSourceNode-loop"><code>loop</code></a> attribute is
+          <code>false</code>), or when the <a href=
+          "#widl-AudioBufferSourceNode-stop-void-double-when"><code>stop()</code></a>
+          method has been called and the specified time has been reached.
+          Please see more details in the <a href=
+          "#widl-AudioBufferSourceNode-start-void-double-when-double-offset-double-duration">
+          <code>start()</code></a> and <a href=
+          "#widl-AudioBufferSourceNode-stop-void-double-when"><code>stop()</code></a>
           description.
         </p>
         <pre>
@@ -4051,8 +4061,11 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
 </pre>
         <p>
           The number of channels of the output always equals the number of
-          channels of the AudioBuffer assigned to the .buffer attribute, or is
-          one channel of silence if .buffer is NULL.
+          channels of the AudioBuffer assigned to the <a href=
+          "#widl-AudioBufferSourceNode-buffer"><code>buffer</code></a>
+          attribute, or is one channel of silence if <a href=
+          "#widl-AudioBufferSourceNode-buffer"><code>buffer</code></a> is
+          <code>null</code>.
         </p>
         <p>
           This node has no <a>tail-time</a> reference.


### PR DESCRIPTION
Add some markup for the functions and attributes in the initial
description of AudioBufferSourceNode.