### PR TITLE
Fix #1073: Move AudioProcessingEvent section into ScriptProcessorNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6090,7 +6090,6 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             </p>
           </dd>
         </dl>
-      </section>
       <section class="informative">
         <h2>
           The AudioProcessingEvent Interface - DEPRECATED
@@ -6185,6 +6184,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             </dd>
           </dl>
         </section>
+      </section>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -6090,101 +6090,101 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             </p>
           </dd>
         </dl>
-      <section class="informative">
-        <h2>
-          The AudioProcessingEvent Interface - DEPRECATED
-        </h2>
-        <p>
-          This is an <code>Event</code> object which is dispatched to
-          <a><code>ScriptProcessorNode</code></a> nodes. It will be removed
-          when the ScriptProcessorNode is removed, as the replacement
-          <a>AudioWorkletNode</a> uses a different approach.
-        </p>
-        <p>
-          The event handler processes audio from the input (if any) by
-          accessing the audio data from the <code>inputBuffer</code> attribute.
-          The audio data which is the result of the processing (or the
-          synthesized data if there are no inputs) is then placed into the
-          <code>outputBuffer</code>.
-        </p>
-        <dl title=
-        "[Constructor((DOMString type, AudioProcessingEventInit eventInitDict)]interface AudioProcessingEvent : Event"
-        class="idl">
-          <dt>
-            readonly attribute double playbackTime
-          </dt>
-          <dd>
-            <p>
-              The time when the audio will be played in the same time
-              coordinate system as the <a><code>AudioContext</code></a>'s
-              <a href="#widl-BaseAudioContext-currentTime">currentTime</a>.
-            </p>
-          </dd>
-          <dt>
-            readonly attribute AudioBuffer inputBuffer
-          </dt>
-          <dd>
-            <p>
-              An AudioBuffer containing the input audio data. It will have a
-              number of channels equal to the
-              <code>numberOfInputChannels</code> parameter of the
-              createScriptProcessor() method. This AudioBuffer is only valid
-              while in the scope of the <a href=
-              "#widl-ScriptProcessorNode-onaudioprocess"><code>onaudioprocess</code></a>
-              function. Its values will be meaningless outside of this scope.
-            </p>
-          </dd>
-          <dt>
-            readonly attribute AudioBuffer outputBuffer
-          </dt>
-          <dd>
-            <p>
-              An AudioBuffer where the output audio data should be written. It
-              will have a number of channels equal to the
-              <code>numberOfOutputChannels</code> parameter of the
-              createScriptProcessor() method. Script code within the scope of
-              the <a href=
-              "#widl-ScriptProcessorNode-onaudioprocess"><code>onaudioprocess</code></a>
-              function is expected to modify the <code>Float32Array</code>
-              arrays representing channel data in this AudioBuffer. Any script
-              modifications to this AudioBuffer outside of this scope will not
-              produce any audible effects.
-            </p>
-          </dd>
-        </dl>
-        <section>
-          <h3>
-            AudioProcessingEventInit
-          </h3>
-          <dl title="dictionary AudioProcessingEventInit : EventInit" class=
-          "idl">
+        <section class="informative">
+          <h2>
+            The AudioProcessingEvent Interface - DEPRECATED
+          </h2>
+          <p>
+            This is an <code>Event</code> object which is dispatched to
+            <a><code>ScriptProcessorNode</code></a> nodes. It will be removed
+            when the ScriptProcessorNode is removed, as the replacement
+            <a>AudioWorkletNode</a> uses a different approach.
+          </p>
+          <p>
+            The event handler processes audio from the input (if any) by
+            accessing the audio data from the <code>inputBuffer</code>
+            attribute. The audio data which is the result of the processing (or
+            the synthesized data if there are no inputs) is then placed into
+            the <code>outputBuffer</code>.
+          </p>
+          <dl title=
+          "[Constructor((DOMString type, AudioProcessingEventInit eventInitDict)]interface AudioProcessingEvent : Event"
+          class="idl">
             <dt>
-              required double playbackTime
+              readonly attribute double playbackTime
             </dt>
             <dd>
-              Value to be assigned to the <a href=
-              "#widl-AudioProcessingEvent-playbackTime"><code>playbackTime</code></a>
-              attribute of the event.
+              <p>
+                The time when the audio will be played in the same time
+                coordinate system as the <a><code>AudioContext</code></a>'s
+                <a href="#widl-BaseAudioContext-currentTime">currentTime</a>.
+              </p>
             </dd>
             <dt>
-              required AudioBuffer inputBuffer
+              readonly attribute AudioBuffer inputBuffer
             </dt>
             <dd>
-              Value to be assigned to the <a href=
-              "#widl-AudioProcessingEvent-inputBuffer"><code>inputBuffer</code></a>
-              attribute of the event.
+              <p>
+                An AudioBuffer containing the input audio data. It will have a
+                number of channels equal to the
+                <code>numberOfInputChannels</code> parameter of the
+                createScriptProcessor() method. This AudioBuffer is only valid
+                while in the scope of the <a href=
+                "#widl-ScriptProcessorNode-onaudioprocess"><code>onaudioprocess</code></a>
+                function. Its values will be meaningless outside of this scope.
+              </p>
             </dd>
             <dt>
-              required AudioBuffer outputBuffer;
+              readonly attribute AudioBuffer outputBuffer
             </dt>
             <dd>
-              Value to be assigned to the <a href=
-              "#widl-AudioProcessingEvent-outputBuffer"><code>outputBuffer</code></a>
-              attribute of the event.
+              <p>
+                An AudioBuffer where the output audio data should be written.
+                It will have a number of channels equal to the
+                <code>numberOfOutputChannels</code> parameter of the
+                createScriptProcessor() method. Script code within the scope of
+                the <a href=
+                "#widl-ScriptProcessorNode-onaudioprocess"><code>onaudioprocess</code></a>
+                function is expected to modify the <code>Float32Array</code>
+                arrays representing channel data in this AudioBuffer. Any
+                script modifications to this AudioBuffer outside of this scope
+                will not produce any audible effects.
+              </p>
             </dd>
           </dl>
+          <section>
+            <h3>
+              AudioProcessingEventInit
+            </h3>
+            <dl title="dictionary AudioProcessingEventInit : EventInit" class=
+            "idl">
+              <dt>
+                required double playbackTime
+              </dt>
+              <dd>
+                Value to be assigned to the <a href=
+                "#widl-AudioProcessingEvent-playbackTime"><code>playbackTime</code></a>
+                attribute of the event.
+              </dd>
+              <dt>
+                required AudioBuffer inputBuffer
+              </dt>
+              <dd>
+                Value to be assigned to the <a href=
+                "#widl-AudioProcessingEvent-inputBuffer"><code>inputBuffer</code></a>
+                attribute of the event.
+              </dd>
+              <dt>
+                required AudioBuffer outputBuffer;
+              </dt>
+              <dd>
+                Value to be assigned to the <a href=
+                "#widl-AudioProcessingEvent-outputBuffer"><code>outputBuffer</code></a>
+                attribute of the event.
+              </dd>
+            </dl>
+          </section>
         </section>
-      </section>
       </section>
       <section>
         <h2>


### PR DESCRIPTION
Move the section for AudioProcessingEvent into the ScriptProcessorNode
section since the AudioProcessingEvent is for ScriptProcessorNode.
This makes this section match the style for
OfflineAudioCompletionEvent and OfflineAudioContext.
