### PR TITLE
Fix #713: Specify clamping of automation times.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3429,7 +3429,10 @@ function setupRoutingGraph() {
                 which the parameter changes to the given value. <span class=
                 "synchronous">A TypeError exception MUST be thrown if
                 <code>startTime</code> is negative or is not a finite
-                number.</span>
+                number.</span> If <var>startTime</var> is less than <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
+                clamped to <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>.
               </dd>
             </dl>
             <p>
@@ -3490,7 +3493,11 @@ function setupRoutingGraph() {
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute
                 at which the automation ends. <span class="synchronous">A
                 TypeError exception MUST be thrown if <code>endTime</code> is
-                negative or is not a finite number.</span>
+                negative or is not a finite number.</span> If
+                <var>endTime</var> is less than <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
+                clamped to <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>.
               </dd>
             </dl>
             <p>
@@ -3613,7 +3620,11 @@ function setupRoutingGraph() {
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute
                 where the exponential ramp ends. <span class="synchronous">A
                 TypeError exception MUST be thrown if <code>endTime</code> is
-                negative or is not a finite number.</span>
+                negative or is not a finite number.</span> If
+                <var>endTime</var> is less than <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
+                clamped to <a href=
+                "#widl-BaseAudioContext-currentTime">currentTime</a>.
               </dd>
             </dl>
           </dd>


### PR DESCRIPTION
Specify clamping of the automation time for all automation methods.
Some were missed in #849.
