### PR TITLE
Fix #981: Use required syntax for required dictionary members

### DIFF
--- a/index.html
+++ b/index.html
@@ -4610,11 +4610,11 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           </h2>
           <p>
             This specifies the options to use in constructing a
-            <a><code>MediaElementAudioSourceNode</code></a>. This is required.
+            <a><code>MediaElementAudioSourceNode</code></a>.
           </p>
           <dl title="dictionary MediaElementAudioSourceOptions" class="idl">
             <dt>
-              HTMLMediaElement mediaElement
+              required HTMLMediaElement mediaElement
             </dt>
             <dd>
               The media element that will be re-routed. This MUST be specified.
@@ -8920,11 +8920,11 @@ odd function with period \(2\pi\).
           </h2>
           <p>
             This specifies the options for constructing a
-            <a><code>MediaStreamAudioSourceNode</code></a>. This is required.
+            <a><code>MediaStreamAudioSourceNode</code></a>.
           </p>
           <dl title="dictionary MediaStreamAudioSourceOptions" class="idl">
             <dt>
-              MediaStream mediaStream
+              required MediaStream mediaStream
             </dt>
             <dd>
               The media stream that will act as a source. This MUST be

--- a/index.html
+++ b/index.html
@@ -4021,7 +4021,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               The number of channels for the buffer.
             </dd>
             <dt>
-              unsigned long length
+              required unsigned long length
             </dt>
             <dd>
               The length in sample frames of the buffer.
@@ -8144,7 +8144,7 @@ $$
           <dl title="dictionary IIRFilterOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              sequence&lt;double&gt; feedforward
+              required sequence&lt;double&gt; feedforward
             </dt>
             <dd>
               The feedforward coefficients for the
@@ -8152,7 +8152,7 @@ $$
               not specifed, a NotFoundError MUST be thrown.
             </dd>
             <dt>
-              sequence&lt;double&gt; feedback
+              required sequence&lt;double&gt; feedback
             </dt>
             <dd>
               The feedback coefficients for the


### PR DESCRIPTION
I think only only AudioBufferOptions and IIRFilterOptions have
required members.

PeriodicWaveOptions requires one of real and/or imag to be specified,
but I don't think that can be specified via IDL, so I'm leaving that
out.