### PR TITLE
Fix #1062: Set correct values for channel count and mode for Convolver

### DIFF
--- a/index.html
+++ b/index.html
@@ -2889,10 +2889,9 @@ function setupRoutingGraph() {
                 <a>ConvolverNode</a>
               </dt>
               <dd>
-                The channel count cannot be greater than two, and a
-                <span class="synchronous"><code>NotSupportedError</code>
-                exception MUST be thrown if count is set to a value greater
-                than two.</span>
+                The channel count cannot changed from two, and a <span class=
+                "synchronous"><code>NotSupportedError</code> exception MUST be
+                thrown for any attempt to change the value..</span>
               </dd>
               <dt>
                 <a>PannerNode</a>
@@ -2975,10 +2974,10 @@ function setupRoutingGraph() {
                 <a>ConvolverNode</a>
               </dt>
               <dd>
-                The channel count mode cannot be set to "max", and a
+                The channel count mode cannot be changed from "explicit", and a
                 <span class="synchronous"><code>NotSupportedError</code>
-                exception MUST be thrown for any attempt to set it to
-                "max".</span>
+                exception MUST be thrown for any attempt to change the
+                value.</span>
               </dd>
               <dt>
                 <a>PannerNode</a>


### PR DESCRIPTION
Specify that channelCount = 2 and channelCountMode = "explicit" and
that they cannot be changed.