### PR TITLE
Define circular routing lifetime correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -3018,8 +3018,9 @@ function setupRoutingGraph() {
           </ol>
           <p>
             Any <a><code>AudioNode</code></a>s which are connected in a cycle
-            <em>and</em> are directly or indirectly connected to the
-            <a><code>AudioDestinationNode</code></a> of the
+            <em>and</em> are directly or indirectly connected to a
+            <a><code>AudioDestinationNode</code></a> or
+            <a>MediaStreamAudioDestinationNode</a> within the
             <a><code>AudioContext</code></a> will stay alive as long as the
             <a><code>AudioContext</code></a> is alive.
           </p>


### PR DESCRIPTION
This addresses #452 which pointed out that MediaStreamAudioDestinationNode also creates a valid sink causing attached cyclic graphs to be retained.