### PR TITLE
Small improvement on Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: cpp
 sudo: false
 install:
-# - curl https://cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz | tar xzf -
-# - make cmake="$PWD/cmake-3.3.1-Linux-x86_64/bin/cmake" install_tidy
   - wget http://binaries.html-tidy.org/binaries/tidy-5.2.0/tidy-5.2.0-64bit.rpm
   - rpm -i tidy-5.2.0-64bit.rpm
 script:
-  - make check
+  - tidy -quiet -config tidyconf.txt index.html | sed -f fixup.sed | diff -U8 index.html -
 branches:
   only:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
-# Travis CI + HTML Tidy 5.2 for Web Audio API.
-
 language: cpp
 sudo: false
 addons:
   apt:
     packages:
-      - tidy
-#install:
-#  - make install_tidy
+      - cmake
 script:
-#  - make check
-#  - tidy -quiet -config tidyconf.txt index.html | sed -f fixup.sed | diff -U8 index.html -
-  - tidy --version
-  - tidy-html5 --version
+  - make check
 branches:
   only:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 addons:
   apt:
     packages:
-      - tidy-html5
+      - tidy
 #install:
 #  - make install_tidy
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ addons:
 #  - make install_tidy
 script:
 #  - make check
-  - tidy -quiet -config tidyconf.txt index.html | sed -f fixup.sed | diff -U8 index.html -
+#  - tidy -quiet -config tidyconf.txt index.html | sed -f fixup.sed | diff -U8 index.html -
+  - tidy --version
+  - tidy-html5 --version
 branches:
   only:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: cpp
 sudo: false
 install:
- - curl https://cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz | tar xzf -
- - make cmake="$PWD/cmake-3.3.1-Linux-x86_64/bin/cmake" install_tidy
+# - curl https://cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz | tar xzf -
+# - make cmake="$PWD/cmake-3.3.1-Linux-x86_64/bin/cmake" install_tidy
+  - wget http://binaries.html-tidy.org/binaries/tidy-5.2.0/tidy-5.2.0-64bit.rpm
+  - rpm -i tidy-5.2.0-64bit.rpm
 script:
   - make check
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
+# Travis CI + HTML Tidy 5.2 for Web Audio API.
+
 language: cpp
 sudo: false
+addons:
+  apt:
+    packages:
+      - cmake
 install:
-  - wget http://binaries.html-tidy.org/binaries/tidy-5.2.0/tidy-5.2.0-64bit.rpm
-  - rpm -i tidy-5.2.0-64bit.rpm
+  - make install_tidy
 script:
-  - tidy -quiet -config tidyconf.txt index.html | sed -f fixup.sed | diff -U8 index.html -
+  - make check
 branches:
   only:
     - gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: false
 addons:
   apt:
     packages:
-      - cmake
-install:
-  - make install_tidy
+      - tidy-html5
+#install:
+#  - make install_tidy
 script:
   - make check
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ addons:
 #install:
 #  - make install_tidy
 script:
-  - make check
+#  - make check
+  - tidy -quiet -config tidyconf.txt index.html | sed -f fixup.sed | diff -U8 index.html -
 branches:
   only:
     - gh-pages


### PR DESCRIPTION
I've included the cmake as a package to the docker build script. This is supposed to speed up the installation process a bit. Here is my founding along the way:

1. Unfortunately we can't install htm-tidy 5.2 through apt-get. It seems like not accessible in Ubuntu 'precise-update' version which is the current docker image.
2. With `sudo`, we can actually fetch the external binary of tidy and install with `dpkg` - but we can't use `sudo` in the docker-based travis worker. So...