### PR TITLE
Fixing "playbackTime" to "currentTime" and the definition of "sampleRate".

### DIFF
--- a/index.html
+++ b/index.html
@@ -5644,21 +5644,19 @@ class MyProcessor extends AudioWorkletProcessor {
             </p>
             <dl title="dictionary AudioContextInfo" class="idl">
               <dt>
-                double playbackTime
+                double currentTime
               </dt>
               <dd>
                 The context time of the block of audio being processed. By
                 definition this will be equal to the value of
-                <a><code>BaseAudioContext</code></a>'s
-                <a><code>currentTime</code></a> attribute that was most
-                recently observable in the <a>control thread</a>.
+                <a>BaseAudioContext</a>'s <a>currentTime</a> attribute that was
+                most recently observable in the <a>control thread</a>.
               </dd>
               <dt>
                 float sampleRate
               </dt>
               <dd>
-                Represents the sample rate of the associated
-                <a><code>BaseAudioContext</code></a>.
+                The sample rate of the associated <a>BaseAudioContext</a>.
               </dd>
             </dl>
           </section>


### PR DESCRIPTION
PTAL - @rtoy.

This PR addresses https://github.com/WebAudio/web-audio-api/issues/969.

Preview: https://rawgit.com/hoch/web-audio-api/969-audiocontextinfo-fix/index.html#idl-def-AudioContextInfo