### PR TITLE
Fix #989: Sort API overview list alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,9 +558,9 @@ function setupRoutingGraph() {
           <a><code>AudioNode</code></a>s exist in the context of an
           <a><code>AudioContext</code></a>.
           </li>
-          <li>An <a><code>AudioDestinationNode</code></a> interface, an
-          <a><code>AudioNode</code></a> subclass representing the final
-          destination for all rendered audio.
+          <li>A <a><code>AnalyserNode</code></a> interface, an
+          <a><code>AudioNode</code></a> for use with music visualizers, or
+          other visualization applications.
           </li>
           <li>An <a><code>AudioBuffer</code></a> interface, for working with
           memory-resident audio assets. These can represent one-shot sounds, or
@@ -570,41 +570,27 @@ function setupRoutingGraph() {
           <a><code>AudioNode</code></a> which generates audio from an
           AudioBuffer.
           </li>
-          <li>A <a><code>MediaElementAudioSourceNode</code></a> interface, an
-          <a><code>AudioNode</code></a> which is the audio source from an
-          <code>audio</code>, <code>video</code>, or other media element.
-          </li>
-          <li>A <a><code>MediaStreamAudioSourceNode</code></a> interface, an
-          <a><code>AudioNode</code></a> which is the audio source from a
-          MediaStream such as live audio input, or from a remote peer.
-          </li>
-          <li>A <a><code>MediaStreamAudioDestinationNode</code></a> interface,
-          an <a><code>AudioNode</code></a> which is the audio destination to a
-          MediaStream sent to a remote peer.
-          </li>
-          <li>An <a><code>AudioWorklet</code></a> interface representing a
-          factory for creating custom nodes that can process audio directly in
-          JavaScript.
-          </li>
-          <li>An <a><code>AudioWorkletNode</code></a> interface, an
-          <a><code>AudioNode</code></a> representing a node processed in an
-          AudioWorkletProcessor.
-          </li>
-          <li>An <a><code>AudioWorkletGlobalScope</code></a> interface, the
-          context in which AudioWorkletProcessor processing scripts run.
-          </li>
-          <li>An <a><code>AudioWorkletProcessor</code></a> interface,
-          representing a single node instance inside an audio worker.
+          <li>An <a><code>AudioDestinationNode</code></a> interface, an
+          <a><code>AudioNode</code></a> subclass representing the final
+          destination for all rendered audio.
           </li>
           <li>An <a><code>AudioParam</code></a> interface, for controlling an
           individual aspect of an <a><code>AudioNode</code></a>'s functioning,
           such as volume.
           </li>
-          <li>A <a><code>GainNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for explicit gain control. Because
-          inputs to <a><code>AudioNode</code></a>s support multiple connections
-          (as a unity-gain summing junction), mixers can be <a href=
-          "#mixer-gain-structure">easily built</a> with GainNodes.
+          <li>An <a><code>AudioWorklet</code></a> interface representing a
+          factory for creating custom nodes that can process audio directly in
+          JavaScript.
+          </li>
+          <li>An <a><code>AudioWorkletGlobalScope</code></a> interface, the
+          context in which AudioWorkletProcessor processing scripts run.
+          </li>
+          <li>An <a><code>AudioWorkletNode</code></a> interface, an
+          <a><code>AudioNode</code></a> representing a node processed in an
+          AudioWorkletProcessor.
+          </li>
+          <li>An <a><code>AudioWorkletProcessor</code></a> interface,
+          representing a single node instance inside an audio worker.
           </li>
           <li>A <a><code>BiquadFilterNode</code></a> interface, an
           <a><code>AudioNode</code></a> for common low-order filters such as:
@@ -627,47 +613,61 @@ function setupRoutingGraph() {
               </li>
             </ul>
           </li>
-          <li>A <a><code>IIRFilterNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for a general IIR filter.
+          <li>A <a><code>ChannelMergerNode</code></a> interface, an
+          <a><code>AudioNode</code></a> for combining channels from multiple
+          audio streams into a single audio stream.
           </li>
-          <li>A <a><code>DelayNode</code></a> interface, an
-          <a><code>AudioNode</code></a> which applies a dynamically adjustable
-          variable delay.
+          <li>A <a><code>ChannelSplitterNode</code></a> interface, an <a><code>
+            AudioNode</code></a> for accessing the individual channels of an
+            audio stream in the routing graph.
           </li>
-          <li>A <a><code>StereoPannerNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for equal-power positioning of audio
-          input in a stereo stream.
+          <li>A <a><code>ConstantSourceNode</code></a> interface, an
+          <a>AudioNode</a> for generating a nominally constant output value
+          with an <a>AudioParam</a> to allow automation of the value.
           </li>
           <li>A <a><code>ConvolverNode</code></a> interface, an
           <a><code>AudioNode</code></a> for applying a <a href=
           "convolution.html">real-time linear effect</a> (such as the sound of
           a concert hall).
           </li>
-          <li>A <a><code>AnalyserNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for use with music visualizers, or
-          other visualization applications.
-          </li>
-          <li>A <a><code>ChannelSplitterNode</code></a> interface, an <a><code>
-            AudioNode</code></a> for accessing the individual channels of an
-            audio stream in the routing graph.
-          </li>
-          <li>A <a><code>ChannelMergerNode</code></a> interface, an
-          <a><code>AudioNode</code></a> for combining channels from multiple
-          audio streams into a single audio stream.
+          <li>A <a><code>DelayNode</code></a> interface, an
+          <a><code>AudioNode</code></a> which applies a dynamically adjustable
+          variable delay.
           </li>
           <li>A <a><code>DynamicsCompressorNode</code></a> interface, an
           <a><code>AudioNode</code></a> for dynamics compression.
           </li>
-          <li>A <a><code>WaveShaperNode</code></a> interface, an
-          <a><code>AudioNode</code></a> which applies a non-linear waveshaping
-          effect for distortion and other more subtle warming effects.
+          <li>A <a><code>GainNode</code></a> interface, an
+          <a><code>AudioNode</code></a> for explicit gain control. Because
+          inputs to <a><code>AudioNode</code></a>s support multiple connections
+          (as a unity-gain summing junction), mixers can be <a href=
+          "#mixer-gain-structure">easily built</a> with GainNodes.
+          </li>
+          <li>A <a><code>IIRFilterNode</code></a> interface, an
+          <a><code>AudioNode</code></a> for a general IIR filter.
+          </li>
+          <li>A <a><code>MediaElementAudioSourceNode</code></a> interface, an
+          <a><code>AudioNode</code></a> which is the audio source from an
+          <code>audio</code>, <code>video</code>, or other media element.
+          </li>
+          <li>A <a><code>MediaStreamAudioSourceNode</code></a> interface, an
+          <a><code>AudioNode</code></a> which is the audio source from a
+          MediaStream such as live audio input, or from a remote peer.
+          </li>
+          <li>A <a><code>MediaStreamAudioDestinationNode</code></a> interface,
+          an <a><code>AudioNode</code></a> which is the audio destination to a
+          MediaStream sent to a remote peer.
           </li>
           <li>A <a><code>OscillatorNode</code></a> interface, an
           <a><code>AudioNode</code></a> for generating a periodic waveform.
           </li>
-          <li>A <a><code>ConstantSourceNode</code></a> interface, an
-          <a>AudioNode</a> for generating a nominally constant output value
-          with an <a>AudioParam</a> to allow automation of the value.
+          <li>A <a><code>StereoPannerNode</code></a> interface, an
+          <a><code>AudioNode</code></a> for equal-power positioning of audio
+          input in a stereo stream.
+          </li>
+          <li>A <a><code>WaveShaperNode</code></a> interface, an
+          <a><code>AudioNode</code></a> which applies a non-linear waveshaping
+          effect for distortion and other more subtle warming effects.
           </li>
         </ul>
         <p>


### PR DESCRIPTION
The list of defined interfaces is sorted alphabetically, except that
AudioContext and AudioNode are first.  Everything after that is
alphabetical.