### PR TITLE
Fix #850: Allow setTargetAtTime timeConstant to be 0

### DIFF
--- a/index.html
+++ b/index.html
@@ -3536,8 +3536,8 @@ function setupRoutingGraph() {
                 The time-constant value of first-order filter (exponential)
                 approach to the target value. The larger this value is, the
                 slower the transition will be. <span class="synchronous">The
-                value must be strictly positive or a TypeError exception MUST
-                be thrown.</span>
+                value must be non-negative or a TypeError exception MUST be
+                thrown.</span>
                 <p>
                   More precisely, <em>timeConstant</em> is the time it takes a
                   first-order linear continuous time-invariant system to reach

--- a/index.html
+++ b/index.html
@@ -3555,7 +3555,8 @@ function setupRoutingGraph() {
                 approach to the target value. The larger this value is, the
                 slower the transition will be. <span class="synchronous">The
                 value must be non-negative or a TypeError exception MUST be
-                thrown.</span>
+                thrown.</span> If <code>timeConstant</code> is zero, the output
+                value jumps immediately to the final value.
                 <p>
                   More precisely, <em>timeConstant</em> is the time it takes a
                   first-order linear continuous time-invariant system to reach


### PR DESCRIPTION
Change the text to say that it must be non-negative instead of
strictly positive.

The formula when the time constant is 0 is pretty well-defined if the limit
is taken, so no text is added to indicate what happens.