### PR TITLE
Small typo fix in `rolloffFactor` description

### DIFF
--- a/index.html
+++ b/index.html
@@ -6364,7 +6364,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           </dt>
           <dd>
             <p>
-              A reference distance for reducing volume as source move further
+              A reference distance for reducing volume as source moves further
               from the listener. The default value is 1.
             </p>
           </dd>
@@ -6391,7 +6391,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               the minimum and maximum values the <code>rolloffFactor</code> can
               have. Values outside the range are clamped to lie within this
               range. The nominal range depends on the <a href=
-              "#widl-PannerNode-panningModel"><code>panningModel</code></a> as
+              "#widl-PannerNode-distanceModel"><code>distanceModel</code></a> as
               follows:
             </p>
             <dl>

--- a/index.html
+++ b/index.html
@@ -1839,7 +1839,7 @@ function setupRoutingGraph() {
                 var elapsedTime = contextTime - timestamp.contextTime;
                 return timestamp.performanceTime + elapsedTime * 1000;
             }
-            </pre>
+</pre>
             <p>
               In the above example the accuracy of the estimation depends on
               how close the argument value is to the current output audio
@@ -3175,7 +3175,7 @@ function setupRoutingGraph() {
       channelCount = 2
       channelCountMode = "explicit"
       channelInterpretation = "speakers"
-        </pre>
+</pre>
         <p>
           The <a>channelCount</a> can be set to any value less than or equal to
           <a href=
@@ -3194,7 +3194,7 @@ function setupRoutingGraph() {
       channelCount = numberOfChannels
       channelCountMode = "explicit"
       channelInterpretation = "speakers"
-        </pre>
+</pre>
         <p>
           where <code>numberOfChannels</code> is the number of channels
           specified when constructing the <a>OfflineAudioContext</a>. This
@@ -3488,7 +3488,7 @@ function setupRoutingGraph() {
               $$
                 v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 - T_0}
               $$
-            </pre>
+</pre>
             <p>
               Where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
               <code>value</code> parameter passed into this method.
@@ -3541,7 +3541,7 @@ function setupRoutingGraph() {
               $$
                 v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t - T_0}{T_1 - T_0}
               $$
-            </pre>
+</pre>
             <p>
               where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is the
               <code>value</code> parameter passed into this method. If \(V_0\)
@@ -3990,7 +3990,7 @@ function setupRoutingGraph() {
             N.p.setValueAtTime(0, 0);
             N.p.linearRampToValueAtTime(4, 1);
             N.p.linearRampToValueAtTime(0, 2)
-          </pre>
+</pre>
           <p>
             The initial slope of the curve is 4, until it reaches the maximum
             value of 1, at which time, the output is held constant. Finally,
@@ -4764,7 +4764,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
         </p>
         <pre>
   computedPlaybackRate(t) = playbackRate(t) * pow(2, detune(t) / 1200)
-        </pre>
+</pre>
         <p>
           The <code>computedPlaybackRate</code> is the effective speed at which
           the <a><code>AudioBuffer</code></a> of this
@@ -4909,7 +4909,7 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
         <pre>
   numberOfInputs  : 0
   numberOfOutputs : 1
-        </pre>
+</pre>
         <dl title=
         "[Constructor(BaseAudioContext context, optional ConstantSourceOptions options)]interface ConstantSourceNode : AudioNode"
         class="idl">
@@ -5179,7 +5179,7 @@ registerProcessor("Bypass", class extends AudioWorkletProcessor {
     output[0].set(input[0]);
   }
 });
-          </pre>
+</pre>
           <pre class="example" title=
           "Importing a script and creating AudioWorkletNode">
 // The main global scope
@@ -5187,7 +5187,7 @@ window.audioWorklet.import("bypass.js").then(function () {
   var context = new AudioContext();
   var bypass = new AudioWorkletNode(context, "Bypass");
 });
-          </pre>
+</pre>
           <p>
             At the instantiation of <a>AudioWorkletNode</a> in the main global
             scope, the counterpart <a>AudioWorkletProcessor</a> will also be
@@ -5520,7 +5520,7 @@ class MyProcessor extends AudioWorkletProcessor {
     }
   }
 }
-            </pre>
+</pre>
             <p>
               <code>process()</code> method is called synchronously by the
               audio <a>rendering thread</a> at every <a>render quantum</a>. It
@@ -5785,7 +5785,7 @@ window.audioWorklet.import('bitcrusher.js').then(function () {
   osc.connect(bitcrusher).connect(amp).connect(context.destination);
   osc.start();
 });
-            </pre>
+</pre>
             <h4>
               AudioWorkletGlobalScope: bitcrusher.js
             </h4>
@@ -5835,7 +5835,7 @@ registerAudioWorkletProcessor('BitCrusher', class extends AudioWorkletProcessor 
   }
 
 });
-            </pre>
+</pre>
           </section>
           <section>
             <h3>
@@ -5895,7 +5895,7 @@ class VUMeterNode extends AudioWorkletNode {
 }
 
 var importAudioWorkletNode = window.audioWorklet.import('vumeterprocessor.js');
-            </pre>
+</pre>
             <h4>
               AudioWorkletGlobalScope: vumeterprocessor.js
             </h4>
@@ -5947,7 +5947,7 @@ registerAudioWorkletProcessor('VUMeter', class extends AudioWorkletProcessor {
       this.updatingInterval = event.data.updatingInterval;
   }
 });
-            </pre>
+</pre>
             <h4>
               Main HTML file
             </h4>
@@ -5965,7 +5965,7 @@ registerAudioWorkletProcessor('VUMeter', class extends AudioWorkletProcessor {
     });
   });
 &lt;/script&gt;
-            </pre>
+</pre>
           </section>
         </section>
       </section>
@@ -6391,8 +6391,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               the minimum and maximum values the <code>rolloffFactor</code> can
               have. Values outside the range are clamped to lie within this
               range. The nominal range depends on the <a href=
-              "#widl-PannerNode-distanceModel"><code>distanceModel</code></a> as
-              follows:
+              "#widl-PannerNode-distanceModel"><code>distanceModel</code></a>
+              as follows:
             </p>
             <dl>
               <dt>
@@ -7230,7 +7230,7 @@ function calculateNormalizationScale(buffer)
                         \left(Y[k] - \mbox{dB}_{min}\right)
                       \right\rfloor
                   $$
-            </pre>
+</pre>
             <p>
               where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code> and
               \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If
@@ -7296,7 +7296,7 @@ function calculateNormalizationScale(buffer)
               $$
                 b[k] = \left\lfloor 128(1 + x[k]) \right\rfloor.
               $$
-            </pre>
+</pre>
             <p>
               If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is clipped
               to lie in that range.
@@ -7496,7 +7496,7 @@ function calculateNormalizationScale(buffer)
             $$
               X[k] = \frac{1}{N} \sum_{n = 0}^{N - 1} \hat{x}[n]\, e^{\frac{-2\pi i k n}{N}}
             $$
-          </pre>
+</pre>
           <p>
             for \(k = 0, \dots, N/2-1\).
           </p>
@@ -8959,7 +8959,7 @@ $$
         </p>
         <pre>
   computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
-        </pre>
+</pre>
         <p>
           The OscillatorNode's instantaneous phase at each time is the time
           integral of <em>computedFrequency</em>. Its <a>nominal range</a> is
@@ -10674,7 +10674,7 @@ Quad up-mix:
   else if (azimuth &gt; 90)
     azimuth = 180 - azimuth;
 
-              </pre>
+</pre>
                 </li>
                 <li>
                   <p>
@@ -10684,7 +10684,7 @@ Quad up-mix:
                   <pre>
   x = (azimuth + 90) / 180;
 
-              </pre>
+</pre>
                   <p>
                     Or for a stereo input as:
                   </p>
@@ -10697,7 +10697,7 @@ Quad up-mix:
     x = azimuth / 90;
   }
 
-                  </pre>
+</pre>
                 </li>
               </ol>
             </li>
@@ -10724,7 +10724,7 @@ Quad up-mix:
     pan = max(-1, pan);
     pan = min(1, pan);
 
-              </pre>
+</pre>
                 </li>
                 <li>
                   <p>
@@ -10734,7 +10734,7 @@ Quad up-mix:
                   <pre>
     x = (pan + 1) / 2;
 
-              </pre>
+</pre>
                   <p>
                     For stereo input:
                   </p>
@@ -10744,7 +10744,7 @@ Quad up-mix:
     else
       x = pan;
 
-              </pre>
+</pre>
                 </li>
               </ol>
               <p>
@@ -10759,7 +10759,7 @@ Quad up-mix:
     gainL = cos(x * Math.PI / 2);
     gainR = sin(x * Math.PI / 2);
 
-              </pre>
+</pre>
                 </li>
                 <li>
                   <p>
@@ -10769,7 +10769,7 @@ Quad up-mix:
     outputL = input * gainL;
     outputR = input * gainR;
 
-              </pre>
+</pre>
                   <p>
                     Else for stereo input, the output is calculated as:
                   </p>
@@ -10784,7 +10784,7 @@ Quad up-mix:
       outputR = inputR + inputL * gainR;
     }
 
-              </pre>
+</pre>
                 </li>
               </ol>
             </li>


### PR DESCRIPTION
Changed `panningModel` to `distanceModel` in `rolloffFactor` attribute description where `linear`, `inverse` and `exponential` models are mentioned. Also added **s** to `source move`, sorry, if I'm wrong here.