### PR TITLE
Allow collecting MediaStreamAudioSourceNode or MediaElementAudioSourceNode when they won't play ever again.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2795,6 +2795,30 @@ function setupRoutingGraph() {
             <a><code>AudioNode</code></a>s have this property. Please see
             details for specific nodes.
             </li>
+            <li>
+              <code>MediaStream</code>s keep a
+              <a>MediaStreamAudioSourceNode</a> alive as long as the underlying
+              <code>MediaStreamTrack</code> that is playing through the
+              <a>MediaStreamAudioSourceNode</a> have not <a href=
+              "https://w3c.github.io/mediacapture-main/#track-ended">ended</a>
+              (as per [[!mediacapture-streams]]).
+            </li>
+            <li>
+              <code>HTMLMediaElement</code>s keep their associated
+              <a>MediaElementAudioSourceNode</a> alive as long as the
+              <a>HTMLMediaElement</a> is in a state where audio could ever be
+              played in the future.
+              <div class="note">
+                <p>
+                  An <code>HTMLMediaElement</code> that has its
+                  <code>src</code> attribute set to <code>""</code>, and all
+                  its references dropped allows the
+                  <a>MediaElementAudioSourceNode</a> to be released as well
+                  (granted nothing keeps the <a>MediaElementAudioSourceNode</a>
+                  alive).
+                </p>
+              </div>
+            </li>
           </ol>
           <p>
             Any <a><code>AudioNode</code></a>s which are connected in a cycle
@@ -4439,9 +4463,8 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           The number of channels of the output corresponds to the number of
           channels of the media referenced by the
           <code>HTMLMediaElement</code>. Thus, changes to the media element's
-          .src attribute can change the number of channels output by this node.
-          If the .src attribute is not set, then the number of channels output
-          will be one silent channel.
+          <code>src</code> attribute can change the number of channels output
+          by this node.
         </p>
         <p>
           This node has no <a>tail-time</a> reference.


### PR DESCRIPTION
This fixes #822.