### PR TITLE
Fix #997: Add defaults to dictionary members

### DIFF
--- a/index.html
+++ b/index.html
@@ -3897,7 +3897,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </p>
           <dl title="dictionary GainOptions : AudioNodeOptions" class="idl">
             <dt>
-              float gain
+              float gain = 1
             </dt>
             <dd>
               The initial gain value for the <a href=
@@ -4001,7 +4001,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               The maximum delay time for the node.
             </dd>
             <dt>
-              double delayTime
+              double delayTime = 0
             </dt>
             <dd>
               The initial delay time for the node
@@ -4558,7 +4558,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           </p>
           <dl title="dictionary AudioBufferSourceOptions" class="idl">
             <dt>
-              AudioBuffer? buffer
+              AudioBuffer? buffer = null
             </dt>
             <dd>
               The audio asset to be played. This is equivalent to assigning
@@ -4567,7 +4567,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               attribute of the <a>AudioBufferSourceNode</a>.
             </dd>
             <dt>
-              float detune
+              float detune = 0
             </dt>
             <dd>
               The initial value for the <a href=
@@ -4575,7 +4575,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               AudioParam.
             </dd>
             <dt>
-              boolean loop
+              boolean loop = false
             </dt>
             <dd>
               The initial value for the <a href=
@@ -4583,7 +4583,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               attribute.
             </dd>
             <dt>
-              double loopEnd
+              double loopEnd = 0
             </dt>
             <dd>
               The initial value for the <a href=
@@ -4591,7 +4591,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               attribute.
             </dd>
             <dt>
-              double loopStart
+              double loopStart = 0
             </dt>
             <dd>
               The initial value for the <a href=
@@ -4599,7 +4599,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               attribute.
             </dd>
             <dt>
-              float playbackRate
+              float playbackRate = 1
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6226,19 +6226,19 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           </p>
           <dl title="dictionary PannerOptions : AudioNodeOptions" class="idl">
             <dt>
-              PanningModelType panningModel
+              PanningModelType panningModel = "equalpower"
             </dt>
             <dd>
               The panning model to use for the node.
             </dd>
             <dt>
-              DistanceModelType distanceModel
+              DistanceModelType distanceModel = "inverse"
             </dt>
             <dd>
               The distance model to use for the node.
             </dd>
             <dt>
-              float positionX
+              float positionX = 0
             </dt>
             <dd>
               The initial X value for the <a href=
@@ -6246,7 +6246,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               AudioParam.
             </dd>
             <dt>
-              float positionY
+              float positionY = 0
             </dt>
             <dd>
               The initial Y value for the <a href=
@@ -6254,7 +6254,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               AudioParam.
             </dd>
             <dt>
-              float positionZ
+              float positionZ = 0
             </dt>
             <dd>
               The initial Z value for the <a href=
@@ -6262,7 +6262,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               AudioParam.
             </dd>
             <dt>
-              float orientationX
+              float orientationX = 1
             </dt>
             <dd>
               The initial X value for the <a href=
@@ -6270,7 +6270,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               AudioParam.
             </dd>
             <dt>
-              float orientationY
+              float orientationY = 0
             </dt>
             <dd>
               The initial Y value for the <a href=
@@ -6278,7 +6278,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               AudioParam.
             </dd>
             <dt>
-              float orientationZ
+              float orientationZ = 0
             </dt>
             <dd>
               The initial Z value for the <a href=
@@ -6286,7 +6286,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               AudioParam.
             </dd>
             <dt>
-              double refDistance
+              double refDistance = 1
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6294,7 +6294,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               attribute of the node.
             </dd>
             <dt>
-              double maxDistance
+              double maxDistance = 10000
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6302,7 +6302,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               attribute of the node.
             </dd>
             <dt>
-              double rolloffFactor
+              double rolloffFactor = 1
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6310,7 +6310,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               attribute of the node.
             </dd>
             <dt>
-              double coneInnerAngle
+              double coneInnerAngle = 360
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6318,7 +6318,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               attribute of the node.
             </dd>
             <dt>
-              double coneOuterAngle
+              double coneOuterAngle = 360
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6326,7 +6326,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               attribute of the node.
             </dd>
             <dt>
-              double coneOuterGain
+              double coneOuterGain = 0
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6611,7 +6611,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dl title="dictionary StereoPannerOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              float pan
+              float pan = 0
             </dt>
             <dd>
               The initial value for the <a href=
@@ -6795,7 +6795,7 @@ function calculateNormalizationScale(buffer)
           <dl title="dictionary ConvolverOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              AudioBuffer? buffer
+              AudioBuffer? buffer = null
             </dt>
             <dd>
               The desired buffer for the <a><code>ConvolverNode</code></a>.
@@ -7521,7 +7521,7 @@ function calculateNormalizationScale(buffer)
           <dl title="dictionary DynamicsCompressorOptions : AudioNodeOptions"
           class="idl">
             <dt>
-              float attack
+              float attack = 0.003
             </dt>
             <dd>
               The initial value for the <a href=
@@ -7529,7 +7529,7 @@ function calculateNormalizationScale(buffer)
               AudioParam.
             </dd>
             <dt>
-              float knee
+              float knee = 30
             </dt>
             <dd>
               The initial value for the <a href=
@@ -7537,7 +7537,7 @@ function calculateNormalizationScale(buffer)
               AudioParam.
             </dd>
             <dt>
-              float ratio
+              float ratio = 12
             </dt>
             <dd>
               The initial value for the <a href=
@@ -7545,7 +7545,7 @@ function calculateNormalizationScale(buffer)
               AudioParam.
             </dd>
             <dt>
-              float release
+              float release = 0.25
             </dt>
             <dd>
               The initial value for the <a href=
@@ -7553,7 +7553,7 @@ function calculateNormalizationScale(buffer)
               AudioParam.
             </dd>
             <dt>
-              float threshold
+              float threshold = -24
             </dt>
             <dd>
               The initial value for the <a href=
@@ -8048,31 +8048,31 @@ function calculateNormalizationScale(buffer)
           <dl title="dictionary BiquadFilterOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              BiquadFilterType type
+              BiquadFilterType type = "lowpass"
             </dt>
             <dd>
               The desired initial type of the filter.
             </dd>
             <dt>
-              float Q
+              float Q = 1
             </dt>
             <dd>
               The desired initial value for <a><code>Q</code></a>.
             </dd>
             <dt>
-              float detune
+              float detune = 0
             </dt>
             <dd>
               The desired initial value for <a><code>detune</code></a>.
             </dd>
             <dt>
-              float frequency
+              float frequency = 350
             </dt>
             <dd>
               The desired initial value for <a><code>frequency</code></a>.
             </dd>
             <dt>
-              float gain
+              float gain = 0
             </dt>
             <dd>
               The desired initial value for <a><code>gain</code></a>.
@@ -8591,13 +8591,13 @@ $$
           <dl title="dictionary WaveShaperOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              sequence&lt;float&gt; curve
+              sequence&lt;float&gt;? curve = null
             </dt>
             <dd>
               The shaping curve for the waveshaping effect.
             </dd>
             <dt>
-              OverSampleType oversample
+              OverSampleType oversample = "none"
             </dt>
             <dd>
               The type of oversampling to use for the shaping curve.
@@ -8828,7 +8828,7 @@ $$
           <dl title="dictionary OscillatorOptions : AudioNodeOptions" class=
           "idl">
             <dt>
-              OscillatorType type
+              OscillatorType type = "sine"
             </dt>
             <dd>
               The type of oscillator to be constructed. If this is set to
@@ -8837,20 +8837,20 @@ $$
               exception MUST be thrown.
             </dd>
             <dt>
-              float frequency
+              float frequency = 440
             </dt>
             <dd>
               The initial frequency for the <a><code>OscillatorNode</code></a>.
             </dd>
             <dt>
-              float detune
+              float detune = 0
             </dt>
             <dd>
               The initial detune value for the
               <a><code>OscillatorNode</code></a>.
             </dd>
             <dt>
-              PeriodicWave periodicWave
+              PeriodicWave? periodicWave = null
             </dt>
             <dd>
               The <a><code>PeriodicWave</code></a> for the


### PR DESCRIPTION
Defaults added for all dictionary members that could be defaulted.
Also fixed a couple of places where the member could be null, like for
the convolver buffer, the wave shaper curve, the oscillator
periodicwave wave.