### PR TITLE
Fix #1049: DynamicsCompressor AudioParams are k-rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -7812,8 +7812,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               The decibel value above which the compression will start taking
-              effect. Its default <code>value</code> is -24. Its <a>nominal
-              range</a> is [-100, 0].
+              effect. Its default <code>value</code> is -24. This parameter is
+              <a>k-rate</a>. Its <a>nominal range</a> is [-100, 0].
             </p>
           </dd>
           <dt>
@@ -7823,8 +7823,8 @@ function calculateNormalizationScale(buffer)
             <p>
               A decibel value representing the range above the threshold where
               the curve smoothly transitions to the "ratio" portion. Its
-              default <code>value</code> is 30. Its <a>nominal range</a> is [0,
-              40].
+              default <code>value</code> is 30. This parameter is
+              <a>k-rate</a>. Its <a>nominal range</a> is [0, 40].
             </p>
           </dd>
           <dt>
@@ -7833,8 +7833,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               The amount of dB change in input for a 1 dB change in output. Its
-              default <code>value</code> is 12. Its <a>nominal range</a> is [1,
-              20].
+              default <code>value</code> is 12. This parameter is
+              <a>k-rate</a>. Its <a>nominal range</a> is [1, 20].
             </p>
           </dd>
           <dt>
@@ -7854,8 +7854,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               The amount of time (in seconds) to reduce the gain by 10dB. Its
-              default <code>value</code> is 0.003. Its <a>nominal range</a> is
-              [0, 1].
+              default <code>value</code> is 0.003. This parameter is
+              <a>k-rate</a>. Its <a>nominal range</a> is [0, 1].
             </p>
           </dd>
           <dt>
@@ -7864,8 +7864,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               The amount of time (in seconds) to increase the gain by 10dB. Its
-              default <code>value</code> is 0.250. Its <a>nominal range</a> is
-              [0, 1].
+              default <code>value</code> is 0.250. This parameter is
+              <a>k-rate</a>. Its <a>nominal range</a> is [0, 1].
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
Mark all AudioParams as being k-rate.