### PR TITLE
Add markup around exception name.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1108,9 +1108,9 @@ function setupRoutingGraph() {
             <p>
               Creates an AudioBuffer of the given size. The audio data in the
               buffer will be zero-initialized (silent). <span class=
-              "synchronous">A NotSupportedError exception MUST be thrown if any
-              of the arguments is negative, zero, or outside its nominal
-              range.</span>
+              "synchronous">A <code>NotSupportedError</code> exception MUST be
+              thrown if any of the arguments is negative, zero, or outside its
+              nominal range.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -1304,7 +1304,7 @@ function setupRoutingGraph() {
               <a href="#AudioWorkletNode"><code>AudioWorkletNode</code></a>.
               Creates a <a><code>ScriptProcessorNode</code></a> for direct
               audio processing using JavaScript. <span class="synchronous">An
-              IndexSizeError exception MUST be thrown if
+              <code>IndexSizeError</code> exception MUST be thrown if
               <a><code>bufferSize</code></a> or
               <a><code>numberOfInputChannels</code></a> or
               <a><code>numberOfOutputChannels</code></a> are outside the valid
@@ -1335,7 +1335,7 @@ function setupRoutingGraph() {
                 pick a good buffer size to balance between <a href=
                 "#latency">latency</a> and audio quality. If the value of this
                 parameter is not one of the allowed power-of-2 values listed
-                above, an IndexSizeError MUST be thrown.
+                above, an <code>IndexSizeError</code> MUST be thrown.
               </dd>
               <dt>
                 optional unsigned long numberOfInputChannels = 2
@@ -1355,7 +1355,7 @@ function setupRoutingGraph() {
             <p>
               It is invalid for both <a><code>numberOfInputChannels</code></a>
               and <a><code>numberOfOutputChannels</code></a> to be zero. In
-              this case an IndexSizeError MUST be thrown.
+              this case an <code>IndexSizeError</code> MUST be thrown.
             </p>
           </dd>
           <dt>
@@ -1391,7 +1391,7 @@ function setupRoutingGraph() {
                 the maximum delay time in seconds allowed for the delay line.
                 <span class="synchronous">If specified, this value MUST be
                 greater than zero and less than three minutes or a
-                NotSupportedError exception MUST be thrown.</span>
+                <code>NotSupportedError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -1422,8 +1422,9 @@ function setupRoutingGraph() {
                 An array of the feedforward (numerator) coefficients for the
                 transfer function of the IIR filter. The maximum length of this
                 array is 20. If all of the values are zero, an
-                InvalidStateError MUST be thrown. A NotSupportedError MUST be
-                thrown if the array length is 0 or greater than 20.
+                InvalidStateError MUST be thrown. A
+                <code>NotSupportedError</code> MUST be thrown if the array
+                length is 0 or greater than 20.
               </dd>
               <dt>
                 sequence&lt;double&gt; feedback
@@ -1432,8 +1433,9 @@ function setupRoutingGraph() {
                 An array of the feedback (denominator) coefficients for the
                 tranfer function of the IIR filter. The maximum length of this
                 array is 20. If the first element of the array is 0, an
-                InvalidStateError MUST be thrown. A NotSupportedError MUST be
-                thrown if the array length is 0 or greater than 20.
+                InvalidStateError MUST be thrown. A
+                <code>NotSupportedError</code> MUST be thrown if the array
+                length is 0 or greater than 20.
               </dd>
             </dl>
           </dd>
@@ -1535,7 +1537,7 @@ function setupRoutingGraph() {
               "synchronous">The <code>real</code> and <code>imag</code>
               parameters must be of type <code>Float32Array</code> (described
               in [[!TYPED-ARRAYS]]) of equal lengths greater than zero or an
-              IndexSizeError exception MUST be thrown.</span> All
+              <code>IndexSizeError</code> exception MUST be thrown.</span> All
               implementations must support arrays up to at least 8192. These
               parameters specify the Fourier coefficients of a <a href=
               "https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
@@ -2051,8 +2053,8 @@ function setupRoutingGraph() {
         <p>
           The OfflineAudioContext is constructed with the same arguments as
           AudioContext.createBuffer. <span class="synchronous">A
-          NotSupportedError exception MUST be thrown if any of the arguments is
-          negative, zero, or outside its nominal range.</span>
+          <code>NotSupportedError</code> exception MUST be thrown if any of the
+          arguments is negative, zero, or outside its nominal range.</span>
         </p>
         <dl class="parameters">
           <dt>
@@ -2464,7 +2466,7 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 connect. <span class="synchronous">If this parameter is
-                out-of-bound, an IndexSizeError exception MUST be
+                out-of-bound, an <code>IndexSizeError</code> exception MUST be
                 thrown.</span> It is possible to connect an
                 <a><code>AudioNode</code></a> output to more than one input
                 with multiple calls to connect(). Thus, "fan-out" is supported.
@@ -2476,7 +2478,7 @@ function setupRoutingGraph() {
                 The <code>input</code> parameter is an index describing which
                 input of the destination <a><code>AudioNode</code></a> to
                 connect to. <span class="synchronous">If this parameter is
-                out-of-bounds, an IndexSizeError exception MUST be
+                out-of-bounds, an <code>IndexSizeError</code> exception MUST be
                 thrown.</span> It is possible to connect an
                 <a><code>AudioNode</code></a> to another
                 <a><code>AudioNode</code></a> which creates a <dfn>cycle</dfn>:
@@ -2606,7 +2608,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. It disconnects all
                 outgoing connections from the given output. <span class=
                 "synchronous">If this parameter is out-of-bounds, an
-                IndexSizeError exception MUST be thrown.</span>
+                <code>IndexSizeError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2659,7 +2661,7 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 disconnect. <span class="synchronous">If this parameter is
-                out-of-bound, an IndexSizeError exception MUST be
+                out-of-bound, an <code>IndexSizeError</code> exception MUST be
                 thrown.</span>
               </dd>
             </dl>
@@ -2691,7 +2693,7 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 disconnect. <span class="synchronous">If this parameter is
-                out-of-bound, an IndexSizeError exception MUST be
+                out-of-bound, an <code>IndexSizeError</code> exception MUST be
                 thrown.</span>
               </dd>
               <dt>
@@ -2701,7 +2703,7 @@ function setupRoutingGraph() {
                 The <code>input</code> parameter is an index describing which
                 input of the destination <a><code>AudioNode</code></a> to
                 disconnect. <span class="synchronous">If this parameter is
-                out-of-bounds, an IndexSizeError exception MUST be
+                out-of-bounds, an <code>IndexSizeError</code> exception MUST be
                 thrown.</span>
               </dd>
             </dl>
@@ -2814,7 +2816,7 @@ function setupRoutingGraph() {
               with no inputs. <span class="synchronous">If this value is set to
               zero or to a value greater than the implementation's maximum
               number of channels the implementation MUST throw a
-              NotSupportedError exception.</span>
+              <code>NotSupportedError</code> exception.</span>
             </p>
             <p>
               In addition, some nodes have additional <dfn>channelCount
@@ -3172,7 +3174,7 @@ function setupRoutingGraph() {
           where <code>numberOfChannels</code> is the number of channels
           specified when constructing the <a>OfflineAudioContext</a>. This
           value may not be changed; <span class="synchronous">a
-          NotSupportedError exception MUST be thrown if <a href=
+          <code>NotSupportedError</code> exception MUST be thrown if <a href=
           "#widl-AudioNode-channelCount">channelCount</a> is changed to a
           different value</span>.
         </p>
@@ -3306,15 +3308,16 @@ function setupRoutingGraph() {
             <span class="synchronous">If setValueCurveAtTime() is called for
             time \(T\) and duration \(D\) and there are any events having a
             time greater than \(T\), but less than \(T + D\), then a
-            NotSupportedError exception MUST be thrown.</span> In other words,
-            it's not ok to schedule a value curve during a time period
-            containing other events.
+            <code>NotSupportedError</code> exception MUST be thrown.</span> In
+            other words, it's not ok to schedule a value curve during a time
+            period containing other events.
           </li>
           <li>
-            <span class="synchronous">Similarly a NotSupportedError exception
-            MUST be thrown if any <em>automation</em> method is called at a
-            time which is inside of the time interval of a
-            <em>SetValueCurve</em> event at time T and duration D.</span>
+            <span class="synchronous">Similarly a
+            <code>NotSupportedError</code> exception MUST be thrown if any
+            <em>automation</em> method is called at a time which is inside of
+            the time interval of a <em>SetValueCurve</em> event at time T and
+            duration D.</span>
           </li>
         </ul>
         <dl title="interface AudioParam" class="idl">
@@ -3557,8 +3560,9 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The value the parameter will exponentially ramp to at the given
-                time. <span class="synchronous">A NotSupportedError exception
-                MUST be thrown if this value is equal to 0.</span>
+                time. <span class="synchronous">A
+                <code>NotSupportedError</code> exception MUST be thrown if this
+                value is equal to 0.</span>
               </dd>
               <dt>
                 double endTime
@@ -6936,16 +6940,16 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               containing the (possibly multi-channel) impulse response used by
               the <a><code>ConvolverNode</code></a>. <span class=
               "synchronous">The <code>AudioBuffer</code> must have 1, 2, or 4
-              channels or a NotSupportedError exception MUST be thrown</span>.
-              <span class="synchronous">This <a><code>AudioBuffer</code></a>
-              must be of the same sample-rate as the
-              <a><code>AudioContext</code></a> or a NotSupportedError exception
-              MUST be thrown</span>. At the time when this attribute is set,
-              the <em>buffer</em> and the state of the <em>normalize</em>
-              attribute will be used to configure the
-              <a><code>ConvolverNode</code></a> with this impulse response
-              having the given normalization. The initial value of this
-              attribute is null.
+              channels or a <code>NotSupportedError</code> exception MUST be
+              thrown</span>. <span class="synchronous">This
+              <a><code>AudioBuffer</code></a> must be of the same sample-rate
+              as the <a><code>AudioContext</code></a> or a
+              <code>NotSupportedError</code> exception MUST be thrown</span>.
+              At the time when this attribute is set, the <em>buffer</em> and
+              the state of the <em>normalize</em> attribute will be used to
+              configure the <a><code>ConvolverNode</code></a> with this impulse
+              response having the given normalization. The initial value of
+              this attribute is null.
             </p>
             <p>
               When the <code>buffer</code> has a single channel, the
@@ -7283,9 +7287,9 @@ function calculateNormalizationScale(buffer)
             <p>
               The size of the FFT used for frequency-domain analysis.
               <span class="synchronous">This must be a power of two in the
-              range 32 to 32768, otherwise an IndexSizeError exception MUST be
-              thrown</span>. The default value is 2048. Note that large FFT
-              sizes can be costly to compute.
+              range 32 to 32768, otherwise an <code>IndexSizeError</code>
+              exception MUST be thrown</span>. The default value is 2048. Note
+              that large FFT sizes can be costly to compute.
             </p>
             <p>
               If the <code>fftSize</code> is changed to a different value, then
@@ -7318,7 +7322,7 @@ function calculateNormalizationScale(buffer)
               conversion to unsigned byte values. The default value is -100.
               <span class="synchronous">If the value of this attribute is set
               to a value more than or equal to <code><a>maxDecibels</a></code>,
-              an IndexSizeError exception MUST be thrown.</span>
+              an <code>IndexSizeError</code> exception MUST be thrown.</span>
             </p>
           </dd>
           <dt>
@@ -7331,7 +7335,7 @@ function calculateNormalizationScale(buffer)
               conversion to unsigned byte values. The default value is -30.
               <span class="synchronous">If the value of this attribute is set
               to a value less than or equal to <code><a>minDecibels</a></code>,
-              an IndexSizeError exception MUST be thrown.</span>
+              an <code>IndexSizeError</code> exception MUST be thrown.</span>
             </p>
           </dd>
           <dt>
@@ -7342,8 +7346,8 @@ function calculateNormalizationScale(buffer)
               A value from 0 -&gt; 1 where 0 represents no time averaging with
               the last analysis frame. The default value is 0.8. <span class=
               "synchronous">If the value of this attribute is set to a value
-              less than 0 or more than 1, an IndexSizeError exception MUST be
-              thrown.</span>
+              less than 0 or more than 1, an <code>IndexSizeError</code>
+              exception MUST be thrown.</span>
             </p>
           </dd>
         </dl>
@@ -8630,7 +8634,8 @@ $$
               <dd>
                 This parameter specifies an output array receiving the linear
                 magnitude response values. If this array is shorter than
-                <code>frequencyHz</code> a NotSupportedError MUST be signaled.
+                <code>frequencyHz</code> a <code>NotSupportedError</code> MUST
+                be signaled.
               </dd>
               <dt>
                 Float32Array phaseResponse
@@ -8638,7 +8643,8 @@ $$
               <dd>
                 This parameter specifies an output array receiving the phase
                 response values in radians. If this array is shorter than
-                <code>frequencyHz</code> a NotSupportedError MUST be signaled.
+                <code>frequencyHz</code> a <code>NotSupportedError</code> MUST
+                be signaled.
               </dd>
             </dl>
           </dd>


### PR DESCRIPTION
This fixes #1011.

Patch written with this:

```sh
# from https://heycam.github.io/webidl/#dfn-error-names-table
EXCEPTION="IndexSizeError HierarchyRequestError WrongDocumentError InvalidCharacterError NoModificationAllowedError NotFoundError NotSupportedError InUseAttributeError InvalidStateError SyntaxError InvalidModificationError NamespaceError InvalidAccessError SecurityError NetworkError AbortError URLMismatchError QuotaExceededError TimeoutError InvalidNodeTypeError DataCloneError EncodingError NotReadableError UnknownError ConstraintError DataError TransactionInactiveError ReadOnlyError VersionError OperationError NotAllowedError"

for e in $EXCEPTION
do
  echo -n "$e: "
  egrep -c "[^>]$e[^<]" index.html
  sed -i 's/[^>]$e[^<]/ <code>$e<\/code> /g' index.html
done

make tidy
```