### PR TITLE
Fix #915 The case for sample-accurate start()

### DIFF
--- a/index.html
+++ b/index.html
@@ -4444,7 +4444,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               between 0 and the duration of the buffer. If
               <code>loopStart</code> is less than 0, looping will begin at 0.
               If <code>loopStart</code> is greater than the duration of the
-              buffer, looping will begin at the end of the buffer.
+              buffer, looping will begin at the end of the buffer. Its behavior is 
+              independent of the value of the <a href="#widl-AudioBufferSourceNode-
+              playbackRate"><code>playbackRate</code></a> parameter.
             </p>
           </dd>
           <dt>
@@ -4461,7 +4463,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               between 0 and the duration of the buffer. If <code>loopEnd</code>
               is less than 0, looping will end at 0. If <code>loopEnd</code> is
               greater than the duration of the buffer, looping will end at the
-              end of the buffer.
+              end of the buffer. Its behavior is independent of the value of 
+              the <a href="#widl-AudioBufferSourceNode-playbackRate">
+              <code>playbackRate</code></a> parameter.
             </p>
           </dd>
           <dt>
@@ -4507,6 +4511,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 is the value of the <code>duration</code> attribute of the
                 <code>AudioBuffer</code> set to the <code>buffer</code>
                 attribute of this <code>AudioBufferSourceNode</code>.
+                Its behavior is independent of the value of the <a href="#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a> parameter.
               </dd>
               <dt>
                 optional double duration

--- a/index.html
+++ b/index.html
@@ -4444,9 +4444,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               between 0 and the duration of the buffer. If
               <code>loopStart</code> is less than 0, looping will begin at 0.
               If <code>loopStart</code> is greater than the duration of the
-              buffer, looping will begin at the end of the buffer. Its behavior is 
-              independent of the value of the <a href="#widl-AudioBufferSourceNode-
-              playbackRate"><code>playbackRate</code></a> parameter.
+              buffer, looping will begin at the end of the buffer. Its behavior
+              is independent of the value of the <a href=
+              "#widl-AudioBufferSourceNode-%20playbackRate"><code>playbackRate</code></a>
+              parameter.
             </p>
           </dd>
           <dt>
@@ -4463,9 +4464,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               between 0 and the duration of the buffer. If <code>loopEnd</code>
               is less than 0, looping will end at 0. If <code>loopEnd</code> is
               greater than the duration of the buffer, looping will end at the
-              end of the buffer. Its behavior is independent of the value of 
-              the <a href="#widl-AudioBufferSourceNode-playbackRate">
-              <code>playbackRate</code></a> parameter.
+              end of the buffer. Its behavior is independent of the value of
+              the <a href=
+              "#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a>
+              parameter.
             </p>
           </dd>
           <dt>
@@ -4510,8 +4512,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 <code>startTime</code> is reached, where <code>duration</code>
                 is the value of the <code>duration</code> attribute of the
                 <code>AudioBuffer</code> set to the <code>buffer</code>
-                attribute of this <code>AudioBufferSourceNode</code>.
-                Its behavior is independent of the value of the <a href="#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a> parameter.
+                attribute of this <code>AudioBufferSourceNode</code>. Its
+                behavior is independent of the value of the <a href=
+                "#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a>
+                parameter.
               </dd>
               <dt>
                 optional double duration

--- a/index.html
+++ b/index.html
@@ -4444,13 +4444,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               between 0 and the duration of the buffer. If
               <code>loopStart</code> is less than 0, looping will begin at 0.
               If <code>loopStart</code> is greater than the duration of the
-              buffer, looping will begin at the end of the buffer. This
-              attribute is converted to an exact sample frame offset within the
-              buffer by multiplying by the buffer's sample rate and rounding to
-              the nearest integer value. Thus its behavior is independent of
-              the value of the <a href=
-              "#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a>
-              parameter.
+              buffer, looping will begin at the end of the buffer.
             </p>
           </dd>
           <dt>
@@ -4467,12 +4461,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               between 0 and the duration of the buffer. If <code>loopEnd</code>
               is less than 0, looping will end at 0. If <code>loopEnd</code> is
               greater than the duration of the buffer, looping will end at the
-              end of the buffer. This attribute is converted to an exact sample
-              frame offset within the buffer by multiplying by the buffer's
-              sample rate and rounding to the nearest integer value. Thus its
-              behavior is independent of the value of the <a href=
-              "#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a>
-              parameter.
+              end of the buffer.
             </p>
           </dd>
           <dt>
@@ -4517,13 +4506,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 <code>startTime</code> is reached, where <code>duration</code>
                 is the value of the <code>duration</code> attribute of the
                 <code>AudioBuffer</code> set to the <code>buffer</code>
-                attribute of this <code>AudioBufferSourceNode</code>. This
-                parameter is converted to an exact sample frame offset within
-                the buffer by multiplying by the buffer's sample rate and
-                rounding to the nearest integer value. Thus its behavior is
-                independent of the value of the <a href=
-                "#widl-AudioBufferSourceNode-playbackRate"><code>playbackRate</code></a>
-                parameter.
+                attribute of this <code>AudioBufferSourceNode</code>.
               </dd>
               <dt>
                 optional double duration


### PR DESCRIPTION
WG should we explicitly statethat this is not quantised to samples?
eg.
It is in the same time coordinate system as the AudioContext's currentTime attribute.
