### PR TITLE
Fix #980: buffer in constructors is nullable

### DIFF
--- a/index.html
+++ b/index.html
@@ -4319,7 +4319,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </p>
           <dl title="dictionary AudioBufferSourceOptions" class="idl">
             <dt>
-              AudioBuffer buffer
+              AudioBuffer? buffer
             </dt>
             <dd>
               The audio asset to be played. This is equivalent to assigning
@@ -6361,7 +6361,7 @@ function calculateNormalizationScale(buffer)
           <dl title="dictionary ConvolverOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              AudioBuffer buffer
+              AudioBuffer? buffer
             </dt>
             <dd>
               The desired buffer for the <a><code>ConvolverNode</code></a>.


### PR DESCRIPTION
AudioBufferSourceOptions.buffer and ConvolverOptions.buffer can null
when used to construct the corresponding nodes.  Make it explicit.