### PR TITLE
Use Mixin pattern for contexts

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,8 +784,8 @@ function setupRoutingGraph() {
             output latency. Lowest power consumption.
           </dd>
         </dl>
-        <dl title="interface BaseAudioContext" class="idl"
-        data-merge="DecodeSuccessCallback DecodeErrorCallback">
+        <dl title="interface BaseAudioContext" class="idl" data-merge=
+        "DecodeSuccessCallback DecodeErrorCallback">
           <dt>
             readonly attribute AudioDestinationNode destination
           </dt>
@@ -2080,7 +2080,8 @@ function setupRoutingGraph() {
             createBuffer</a> for valid sample rates.
           </dd>
         </dl>
-        <dl title='OfflineAudioContext implements BaseAudioContext' class='idl'></dl>
+        <dl title='OfflineAudioContext implements BaseAudioContext' class=
+        'idl'></dl>
         <dl title=
         '[Constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate)] interface OfflineAudioContext : EventTarget'
         class='idl'>

--- a/index.html
+++ b/index.html
@@ -784,7 +784,7 @@ function setupRoutingGraph() {
             output latency. Lowest power consumption.
           </dd>
         </dl>
-        <dl title="interface BaseAudioContext : EventTarget" class="idl"
+        <dl title="interface BaseAudioContext" class="idl"
         data-merge="DecodeSuccessCallback DecodeErrorCallback">
           <dt>
             readonly attribute AudioDestinationNode destination
@@ -898,101 +898,6 @@ function setupRoutingGraph() {
               internally and can process and output audio every 128 sample
               frames, then the processing latency is \((2\cdot128)/44100 =
               5.805 \mathrm{ ms}\), approximately.
-            </p>
-          </dd>
-          <dt>
-            Promise&lt;void&gt; suspend()
-          </dt>
-          <dd>
-            <p>
-              Suspends the progression of
-              <a><code>BaseAudioContext</code></a>'s <a href=
-              "#widl-BaseAudioContext-currentTime">currentTime</a>, allows any
-              current context processing blocks that are already processed to
-              be played to the destination, and then allows the system to
-              release its claim on audio hardware. This is generally useful
-              when the application knows it will not need the
-              <a>BaseAudioContext</a> for some time, and wishes to temporarily
-              <a>release system resource</a> associated with the
-              <a>BaseAudioContext</a>. The promise resolves when the frame
-              buffer is empty (has been handed off to the hardware), or
-              immediately (with no other effect) if the context is already
-              <code>suspended</code>. The promise is rejected if the context
-              has been closed.
-            </p>
-            <p>
-              <span class="synchronous">When suspend is called, execute these
-              steps:</span>
-            </p>
-            <ol>
-              <li>Let <em>promise</em> be a new Promise.
-              </li>
-              <li>If the <em>control thread state</em> flag on the
-              <a>AudioContext</a> is <code>closed</code> reject the promise
-              with <code>InvalidStateError</code>, abort these steps, returning
-              <em>promise</em>.
-              </li>
-              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
-              of the <a>AudioContext</a> is already <code>suspended</code>,
-              resolve <em>promise</em>, return it, and abort these steps.
-              </li>
-              <li>Set the <em>control thread state</em> flag on the
-              <a>AudioContext</a> to <code>suspended</code>.
-              </li>
-              <li>
-                <a href="#queue">Queue a control message</a> to suspend the
-                <a>AudioContext</a>.
-              </li>
-              <li>Return <em>promise</em>.
-              </li>
-            </ol>
-            <p>
-              Running a <a>control message</a> to suspend an
-              <a>AudioContext</a> means running these steps on the <a>rendering
-              thread</a>:
-            </p>
-            <ol>
-              <li>Attempt to <a>release system resources</a>.
-              </li>
-              <li>Set the <a>rendering thread state</a> on the
-              <a>AudioContext</a> to <code>suspended</code>.
-              </li>
-              <li>Queue a task on the <a>control thread</a>'s event loop, to
-              execute these steps:
-                <ol>
-                  <li>Resolve <em>promise</em>.
-                  </li>
-                  <li>If the <a href="#widl-audiocontext-state">state</a>
-                  attribute of the <a>AudioContext</a> is not already
-                  <code>suspended</code>:
-                    <ol>
-                      <li>Set the <a href="#widl-audiocontext-state">state</a>
-                      attribute of the <a>AudioContext</a> to
-                      <code>suspended</code>.
-                      </li>
-                      <li>Queue a task to fire a simple event named
-                      <code>statechange</code> at the <a>AudioContext</a>
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-            <p>
-              While a <a>BaseAudioContext</a> is suspended,
-              <code>MediaStream</code>s will have their output ignored; that
-              is, data will be lost by the real time nature of media streams.
-              <code>HTMLMediaElement</code>s will similarly have their output
-              ignored until the system is resumed.
-              <a>AudioWorkletProcessor</a>s and <a>ScriptProcessorNode</a>s
-              will cease to have their processing handlers invoked while
-              suspended, but will resume when resumed. For the purpose of
-              <a>AnalyserNode</a> window functions, the data is considered as a
-              continuous stream - i.e. the
-              <code>resume()</code>/<code>suspend()</code> does not cause
-              silence to appear in the <a>AnalyserNode</a>'s stream of data. In
-              particular, calling <a>AnalyserNode</a> functions repeatedly when
-              a <a>BaseAudioContext</a> is suspended MUST return the same data.
             </p>
           </dd>
           <dt>
@@ -1707,8 +1612,9 @@ function setupRoutingGraph() {
           "https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">
           triggered by a user activation</a> (as described in [[HTML]]).
         </p>
+        <dl title='AudioContext implements BaseAudioContext' class='idl'></dl>
         <dl title=
-        '[Constructor(optional AudioContextOptions contextOptions)] interface AudioContext : BaseAudioContext'
+        '[Constructor(optional AudioContextOptions contextOptions)] interface AudioContext : EventTarget'
         class='idl'>
           <dt>
             Constructor
@@ -1858,6 +1764,101 @@ function setupRoutingGraph() {
               may be incremented at non-uniform time intervals, so <a href=
               "#widl-AudioContext-outputLatency"><code>outputLatency</code></a>
               attribute should be used instead.
+            </p>
+          </dd>
+          <dt>
+            Promise&lt;void&gt; suspend()
+          </dt>
+          <dd>
+            <p>
+              Suspends the progression of
+              <a><code>BaseAudioContext</code></a>'s <a href=
+              "#widl-BaseAudioContext-currentTime">currentTime</a>, allows any
+              current context processing blocks that are already processed to
+              be played to the destination, and then allows the system to
+              release its claim on audio hardware. This is generally useful
+              when the application knows it will not need the
+              <a>BaseAudioContext</a> for some time, and wishes to temporarily
+              <a>release system resource</a> associated with the
+              <a>BaseAudioContext</a>. The promise resolves when the frame
+              buffer is empty (has been handed off to the hardware), or
+              immediately (with no other effect) if the context is already
+              <code>suspended</code>. The promise is rejected if the context
+              has been closed.
+            </p>
+            <p>
+              <span class="synchronous">When suspend is called, execute these
+              steps:</span>
+            </p>
+            <ol>
+              <li>Let <em>promise</em> be a new Promise.
+              </li>
+              <li>If the <em>control thread state</em> flag on the
+              <a>AudioContext</a> is <code>closed</code> reject the promise
+              with <code>InvalidStateError</code>, abort these steps, returning
+              <em>promise</em>.
+              </li>
+              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
+              of the <a>AudioContext</a> is already <code>suspended</code>,
+              resolve <em>promise</em>, return it, and abort these steps.
+              </li>
+              <li>Set the <em>control thread state</em> flag on the
+              <a>AudioContext</a> to <code>suspended</code>.
+              </li>
+              <li>
+                <a href="#queue">Queue a control message</a> to suspend the
+                <a>AudioContext</a>.
+              </li>
+              <li>Return <em>promise</em>.
+              </li>
+            </ol>
+            <p>
+              Running a <a>control message</a> to suspend an
+              <a>AudioContext</a> means running these steps on the <a>rendering
+              thread</a>:
+            </p>
+            <ol>
+              <li>Attempt to <a>release system resources</a>.
+              </li>
+              <li>Set the <a>rendering thread state</a> on the
+              <a>AudioContext</a> to <code>suspended</code>.
+              </li>
+              <li>Queue a task on the <a>control thread</a>'s event loop, to
+              execute these steps:
+                <ol>
+                  <li>Resolve <em>promise</em>.
+                  </li>
+                  <li>If the <a href="#widl-audiocontext-state">state</a>
+                  attribute of the <a>AudioContext</a> is not already
+                  <code>suspended</code>:
+                    <ol>
+                      <li>Set the <a href="#widl-audiocontext-state">state</a>
+                      attribute of the <a>AudioContext</a> to
+                      <code>suspended</code>.
+                      </li>
+                      <li>Queue a task to fire a simple event named
+                      <code>statechange</code> at the <a>AudioContext</a>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+            <p>
+              While a <a>BaseAudioContext</a> is suspended,
+              <code>MediaStream</code>s will have their output ignored; that
+              is, data will be lost by the real time nature of media streams.
+              <code>HTMLMediaElement</code>s will similarly have their output
+              ignored until the system is resumed.
+              <a>AudioWorkletProcessor</a>s and <a>ScriptProcessorNode</a>s
+              will cease to have their processing handlers invoked while
+              suspended, but will resume when resumed. For the purpose of
+              <a>AnalyserNode</a> window functions, the data is considered as a
+              continuous stream - i.e. the
+              <code>resume()</code>/<code>suspend()</code> does not cause
+              silence to appear in the <a>AnalyserNode</a>'s stream of data. In
+              particular, calling <a>AnalyserNode</a> functions repeatedly when
+              a <a>BaseAudioContext</a> is suspended MUST return the same data.
             </p>
           </dd>
           <dt>
@@ -2079,8 +2080,9 @@ function setupRoutingGraph() {
             createBuffer</a> for valid sample rates.
           </dd>
         </dl>
+        <dl title='OfflineAudioContext implements BaseAudioContext' class='idl'></dl>
         <dl title=
-        '[Constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate)] interface OfflineAudioContext : BaseAudioContext'
+        '[Constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate)] interface OfflineAudioContext : EventTarget'
         class='idl'>
           <dt>
             Promise&lt;AudioBuffer&gt; startRendering()
@@ -2247,8 +2249,6 @@ function setupRoutingGraph() {
             </p>
           </dd>
         </dl>
-        <dl title="[Constructor] interface AudioContext : BaseAudioContext"
-        class="idl"></dl>
         <section>
           <h2 id="OfflineAudioCompletionEvent">
             The OfflineAudioCompletionEvent Interface


### PR DESCRIPTION
PTAL. Two simple changes.
- Moved `suspend` from BAC to AC.
- Added `EventTarget` and `implements` to AC and OAC.

Having the `onstatechange` event handler while BaseAudioContext does not extend EventTarget is still weird. I believe we might have to move this to each context.

Preview: https://rawgit.com/hoch/web-audio-api/fixing-context-idl/index.html
