### PR TITLE
Fix #1052: Add PannerNode and AudioListener back to API Overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ function setupRoutingGraph() {
           such as volume.
           </li>
           <li>An <a><code>AudioListener</code></a> interface, which works with
-            a <a>PannerNode</a> for spatialization.
+          a <a>PannerNode</a> for spatialization.
           </li>
           <li>An <a><code>AudioWorklet</code></a> interface representing a
           factory for creating custom nodes that can process audio directly in
@@ -662,8 +662,8 @@ function setupRoutingGraph() {
           MediaStream sent to a remote peer.
           </li>
           <li>A <a><code>PannerNode</code></a> interface, an
-            <a><code>AudioNode</code></a> for spatializing / positioning audio
-            in 3D space.
+          <a><code>AudioNode</code></a> for spatializing / positioning audio in
+          3D space.
           </li>
           <li>A <a><code>PeriodicWave</code></a> interface for specifying
           custom periodic waveforms for use by the

--- a/index.html
+++ b/index.html
@@ -578,6 +578,9 @@ function setupRoutingGraph() {
           individual aspect of an <a><code>AudioNode</code></a>'s functioning,
           such as volume.
           </li>
+          <li>An <a><code>AudioListener</code></a> interface, which works with
+            a <a>PannerNode</a> for spatialization.
+          </li>
           <li>An <a><code>AudioWorklet</code></a> interface representing a
           factory for creating custom nodes that can process audio directly in
           JavaScript.
@@ -657,6 +660,10 @@ function setupRoutingGraph() {
           <li>A <a><code>MediaStreamAudioDestinationNode</code></a> interface,
           an <a><code>AudioNode</code></a> which is the audio destination to a
           MediaStream sent to a remote peer.
+          </li>
+          <li>A <a><code>PannerNode</code></a> interface, an
+            <a><code>AudioNode</code></a> for spatializing / positioning audio
+            in 3D space.
           </li>
           <li>A <a><code>PeriodicWave</code></a> interface for specifying
           custom periodic waveforms for use by the


### PR DESCRIPTION
The PannerNode and AudioListener interfaces were accidentally deleted
in #749.  Put these entries back in sorted alphabetically.