### PR TITLE
Fix #1011: more exception markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,7 +754,7 @@ function setupRoutingGraph() {
             This context has been released, and can no longer be used to
             process audio. All system audio resources have been released.
             <span class="synchronous">Attempts to create new Nodes on the
-            AudioContext will throw InvalidStateError</span>. (AudioBuffers may
+            AudioContext will throw <code>InvalidStateError</code></span>. (AudioBuffers may
             still be created, through <a href=
             "#widl-BaseAudioContext-createBuffer-AudioBuffer-unsigned-long-numberOfChannels-unsigned-long-length-float-sampleRate">
             createBuffer</a> or <a href=
@@ -2841,7 +2841,7 @@ function setupRoutingGraph() {
                   <dd>
                     The channel count must be between 1 and
                     <a>maxChannelCount</a>. An <span class=
-                    "synchronous">IndexSizeError exception must be thrown for
+                    "synchronous"><code>IndexSizeError</code> exception must be thrown for
                     any attempt to set the count outside this range</span>.
                   </dd>
                   <dt>
@@ -2849,7 +2849,7 @@ function setupRoutingGraph() {
                   </dt>
                   <dd>
                     The channel count cannot be changed. An <span class=
-                    "synchronous">InvalidStateError exception MUST be thrown
+                    "synchronous"><code>InvalidStateError</code> exception MUST be thrown
                     for any attempt to change the value.</span>
                   </dd>
                 </dl>
@@ -2867,7 +2867,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count cannot be changed, and an <span class=
-                "synchronous">InvalidStateError exception MUST be thrown for
+                "synchronous"><code>InvalidStateError</code> exception MUST be thrown for
                 any attempt to change the value.</span>
               </dd>
               <dt>
@@ -2875,7 +2875,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count cannot be greater than two, and a
-                <span class="syncrhonous">NotSupportedError exception MUST be
+                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
                 thrown if count is set to a value greater than two.</span>
               </dd>
               <dt>
@@ -2883,7 +2883,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count cannot be greater than two, and a
-                <span class="syncrhonous">NotSupportedError exception MUST be
+                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
                 thrown for any attempt to change the to a value greater than
                 two.</span>
               </dd>
@@ -2892,7 +2892,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count cannot be changed, and an <span class=
-                "synchronous">InvalidStateError exception MUST be thrown for
+                "synchronous"><code>InvalidStateError</code> exception MUST be thrown for
                 any attempt to change the value.</span>
               </dd>
               <dt>
@@ -2900,7 +2900,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count cannot be greater than two, and a
-                <span class="syncrhonous">NotSupportedError exception MUST be
+                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
                 thrown for any attempt to change the to a value greater than
                 two.</span>
               </dd>
@@ -2933,7 +2933,7 @@ function setupRoutingGraph() {
                 If the <a>AudioDestinationNode</a> is the <a href=
                 "#widl-BaseAudioContext-destination">destination</a> node of an
                 <a>OfflineAudioContext</a>, then the channel count mode cannot
-                be changed. An <span class="synchronous">InvalidStateError
+                be changed. An <span class="synchronous"><code>InvalidStateError</code>
                 exception MUST be thrown for any attempt to change the
                 value.</span>
               </dd>
@@ -2951,7 +2951,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count mode cannot be changed from "explicit" and an
-                <span class="synchronous">InvalidStateError exception must be
+                <span class="synchronous"><code>InvalidStateError</code> exception must be
                 thrown for any attempt to change the value.</span>
               </dd>
               <dt>
@@ -2959,7 +2959,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count mode cannot be set to "max", and a
-                <span class="syncrhonous">NotSupportedError exception MUST be
+                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
                 thrown for any attempt to set it to "max".</span>
               </dd>
               <dt>
@@ -2967,7 +2967,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count mode cannot be set to "max", and a
-                <span class="syncrhonous">NotSupportedError exception MUST be
+                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
                 thrown for any attempt to set it to "max".</span>
               </dd>
               <dt>
@@ -2975,7 +2975,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count mode cannot be changed from "explicit" and an
-                <span class="synchronous">InvalidStateError exception MUST be
+                <span class="synchronous"><code>InvalidStateError</code> exception MUST be
                 thrown for any attempt to change the value.</span>
               </dd>
               <dt>
@@ -2983,7 +2983,7 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count mode cannot be set to "max", and a
-                <span class="syncrhonous">NotSupportedError exception MUST be
+                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
                 thrown for any attempt to set it to "max".</span>
               </dd>
             </dl>

--- a/index.html
+++ b/index.html
@@ -754,8 +754,8 @@ function setupRoutingGraph() {
             This context has been released, and can no longer be used to
             process audio. All system audio resources have been released.
             <span class="synchronous">Attempts to create new Nodes on the
-            AudioContext will throw <code>InvalidStateError</code></span>. (AudioBuffers may
-            still be created, through <a href=
+            AudioContext will throw <code>InvalidStateError</code></span>.
+            (AudioBuffers may still be created, through <a href=
             "#widl-BaseAudioContext-createBuffer-AudioBuffer-unsigned-long-numberOfChannels-unsigned-long-length-float-sampleRate">
             createBuffer</a> or <a href=
             "#widl-BaseAudioContext-decodeAudioData-Promise-AudioBuffer--ArrayBuffer-audioData-DecodeSuccessCallback-successCallback-DecodeErrorCallback-errorCallback">
@@ -1477,8 +1477,9 @@ function setupRoutingGraph() {
           <dd>
             <p>
               Creates a <a><code>ChannelSplitterNode</code></a> representing a
-              channel splitter. <span class="synchronous">An <code>IndexSizeError</code>
-              exception MUST be thrown for invalid parameter values.</span>
+              channel splitter. <span class="synchronous">An
+              <code>IndexSizeError</code> exception MUST be thrown for invalid
+              parameter values.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -1496,8 +1497,9 @@ function setupRoutingGraph() {
           <dd>
             <p>
               Creates a <a><code>ChannelMergerNode</code></a> representing a
-              channel merger. <span class="synchronous">An <code>IndexSizeError</code>
-              exception MUST be thrown for invalid parameter values.</span>
+              channel merger. <span class="synchronous">An
+              <code>IndexSizeError</code> exception MUST be thrown for invalid
+              parameter values.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -2454,9 +2456,10 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to connect to. If the
                 <code>destination</code> parameter is an
                 <a><code>AudioNode</code></a> that has been created using
-                another <a><code>AudioContext</code></a>, an <code>InvalidAccessError</code>
-                MUST be thrown. That is, <a><code>AudioNodes</code></a> cannot
-                be shared between <a><code>AudioContext</code></a>s.
+                another <a><code>AudioContext</code></a>, an
+                <code>InvalidAccessError</code> MUST be thrown. That is,
+                <a><code>AudioNodes</code></a> cannot be shared between
+                <a><code>AudioContext</code></a>s.
               </dd>
               <dt>
                 optional unsigned long output = 0
@@ -2485,8 +2488,8 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a>, which in turn connects back to
                 the first <a><code>AudioNode</code></a>. This is allowed only
                 if there is at least one <a><code>DelayNode</code></a> in the
-                <em>cycle</em> <span class="synchronous">or a <code>NotSupportedError</code>
-                exception MUST be thrown.</span>
+                <em>cycle</em> <span class="synchronous">or a
+                <code>NotSupportedError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
             <p>
@@ -2538,8 +2541,8 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 connect. <span class="synchronous">If the
-                <code>parameter</code> is out-of-bound, an <code>IndexSizeError</code>
-                exception MUST be thrown.</span>
+                <code>parameter</code> is out-of-bound, an
+                <code>IndexSizeError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
             <p>
@@ -2631,8 +2634,8 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. It disconnects all
                 outgoing connections to the given <code>destination</code>.
                 <span class="synchronous">If there is no connection to
-                <code>destination</code>, an <code>InvalidAccessError</code> exception MUST
-                be thrown.</span>
+                <code>destination</code>, an <code>InvalidAccessError</code>
+                exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2654,7 +2657,8 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
                 <code>destination</code> from the given output, an
-                <code>InvalidAccessError</code> exception MUST be thrown.</span>
+                <code>InvalidAccessError</code> exception MUST be
+                thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2686,7 +2690,8 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
                 <code>destination</code> from the given output to the given
-                input, an <code>InvalidAccessError</code> exception MUST be thrown.</span>
+                input, an <code>InvalidAccessError</code> exception MUST be
+                thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2730,8 +2735,8 @@ function setupRoutingGraph() {
                 The <code>destination</code> parameter is the
                 <a><code>AudioParam</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
-                <code>destination</code>, an <code>InvalidAccessError</code> exception MUST
-                be thrown.</span>
+                <code>destination</code>, an <code>InvalidAccessError</code>
+                exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2755,8 +2760,8 @@ function setupRoutingGraph() {
                 The <code>destination</code> parameter is the
                 <a><code>AudioParam</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
-                <code>destination</code>, an <code>InvalidAccessError</code> exception MUST
-                be thrown.</span>
+                <code>destination</code>, an <code>InvalidAccessError</code>
+                exception MUST be thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2765,8 +2770,8 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 disconnect. <span class="synchronous">If the
-                <code>parameter</code> is out-of-bound, an <code>IndexSizeError</code>
-                exception MUST be thrown.</span>
+                <code>parameter</code> is out-of-bound, an
+                <code>IndexSizeError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -2841,16 +2846,17 @@ function setupRoutingGraph() {
                   <dd>
                     The channel count must be between 1 and
                     <a>maxChannelCount</a>. An <span class=
-                    "synchronous"><code>IndexSizeError</code> exception must be thrown for
-                    any attempt to set the count outside this range</span>.
+                    "synchronous"><code>IndexSizeError</code> exception must be
+                    thrown for any attempt to set the count outside this
+                    range</span>.
                   </dd>
                   <dt>
                     <a>OfflineAudioContext</a>
                   </dt>
                   <dd>
                     The channel count cannot be changed. An <span class=
-                    "synchronous"><code>InvalidStateError</code> exception MUST be thrown
-                    for any attempt to change the value.</span>
+                    "synchronous"><code>InvalidStateError</code> exception MUST
+                    be thrown for any attempt to change the value.</span>
                   </dd>
                 </dl>
               </dd>
@@ -2867,42 +2873,43 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count cannot be changed, and an <span class=
-                "synchronous"><code>InvalidStateError</code> exception MUST be thrown for
-                any attempt to change the value.</span>
+                "synchronous"><code>InvalidStateError</code> exception MUST be
+                thrown for any attempt to change the value.</span>
               </dd>
               <dt>
                 <a>ConvolverNode</a>
               </dt>
               <dd>
                 The channel count cannot be greater than two, and a
-                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
-                thrown if count is set to a value greater than two.</span>
+                <span class="syncrhonous"><code>NotSupportedError</code>
+                exception MUST be thrown if count is set to a value greater
+                than two.</span>
               </dd>
               <dt>
                 <a>PannerNode</a>
               </dt>
               <dd>
                 The channel count cannot be greater than two, and a
-                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
-                thrown for any attempt to change the to a value greater than
-                two.</span>
+                <span class="syncrhonous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to change the to a
+                value greater than two.</span>
               </dd>
               <dt>
                 <a>ScriptProcessorNode</a>
               </dt>
               <dd>
                 The channel count cannot be changed, and an <span class=
-                "synchronous"><code>InvalidStateError</code> exception MUST be thrown for
-                any attempt to change the value.</span>
+                "synchronous"><code>InvalidStateError</code> exception MUST be
+                thrown for any attempt to change the value.</span>
               </dd>
               <dt>
                 <a>StereoPannerNode</a>
               </dt>
               <dd>
                 The channel count cannot be greater than two, and a
-                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
-                thrown for any attempt to change the to a value greater than
-                two.</span>
+                <span class="syncrhonous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to change the to a
+                value greater than two.</span>
               </dd>
             </dl>
             <p>
@@ -2933,9 +2940,9 @@ function setupRoutingGraph() {
                 If the <a>AudioDestinationNode</a> is the <a href=
                 "#widl-BaseAudioContext-destination">destination</a> node of an
                 <a>OfflineAudioContext</a>, then the channel count mode cannot
-                be changed. An <span class="synchronous"><code>InvalidStateError</code>
-                exception MUST be thrown for any attempt to change the
-                value.</span>
+                be changed. An <span class=
+                "synchronous"><code>InvalidStateError</code> exception MUST be
+                thrown for any attempt to change the value.</span>
               </dd>
               <dt>
                 <a>ChannelSplitterNode</a>
@@ -2951,40 +2958,45 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The channel count mode cannot be changed from "explicit" and an
-                <span class="synchronous"><code>InvalidStateError</code> exception must be
-                thrown for any attempt to change the value.</span>
+                <span class="synchronous"><code>InvalidStateError</code>
+                exception must be thrown for any attempt to change the
+                value.</span>
               </dd>
               <dt>
                 <a>ConvolverNode</a>
               </dt>
               <dd>
                 The channel count mode cannot be set to "max", and a
-                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
-                thrown for any attempt to set it to "max".</span>
+                <span class="syncrhonous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to set it to
+                "max".</span>
               </dd>
               <dt>
                 <a>PannerNode</a>
               </dt>
               <dd>
                 The channel count mode cannot be set to "max", and a
-                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
-                thrown for any attempt to set it to "max".</span>
+                <span class="syncrhonous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to set it to
+                "max".</span>
               </dd>
               <dt>
                 <a>ScriptProcessorNode</a>
               </dt>
               <dd>
                 The channel count mode cannot be changed from "explicit" and an
-                <span class="synchronous"><code>InvalidStateError</code> exception MUST be
-                thrown for any attempt to change the value.</span>
+                <span class="synchronous"><code>InvalidStateError</code>
+                exception MUST be thrown for any attempt to change the
+                value.</span>
               </dd>
               <dt>
                 <a>StereoPannerNode</a>
               </dt>
               <dd>
                 The channel count mode cannot be set to "max", and a
-                <span class="syncrhonous"><code>NotSupportedError</code> exception MUST be
-                thrown for any attempt to set it to "max".</span>
+                <span class="syncrhonous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to set it to
+                "max".</span>
               </dd>
             </dl>
             <p>
@@ -4295,8 +4307,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 This parameter is an index representing the particular channel
                 to get data for. An index value of 0 represents the first
                 channel. <span class="synchronous">This index value MUST be
-                less than <code>numberOfChannels</code> or an <code>IndexSizeError</code>
-                exception MUST be thrown.</span>
+                less than <code>numberOfChannels</code> or an
+                <code>IndexSizeError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -4451,8 +4463,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             This specifies the options to use in constructing an
             <a><code>AudioBuffer</code></a>. Only the <a href=
             "#widl-AudioBufferOptions-length"><code>length</code></a> member is
-            required. A <code>NotFoundError</code> exception MUST be thrown if any of the
-            required members are not specified.
+            required. A <code>NotFoundError</code> exception MUST be thrown if
+            any of the required members are not specified.
           </p>
           <dl title="dictionary AudioBufferOptions" class="idl">
             <dt>
@@ -4636,7 +4648,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               Schedules a sound to playback at an exact time.
               <code>start</code> may only be called one time and <span class=
               "synchronous">must be called before <code>stop</code> is called
-              or an <code>InvalidStateError</code> exception MUST be thrown.</span>
+              or an <code>InvalidStateError</code> exception MUST be
+              thrown.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -6445,8 +6458,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               A parameter for directional audio sources, this is the gain
               outside of the <a><code>coneOuterAngle</code></a>. The default
               value is 0. It is a linear value (not dB) in the range [0, 1]. An
-              <code>InvalidStateError</code> MUST be thrown if the parameter is outside this
-              range.
+              <code>InvalidStateError</code> MUST be thrown if the parameter is
+              outside this range.
             </p>
           </dd>
           <dt>
@@ -9010,8 +9023,8 @@ $$
             <p>
               The shape of the periodic waveform. It may directly be set to any
               of the type constant values except for "custom". <span class=
-              "synchronous">Doing so MUST throw an <code>InvalidStateError</code>
-              exception.</span> The <a href=
+              "synchronous">Doing so MUST throw an
+              <code>InvalidStateError</code> exception.</span> The <a href=
               "#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">
               <code>setPeriodicWave()</code></a> method can be used to set a
               custom waveform, which results in this attribute being set to
@@ -9136,8 +9149,8 @@ $$
             <dd>
               The type of oscillator to be constructed. If this is set to
               "custom" without also specifying a
-              <a><code>periodicWave</code></a>, then an <code>InvalidStateError</code>
-              exception MUST be thrown.
+              <a><code>periodicWave</code></a>, then an
+              <code>InvalidStateError</code> exception MUST be thrown.
             </dd>
             <dt>
               float frequency = 440
@@ -9159,8 +9172,8 @@ $$
               The <a><code>PeriodicWave</code></a> for the
               <a><code>OscillatorNode</code></a>. If this is specified, then
               the <a><code>type</code></a> member must either be unspecified or
-              set to "custom". If this is not true, an <code>InvalidStateError</code>
-              exception MUST be thrown.
+              set to "custom". If this is not true, an
+              <code>InvalidStateError</code> exception MUST be thrown.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -1421,7 +1421,7 @@ function setupRoutingGraph() {
                 An array of the feedforward (numerator) coefficients for the
                 transfer function of the IIR filter. The maximum length of this
                 array is 20. If all of the values are zero, an
-                InvalidStateError MUST be thrown. A
+                <code>InvalidStateError</code> MUST be thrown. A
                 <code>NotSupportedError</code> MUST be thrown if the array
                 length is 0 or greater than 20.
               </dd>
@@ -1432,7 +1432,7 @@ function setupRoutingGraph() {
                 An array of the feedback (denominator) coefficients for the
                 tranfer function of the IIR filter. The maximum length of this
                 array is 20. If the first element of the array is 0, an
-                InvalidStateError MUST be thrown. A
+                <code>InvalidStateError</code> MUST be thrown. A
                 <code>NotSupportedError</code> MUST be thrown if the array
                 length is 0 or greater than 20.
               </dd>
@@ -1477,7 +1477,7 @@ function setupRoutingGraph() {
           <dd>
             <p>
               Creates a <a><code>ChannelSplitterNode</code></a> representing a
-              channel splitter. <span class="synchronous">An IndexSizeError
+              channel splitter. <span class="synchronous">An <code>IndexSizeError</code>
               exception MUST be thrown for invalid parameter values.</span>
             </p>
             <dl class="parameters">
@@ -1496,7 +1496,7 @@ function setupRoutingGraph() {
           <dd>
             <p>
               Creates a <a><code>ChannelMergerNode</code></a> representing a
-              channel merger. <span class="synchronous">An IndexSizeError
+              channel merger. <span class="synchronous">An <code>IndexSizeError</code>
               exception MUST be thrown for invalid parameter values.</span>
             </p>
             <dl class="parameters">
@@ -2454,7 +2454,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to connect to. If the
                 <code>destination</code> parameter is an
                 <a><code>AudioNode</code></a> that has been created using
-                another <a><code>AudioContext</code></a>, an InvalidAccessError
+                another <a><code>AudioContext</code></a>, an <code>InvalidAccessError</code>
                 MUST be thrown. That is, <a><code>AudioNodes</code></a> cannot
                 be shared between <a><code>AudioContext</code></a>s.
               </dd>
@@ -2485,7 +2485,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a>, which in turn connects back to
                 the first <a><code>AudioNode</code></a>. This is allowed only
                 if there is at least one <a><code>DelayNode</code></a> in the
-                <em>cycle</em> <span class="synchronous">or a NotSupportedError
+                <em>cycle</em> <span class="synchronous">or a <code>NotSupportedError</code>
                 exception MUST be thrown.</span>
               </dd>
             </dl>
@@ -2538,7 +2538,7 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 connect. <span class="synchronous">If the
-                <code>parameter</code> is out-of-bound, an IndexSizeError
+                <code>parameter</code> is out-of-bound, an <code>IndexSizeError</code>
                 exception MUST be thrown.</span>
               </dd>
             </dl>
@@ -2631,7 +2631,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. It disconnects all
                 outgoing connections to the given <code>destination</code>.
                 <span class="synchronous">If there is no connection to
-                <code>destination</code>, an InvalidAccessError exception MUST
+                <code>destination</code>, an <code>InvalidAccessError</code> exception MUST
                 be thrown.</span>
               </dd>
             </dl>
@@ -2654,7 +2654,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
                 <code>destination</code> from the given output, an
-                InvalidAccessError exception MUST be thrown.</span>
+                <code>InvalidAccessError</code> exception MUST be thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2686,7 +2686,7 @@ function setupRoutingGraph() {
                 <a><code>AudioNode</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
                 <code>destination</code> from the given output to the given
-                input, an InvalidAccessError exception MUST be thrown.</span>
+                input, an <code>InvalidAccessError</code> exception MUST be thrown.</span>
               </dd>
               <dt>
                 unsigned long output
@@ -2730,7 +2730,7 @@ function setupRoutingGraph() {
                 The <code>destination</code> parameter is the
                 <a><code>AudioParam</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
-                <code>destination</code>, an InvalidAccessError exception MUST
+                <code>destination</code>, an <code>InvalidAccessError</code> exception MUST
                 be thrown.</span>
               </dd>
             </dl>
@@ -2755,7 +2755,7 @@ function setupRoutingGraph() {
                 The <code>destination</code> parameter is the
                 <a><code>AudioParam</code></a> to disconnect. <span class=
                 "synchronous">If there is no connection to the
-                <code>destination</code>, an InvalidAccessError exception MUST
+                <code>destination</code>, an <code>InvalidAccessError</code> exception MUST
                 be thrown.</span>
               </dd>
               <dt>
@@ -2765,7 +2765,7 @@ function setupRoutingGraph() {
                 The <code>output</code> parameter is an index describing which
                 output of the <a><code>AudioNode</code></a> from which to
                 disconnect. <span class="synchronous">If the
-                <code>parameter</code> is out-of-bound, an IndexSizeError
+                <code>parameter</code> is out-of-bound, an <code>IndexSizeError</code>
                 exception MUST be thrown.</span>
               </dd>
             </dl>
@@ -4295,7 +4295,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 This parameter is an index representing the particular channel
                 to get data for. An index value of 0 represents the first
                 channel. <span class="synchronous">This index value MUST be
-                less than <code>numberOfChannels</code> or an IndexSizeError
+                less than <code>numberOfChannels</code> or an <code>IndexSizeError</code>
                 exception MUST be thrown.</span>
               </dd>
             </dl>
@@ -4451,7 +4451,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             This specifies the options to use in constructing an
             <a><code>AudioBuffer</code></a>. Only the <a href=
             "#widl-AudioBufferOptions-length"><code>length</code></a> member is
-            required. A NotFoundError exception MUST be thrown if any of the
+            required. A <code>NotFoundError</code> exception MUST be thrown if any of the
             required members are not specified.
           </p>
           <dl title="dictionary AudioBufferOptions" class="idl">
@@ -4636,7 +4636,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               Schedules a sound to playback at an exact time.
               <code>start</code> may only be called one time and <span class=
               "synchronous">must be called before <code>stop</code> is called
-              or an InvalidStateError exception MUST be thrown.</span>
+              or an <code>InvalidStateError</code> exception MUST be thrown.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -6445,7 +6445,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               A parameter for directional audio sources, this is the gain
               outside of the <a><code>coneOuterAngle</code></a>. The default
               value is 0. It is a linear value (not dB) in the range [0, 1]. An
-              InvalidStateError MUST be thrown if the parameter is outside this
+              <code>InvalidStateError</code> MUST be thrown if the parameter is outside this
               range.
             </p>
           </dd>
@@ -8695,7 +8695,7 @@ $$
             <dd>
               The feedforward coefficients for the
               <a><code>IIRFilterNode</code></a>. This member is required. If
-              not specifed, a NotFoundError MUST be thrown.
+              not specifed, a <code>NotFoundError</code> MUST be thrown.
             </dd>
             <dt>
               required sequence&lt;double&gt; feedback
@@ -8703,7 +8703,7 @@ $$
             <dd>
               The feedback coefficients for the
               <a><code>IIRFilterNode</code></a>. This member is required. If
-              not specifed, a NotFoundError MUST be thrown.
+              not specifed, a <code>NotFoundError</code> MUST be thrown.
             </dd>
           </dl>
         </section>
@@ -9010,7 +9010,7 @@ $$
             <p>
               The shape of the periodic waveform. It may directly be set to any
               of the type constant values except for "custom". <span class=
-              "synchronous">Doing so MUST throw an InvalidStateError
+              "synchronous">Doing so MUST throw an <code>InvalidStateError</code>
               exception.</span> The <a href=
               "#widl-OscillatorNode-setPeriodicWave-void-PeriodicWave-periodicWave">
               <code>setPeriodicWave()</code></a> method can be used to set a
@@ -9136,7 +9136,7 @@ $$
             <dd>
               The type of oscillator to be constructed. If this is set to
               "custom" without also specifying a
-              <a><code>periodicWave</code></a>, then an InvalidStateError
+              <a><code>periodicWave</code></a>, then an <code>InvalidStateError</code>
               exception MUST be thrown.
             </dd>
             <dt>
@@ -9159,7 +9159,7 @@ $$
               The <a><code>PeriodicWave</code></a> for the
               <a><code>OscillatorNode</code></a>. If this is specified, then
               the <a><code>type</code></a> member must either be unspecified or
-              set to "custom". If this is not true, an InvalidStateError
+              set to "custom". If this is not true, an <code>InvalidStateError</code>
               exception MUST be thrown.
             </dd>
           </dl>


### PR DESCRIPTION
#1026 missed a few places and this PR fixes some of the using the
following script.

```
PATTERN="\(IndexSizeError\|HierarchyRequestError\|WrongDocumentError\|InvalidCharacterError\|NoModificationAllowedError\|NotFoundError\|NotSupportedError\|InUseAttributeError\|InvalidStateError\|SyntaxError\|InvalidModificationError\|NamespaceError\|InvalidAccessError\|SecurityError\|NetworkError\|AbortError\|URLMismatchError\|QuotaExceededError\|TimeoutError\|InvalidNodeTypeError\|DataCloneError\|EncodingError\|NotReadableError\|UnknownError\|ConstraintError\|DataError\|TransactionInactiveError\|ReadOnlyError\|VersionError\|OperationError\|NotAllowedError\)"

sed -i 's;'"$PATTERN"'\(</[^c]\);<code>\1</code>\2;g' index.html
sed -i 's;\([^e]>\)'"$PATTERN"';\1<code>\2</code>;g' index.html
```

This still misses the cases where the exception type is at the
beginning or end of a line.
