### PR TITLE
Fix #1083: Use RangeError instead of TypeError

### DIFF
--- a/index.html
+++ b/index.html
@@ -6539,8 +6539,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             <p>
               A reference distance for reducing volume as source moves further
               from the listener. The default value is 1. A
-              <code>RangeError</code> exception must be thrown if this is set to
-              a non-positive value.
+              <code>RangeError</code> exception must be thrown if this is set
+              to a non-positive value.
             </p>
           </dd>
           <dt>

--- a/index.html
+++ b/index.html
@@ -6539,7 +6539,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             <p>
               A reference distance for reducing volume as source moves further
               from the listener. The default value is 1. A
-              <code>TypeError</code> exception must be thrown if this is set to
+              <code>RangeError</code> exception must be thrown if this is set to
               a non-positive value.
             </p>
           </dd>
@@ -6550,7 +6550,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             <p>
               The maximum distance between source and listener, after which the
               volume will not be reduced any further. The default value is
-              10000. A <code>TypeError</code> exception must be thrown if this
+              10000. A <code>RangeError</code> exception must be thrown if this
               is set to a non-positive value.
             </p>
           </dd>


### PR DESCRIPTION
For the PannerNode maxDistance and refDistance, use RangeError instead
of TypeError on attempts to set them to invalid values.

This is a minor update to #611.