### PR TITLE
Fix #1030: Define value for ChannelSplitterNode.channelCount

### DIFF
--- a/index.html
+++ b/index.html
@@ -7593,8 +7593,9 @@ function calculateNormalizationScale(buffer)
         </p>
         <p>
           The <code>channelCount</code> is set equal to
-          <code>numberOfOutputs</code>.  There are <a>channelCount
-          constraints</a> and <a>channelCountMode constraints</a> for this node.
+          <code>numberOfOutputs</code>. There are <a>channelCount
+          constraints</a> and <a>channelCountMode constraints</a> for this
+          node.
         </p>
         <p>
           This node has no <a>tail-time</a> reference.

--- a/index.html
+++ b/index.html
@@ -7592,6 +7592,11 @@ function calculateNormalizationScale(buffer)
           output silence and would typically not be connected to anything.
         </p>
         <p>
+          The <code>channelCount</code> is set equal to
+          <code>numberOfOutputs</code>.  There are <a>channelCount
+          constraints</a> and <a>channelCountMode constraints</a> for this node.
+        </p>
+        <p>
           This node has no <a>tail-time</a> reference.
         </p>
         <h3>


### PR DESCRIPTION
The text never said that channelCount should be set to be the same as
the number of outputs.  Make it so, and add a note that there are
channelCount and channelCountMode constraints.