### PR TITLE
Fix #324: Handle degenerate azimuth/elevation calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10657,10 +10657,11 @@ Quad up-mix:
           Azimuth and Elevation
         </h3>
         <p>
-          The following algorithm must be used to calculate the <em>azimuth</em>
-          and <em>elevation</em> for the <a><code>PannerNode</code></a>. The
-          <code>normalize()</code> function makes the vector a unit vector,
-          except when the vector has zero length. In this case, nothing is done.
+          The following algorithm must be used to calculate the
+          <em>azimuth</em> and <em>elevation</em> for the
+          <a><code>PannerNode</code></a>. The <code>normalize()</code> function
+          makes the vector a unit vector, except when the vector has zero
+          length. In this case, nothing is done.
         </p>
         <pre>
   // Calculate the source-listener vector.

--- a/index.html
+++ b/index.html
@@ -10657,20 +10657,14 @@ Quad up-mix:
           Azimuth and Elevation
         </h3>
         <p>
-          The following algorithm must be used to calculate the
-          <em>azimuth</em> and <em>elevation</em> for the
-          <a><code>PannerNode</code></a>:
+          The following algorithm must be used to calculate the <em>azimuth</em>
+          and <em>elevation</em> for the <a><code>PannerNode</code></a>. The
+          <code>normalize()</code> function makes the vector a unit vector,
+          except when the vector has zero length. In this case, nothing is done.
         </p>
         <pre>
   // Calculate the source-listener vector.
   vec3 sourceListener = source.position - listener.position;
-
-  if (sourceListener.isZero()) {
-      // Handle degenerate case if source and listener are at the same point.
-      azimuth = 0;
-      elevation = 0;
-      return;
-  }
 
   sourceListener.normalize();
 


### PR DESCRIPTION
In the current code, if the source to listener vector is zero, the
algorithm immediately returns azimuth = 0 and elevation = 0.  This
causes a discontinuity.

Instead, remove the early exit and let the source-listener vector
propagate through. This removes this discontinuity, but in general
there is still the discontinuity when the source and listener
positions are the same.  This is unavoidable.

Also add a short note on what normalize() does in general and when the
vector is the 0 vector. (Does nothing).