### PR TITLE
Fix #1014: Use correct nominal range for ConstantSourceNode.offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -4689,8 +4689,8 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           <dd>
             <p>
               The constant value of the source. Its default value is 1. This
-              parameter is <a>a-rate</a>. Its nominal range is \([-\infty,
-              \infty]\).
+              parameter is <a>a-rate</a>. Its nominal range is \((-\infty,
+              \infty)\).
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
The correct range is (-infty, infty); infinity is not allowed as a
value for the offset.