### PR TITLE
Fix #948: Move close() to AudioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -1061,83 +1061,6 @@ function setupRoutingGraph() {
             </ol>
           </dd>
           <dt>
-            Promise&lt;void&gt; close()
-          </dt>
-          <dd>
-            <p>
-              Closes the <a>BaseAudioContext</a>, <a>releasing the system
-              resources</a> it's using. This will not automatically release all
-              <a>AudioContext</a>-created objects, but will suspend the
-              progression of the <a><code>AudioContext</code></a>'s <a href=
-              "#widl-AudioContext-currentTime">currentTime</a>, and stop
-              processing audio data.
-            </p>
-            <p>
-              <span class="synchronous">When close is called, execute these
-              steps:</span>
-            </p>
-            <ol>
-              <li>Let <em>promise</em> be a new Promise.
-              </li>
-              <li>If this <a>BaseAudioContext</a> is an
-              <a>OfflineAudioContext</a>, reject <em>promise</em> with
-              <code>NotSupportedError</code>, return it, and abort these steps.
-              </li>
-              <li>If the <em>control thread state</em> flag on the
-              <a>AudioContext</a> is <code>closed</code> reject the promise
-              with <code>InvalidStateError</code>, abort these steps, returning
-              <em>promise</em>.
-              </li>
-              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
-              of the <a>AudioContext</a> is already <code>closed</code>,
-              resolve <em>promise</em>, return it, and abort these steps.
-              </li>
-              <li>Set the <em>control thread state</em> flag on the
-              <a>AudioContext</a> to <code>closed</code>.
-              </li>
-              <li>
-                <a href="#queue">Queue a control message</a> to the
-                <a>AudioContext</a>.
-              </li>
-              <li>Return <em>promise</em>.
-              </li>
-            </ol>
-            <p>
-              Running a <a>control message</a> to close an
-              <a>BaseAudioContext</a> means running these steps on the
-              <a>rendering thread</a>:
-            </p>
-            <ol>
-              <li>Attempt to <a>release system resources</a>.
-              </li>
-              <li>Queue a task on the <a>control thread</a>'s event loop, to
-              execute these steps:
-                <ol>
-                  <li>Resolve <em>promise</em>.
-                  </li>
-                  <li>If the <a href="#widl-audiocontext-state">state</a>
-                  attribute of the <a>AudioContext</a> is not already
-                  <code>closed</code>:
-                    <ol>
-                      <li>Set the <a href="#widl-audiocontext-state">state</a>
-                      attribute of the <a>AudioContext</a> to
-                      <code>closed</code>.
-                      </li>
-                      <li>Queue a task to fire a simple event named
-                      <code>statechange</code> at the <a>AudioContext</a>
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-            <p class="note">
-              When an <a>BaseAudioContext</a> has been closed, implementation
-              can choose to aggressively release more resources than when
-              suspending.
-            </p>
-          </dd>
-          <dt>
             attribute EventHandler onstatechange
           </dt>
           <dd>
@@ -1877,6 +1800,78 @@ function setupRoutingGraph() {
               may be incremented at non-uniform time intervals, so <a href=
               "#widl-AudioContext-outputLatency"><code>outputLatency</code></a>
               attribute should be used instead.
+            </p>
+          </dd>
+          <dt>
+            Promise&lt;void&gt; close()
+          </dt>
+          <dd>
+            <p>
+              Closes the <a>AudioContext</a>, <a>releasing the system
+              resources</a> it's using. This will not automatically release all
+              <a>AudioContext</a>-created objects, but will suspend the
+              progression of the <a><code>AudioContext</code></a>'s <a href=
+              "#widl-AudioContext-currentTime">currentTime</a>, and stop
+              processing audio data.
+            </p>
+            <p>
+              <span class="synchronous">When close is called, execute these
+              steps:</span>
+            </p>
+            <ol>
+              <li>Let <em>promise</em> be a new Promise.
+              </li>
+              <li>If the <em>control thread state</em> flag on the
+              <a>AudioContext</a> is <code>closed</code> reject the promise
+              with <code>InvalidStateError</code>, abort these steps, returning
+              <em>promise</em>.
+              </li>
+              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
+              of the <a>AudioContext</a> is already <code>closed</code>,
+              resolve <em>promise</em>, return it, and abort these steps.
+              </li>
+              <li>Set the <em>control thread state</em> flag on the
+              <a>AudioContext</a> to <code>closed</code>.
+              </li>
+              <li>
+                <a href="#queue">Queue a control message</a> to the
+                <a>AudioContext</a>.
+              </li>
+              <li>Return <em>promise</em>.
+              </li>
+            </ol>
+            <p>
+              Running a <a>control message</a> to close an <a>AudioContext</a>
+              means running these steps on the <a>rendering thread</a>:
+            </p>
+            <ol>
+              <li>Attempt to <a>release system resources</a>.
+              </li>
+              <li>Queue a task on the <a>control thread</a>'s event loop, to
+              execute these steps:
+                <ol>
+                  <li>Resolve <em>promise</em>.
+                  </li>
+                  <li>If the <a href="#widl-audiocontext-state">state</a>
+                  attribute of the <a>AudioContext</a> is not already
+                  <code>closed</code>:
+                    <ol>
+                      <li>Set the <a href="#widl-audiocontext-state">state</a>
+                      attribute of the <a>AudioContext</a> to
+                      <code>closed</code>.
+                      </li>
+                      <li>Queue a task to fire a simple event named
+                      <code>statechange</code> at the <a>AudioContext</a>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+            <p class="note">
+              When an <a>AudioContext</a> has been closed, implementation can
+              choose to aggressively release more resources than when
+              suspending.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
Having close() be in BaseAudioContext is a little confusing because
you can't close an OfflineAudioContext.

Move close() to the AudioContext instead.