### PR TITLE
Fix #924: Changing fftSize of Analyser

### DIFF
--- a/index.html
+++ b/index.html
@@ -6558,6 +6558,15 @@ function calculateNormalizationScale(buffer)
               thrown</span>. The default value is 2048. Note that large FFT
               sizes can be costly to compute.
             </p>
+            <p>
+              If the <code>fftSize</code> is changed, then all state associated
+              with smoothing of the frequency data (for <a href=
+              "#widl-AnalyserNode-getByteFrequencyData-void-Uint8Array-array"><code>
+              getByteFrequencyData</code></a> and <a href=
+              "#widl-AnalyserNode-getFloatFrequencyData-void-Float32Array-array">
+              <code>getFloatFrequencyData</code></a>) is reset, as if a new
+              <a>AnalyserNode</a> were created with the new size.
+            </p>
           </dd>
           <dt>
             readonly attribute unsigned long frequencyBinCount


### PR DESCRIPTION
If the fftSize is changed, reset the internal state for the FFT
computations as if a new AnalyserNode were created.