### PR TITLE
Consistently use IsDetachedBuffer and link to the spec when referencing a detach operation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3942,13 +3942,17 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           operation occurs on an <a>AudioBuffer</a>, run the following steps:
         </p>
         <ol>
-          <li>If any of the <a>AudioBuffer</a>'s <code>ArrayBuffer</code> have
-          been <em>detached</em>, abort these steps, and return a zero-length
+          <li>If the operation <a href=
+          "https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
+          on any of the <a>AudioBuffer</a>'s <code>ArrayBuffer</code> return
+          <code>true</code>, abort these steps, and return a zero-length
           channel data buffers to the invoker.
           </li>
           <li>
-            <em>Detach</em>all <code>ArrayBuffer</code>s for arrays previously
-            returned by <code>getChannelData</code> on this <a>AudioBuffer</a>.
+            <a href=
+            "https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
+            all <code>ArrayBuffer</code>s for arrays previously returned by
+            <code>getChannelData</code> on this <a>AudioBuffer</a>.
           </li>
           <li>Retain the underlying data buffers from those
           <code>ArrayBuffer</code>s and return references to them to the


### PR DESCRIPTION
There is no facility in WebIDL for now to check if a buffer has been detached, so we're using ES's concepts.
 
This fixes #687.