### PR TITLE
Fix #962: Default values for AudioBufferOptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3997,16 +3997,17 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </h2>
           <p>
             This specifies the options to use in constructing an
-            <a><code>AudioBuffer</code></a>. All members are required. A
-            NotFoundError exception MUST be thrown if any of the required
-            members are not specified.
+            <a><code>AudioBuffer</code></a>. Only the <a href=
+            "#widl-AudioBufferOptions-length"><code>length</code></a> member is
+            required. A NotFoundError exception MUST be thrown if any of the
+            required members are not specified.
           </p>
           <dl title="dictionary AudioBufferOptions" class="idl">
             <dt>
               unsigned long numberOfChannels
             </dt>
             <dd>
-              The number of channels for the buffer
+              The number of channels for the buffer. The default is 1.
             </dd>
             <dt>
               unsigned long length
@@ -4018,7 +4019,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               float sampleRate
             </dt>
             <dd>
-              The sample rate in Hz for the buffer.
+              The sample rate in Hz for the buffer. The default is the sample
+              rate of the <code>context</code> used in constructing this
+              object.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -4004,10 +4004,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </p>
           <dl title="dictionary AudioBufferOptions" class="idl">
             <dt>
-              unsigned long numberOfChannels
+              unsigned long numberOfChannels = 1
             </dt>
             <dd>
-              The number of channels for the buffer. The default is 1.
+              The number of channels for the buffer.
             </dd>
             <dt>
               unsigned long length


### PR DESCRIPTION
Specify that the numberOfChannels and sampleRate are optional with the
default being 1 and the context sample rate, respectively.  Thus, only
the length is required.

This is a handy shortcut.