### PR TITLE
Fix #1047: Simplify AudioNode dictionary section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3036,8 +3036,13 @@ function setupRoutingGraph() {
         </dl>
         <section>
           <h2>
-            Dictionaries
+            AudioNodeOptions
           </h2>
+          <p>
+            This specifies the options that can be used in constructing all
+            <a>AudioNode</a>s. All members are optional. However, the specific
+            values used for each node depends on the actual node.
+          </p>
           <dl title="dictionary AudioNodeOptions" class="idl">
             <dt>
               unsigned long channelCount


### PR DESCRIPTION
Basically rename the section from "Dictionaries" to
"AudioNodeOptions" to match how other nodes handle their
dictionaries.

Also add a bit of text saying the members are optional, and that the
specific default values depend on the actual node.