### PR TITLE
Fix #1068: ConstantSourceNode output behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -4102,6 +4102,14 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a>OscillatorNode</a>.
         </p>
         <p>
+          Before a source is started (by calling <a href=
+          "#widl-AudioScheduledSourceNode-start-void-double-when"><code>start</code></a>,
+          the source node must output silence (0). After a source has been
+          stopped (by calling <a href=
+          "#widl-AudioScheduledSourceNode-stop-void-double-when"><code>stop</code></a>),
+          the source must then output silence (0).
+        </p>
+        <p>
           <a>AudioScheduledSourceNode</a> cannot be instantiated directly, but
           is instead extended by the concrete interfaces for the source nodes.
         </p>


### PR DESCRIPTION
Specify that all source nodes produce silence before the node has
started and produces silence after the node has stopped.