### PR TITLE
 Spec which track to use when using MediaStreamAudioSourceNode, and introduce MediaStreamTrackAudioSourceNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -9605,10 +9605,17 @@ odd function with period \(2\pi\).
         </h2>
         <p>
           This interface represents an audio source from a
-          <code>MediaStream</code>. The first
-          <code>AudioMediaStreamTrack</code> from the <code>MediaStream</code>
-          will be used as a source of audio. Those interfaces are described in
-          [[!mediacapture-streams]].
+          <code>MediaStream</code>. The track that will be used as the source of
+          audio and will be output from this node is the first
+          <code>AudioMediaStreamTrack</code>, when alphabetically sorting the
+          tracks of this <code>MediaStream</code> by their <code>id</code>
+          attribute.  will be used as a source of audio. Those interfaces are
+          described in [[!mediacapture-streams]].
+        </p>
+        <p class="note">
+          The behaviour for picking the track to output is weird for legacy
+          reasons. <a>MediaStreamTrackAudioSourceNode</a> should be used
+          instead.
         </p>
         <pre>
     numberOfInputs  : 0

--- a/index.html
+++ b/index.html
@@ -1991,7 +1991,7 @@ function setupRoutingGraph() {
             </dl>
           </dd>
           <dt>
-            MediaStreamTrackAudioSourceNode createMediaStreamSource()
+            MediaStreamTrackAudioSourceNode createMediaStreamTrackSource()
           </dt>
           <dd>
             <p>

--- a/index.html
+++ b/index.html
@@ -272,12 +272,14 @@
             element</a>.
           </li>
           <li>Processing live audio input using a <a href=
-          "#MediaStreamAudioSourceNode">MediaStream</a> from getUserMedia().
+          "#MediaStreamTrackAudioSourceNode">MediaStream</a> from
+          getUserMedia().
           </li>
           <li>Integration with WebRTC
             <ul>
               <li>Processing audio received from a remote peer using a
-              <a><code>MediaStreamAudioSourceNode</code></a> and [[!webrtc]].
+              <a><code>MediaStreamTrackAudioSourceNode</code></a> and
+              [[!webrtc]].
               </li>
               <li>Sending a generated or processed audio stream to a remote
               peer using a <a><code>MediaStreamAudioDestinationNode</code></a>
@@ -656,6 +658,10 @@ function setupRoutingGraph() {
           <li>A <a><code>MediaStreamAudioSourceNode</code></a> interface, an
           <a><code>AudioNode</code></a> which is the audio source from a
           MediaStream such as live audio input, or from a remote peer.
+          </li>
+          <li>A <a><code>MediaStreamTrackAudioSourceNode</code></a> interface,
+          an <a><code>AudioNode</code></a> which is the audio source from a
+          <code>MediaStreamTrack</code>.
           </li>
           <li>A <a><code>MediaStreamAudioDestinationNode</code></a> interface,
           an <a><code>AudioNode</code></a> which is the audio destination to a
@@ -1981,6 +1987,22 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The media stream that will act as source.
+              </dd>
+            </dl>
+          </dd>
+          <dt>
+            MediaStreamTrackAudioSourceNode createMediaStreamSource()
+          </dt>
+          <dd>
+            <p>
+              Creates a <a><code>MediaStreamAudioSourceNode</code></a>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                AudioMediaStreamTrack mediaStreamTrack
+              </dt>
+              <dd>
+                The audio media stream track that will act as source.
               </dd>
             </dl>
           </dd>
@@ -9605,11 +9627,11 @@ odd function with period \(2\pi\).
         </h2>
         <p>
           This interface represents an audio source from a
-          <code>MediaStream</code>. The track that will be used as the source of
-          audio and will be output from this node is the first
+          <code>MediaStream</code>. The track that will be used as the source
+          of audio and will be output from this node is the first
           <code>AudioMediaStreamTrack</code>, when alphabetically sorting the
           tracks of this <code>MediaStream</code> by their <code>id</code>
-          attribute.  will be used as a source of audio. Those interfaces are
+          attribute. will be used as a source of audio. Those interfaces are
           described in [[!mediacapture-streams]].
         </p>
         <p class="note">
@@ -9648,6 +9670,48 @@ odd function with period \(2\pi\).
             <dd>
               The media stream that will act as a source. This MUST be
               specified.
+            </dd>
+          </dl>
+        </section>
+      </section>
+      <section>
+        <h2 id="MediaStreamTrackAudioSourceNode">
+          The MediaStreamTrackAudioSourceNode Interface
+        </h2>
+        <p>
+          This interface represents an audio source from a
+          <code>AudioMediaStreamTrack</code>.
+        </p>
+        <pre>
+    numberOfInputs  : 0
+    numberOfOutputs : 1
+</pre>
+        <p>
+          The number of channels of the output corresponds to the number of
+          channels of the <code>AudioMediaStreamTrack</code>.
+        </p>
+        <p>
+          This node has no <a>tail-time</a> reference.
+        </p>
+        <dl title=
+        "[Constructor(AudioContext context, MediaStreamTrackAudioSourceOptions options)]interface MediaStreamTrackAudioSourceNode : AudioNode"
+        class="idl"></dl>
+        <section>
+          <h2>
+            MediaStreamTrackAudioSourceOptions
+          </h2>
+          <p>
+            This specifies the options for constructing a
+            <a><code>MediaStreamTrackAudioSourceNode</code></a>. This is
+            required.
+          </p>
+          <dl title="dictionary MediaStreamTrackAudioSourceOptions" class=
+          "idl">
+            <dt>
+              required AudioMediaStreamTrack mediaStreamTrack
+            </dt>
+            <dd>
+              The audio media stream track that will act as a source.
             </dd>
           </dl>
         </section>
@@ -11152,7 +11216,8 @@ function coneGain() {
           <li>The <a>DynamicsCompressorNode</a> has a look ahead algorithm that
           causes delay in the signal path.
           </li>
-          <li>The <a>MediaStreamAudioSourceNode</a> and
+          <li>The <a>MediaStreamAudioSourceNode</a>,
+          <a>MediaStreamTrackAudioSourceNode</a> and
           <a>MediaStreamAudioDestinationNode</a>, depending on the
           implementation, can add buffers internally that add delays.
           </li>


### PR DESCRIPTION
We needed a arbitrary but stable order, so I did what I could.

Also, multi-track MediaStream are not that common these days, so changing this is probably safe. People who rely on the order for multi-track stream are going to be using the new Node.
