### PR TITLE
Fix #929: Remove sentence on mixing the input

### DIFF
--- a/index.html
+++ b/index.html
@@ -8957,9 +8957,7 @@ odd function with period \(2\pi\).
     channelInterpretation = "speakers";
 </pre>
         <p>
-          The number of channels of the input is by default 2 (stereo). Any
-          connections to the input are up-mixed/down-mixed to the number of
-          channels of the input.
+          The number of channels of the input is by default 2 (stereo).
         </p>
         <dl title=
         "[Constructor(AudioContext context, optional AudioNodeOptions options)]interface MediaStreamAudioDestinationNode : AudioNode"


### PR DESCRIPTION
Not needed because inputs are always mixed according to the mixing
rules.