### PR TITLE
Fix #1082: AudioNode context is a BaseAudioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -2824,11 +2824,11 @@ function setupRoutingGraph() {
             </dl>
           </dd>
           <dt>
-            readonly attribute AudioContext context
+            readonly attribute BaseAudioContext context
           </dt>
           <dd>
             <p>
-              The <a><code>AudioContext</code></a> which owns this
+              The <a><code>BaseAudioContext</code></a> which owns this
               <a><code>AudioNode</code></a>.
             </p>
           </dd>


### PR DESCRIPTION
Fix typo.