### PR TITLE
Fix #611: Clamp maxDistance and refDistance

### DIFF
--- a/index.html
+++ b/index.html
@@ -6238,12 +6238,17 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             </p>
             <pre class="nohighlight">
             $$
-              1 - f\frac{\max(\min(d, d_{max}), d_{ref}) - d_{ref}}{d_{max} - d_{ref}}
+              1 - f\frac{\max(\min(d, d'_{max}), d'_{ref}) - d'_{ref}}{d'_{max} - d'_{ref}}
             $$
             
 </pre>
             <p>
-              That is, \(d\) is clamped to the interval \([d_{ref},\,
+              where \(d'_{ref} = \min(d_{ref}, d_{max})\) and \(d'_{max} =
+              \max(d_{ref}, d_{max})\). In the case where \(d'_{ref} =
+              d'_{max}\), the value of the linear model is taken to be \(1-f\).
+            </p>
+            <p>
+              Note that \(d\) is clamped to the interval \([d_{ref},\,
               d_{max}]\).
             </p>
           </dd>
@@ -6396,7 +6401,9 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dd>
             <p>
               A reference distance for reducing volume as source moves further
-              from the listener. The default value is 1.
+              from the listener. The default value is 1. A
+              <code>TypeError</code> exception must be thrown if this is set to
+              a non-positive value.
             </p>
           </dd>
           <dt>
@@ -6406,7 +6413,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             <p>
               The maximum distance between source and listener, after which the
               volume will not be reduced any further. The default value is
-              10000.
+              10000. A <code>TypeError</code> exception must be thrown if this
+              is set to a non-positive value.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
For the linear distance model, make d'max = max(dref, dmax) and d'ref
= min(dref,dmax).  And specify the value of the model is 1-f if
d'ref=d'max. This makes the model well-defined for all values of dref
and dmax.

Note that this change allows a user to set dref > dmax, but the
behavior is well-defined in this case (by reversing the order). Not
sure if we want that or not.

Also, specify that setting refDistance and maxDistance to a
non-positive value throws a TypeError.