### PR TITLE
Fix #1067: Add arguments to event constructors

### DIFF
--- a/index.html
+++ b/index.html
@@ -2270,8 +2270,8 @@ function setupRoutingGraph() {
             <a><code>OfflineAudioContext</code></a> for legacy reasons.
           </p>
           <dl title=
-          "[Constructor]interface OfflineAudioCompletionEvent : Event" class=
-          "idl">
+          "[Constructor(DOMString type, OfflineAudioCompletionEventInit eventInitDict)]interface OfflineAudioCompletionEvent : Event"
+          class="idl">
             <dt>
               readonly attribute AudioBuffer renderedBuffer
             </dt>
@@ -2281,6 +2281,22 @@ function setupRoutingGraph() {
               </p>
             </dd>
           </dl>
+          <section>
+            <h3>
+              OfflineAudioCompletionEventInit
+            </h3>
+            <dl title="dictionary OfflineAudioCompletionEventInit : EventInit"
+            class="idl">
+              <dt>
+                required AudioBuffer renderedBuffer
+              </dt>
+              <dd>
+                Value to be assigned to the <a href=
+                "#widl-OfflineAudioCompletionEvent-renderedBuffer"><code>renderedBuffer</code></a>
+                attribute of the event.
+              </dd>
+            </dl>
+          </section>
         </section>
       </section>
       <section>
@@ -6092,8 +6108,9 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           synthesized data if there are no inputs) is then placed into the
           <code>outputBuffer</code>.
         </p>
-        <dl title="[Constructor]interface AudioProcessingEvent : Event" class=
-        "idl">
+        <dl title=
+        "[Constructor((DOMString type, AudioProcessingEventInit eventInitDict)]interface AudioProcessingEvent : Event"
+        class="idl">
           <dt>
             readonly attribute double playbackTime
           </dt>
@@ -6136,6 +6153,38 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             </p>
           </dd>
         </dl>
+        <section>
+          <h3>
+            AudioProcessingEventInit
+          </h3>
+          <dl title="dictionary AudioProcessingEventInit : EventInit" class=
+          "idl">
+            <dt>
+              required double playbackTime
+            </dt>
+            <dd>
+              Value to be assigned to the <a href=
+              "#widl-AudioProcessingEvent-playbackTime"><code>playbackTime</code></a>
+              attribute of the event.
+            </dd>
+            <dt>
+              required AudioBuffer inputBuffer
+            </dt>
+            <dd>
+              Value to be assigned to the <a href=
+              "#widl-AudioProcessingEvent-inputBuffer"><code>inputBuffer</code></a>
+              attribute of the event.
+            </dd>
+            <dt>
+              required AudioBuffer outputBuffer;
+            </dt>
+            <dd>
+              Value to be assigned to the <a href=
+              "#widl-AudioProcessingEvent-outputBuffer"><code>outputBuffer</code></a>
+              attribute of the event.
+            </dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
To be useful, the event constructors needs arguments.  Add them and
also define the needed dictionaries.