### PR TITLE
Clarify behaviour of AudioParam.cancelScheduledValues()

### DIFF
--- a/index.html
+++ b/index.html
@@ -3851,13 +3851,15 @@ function setupRoutingGraph() {
           <dd>
             <p>
               Cancels all scheduled parameter changes with times greater than
-              or equal to <code>cancelTime</code>. Active
-              <code><a>setTargetAtTime</a></code> automations (those with
-              <code>cancelTime</code> less than the supplied time value) will
-              also be cancelled. Any hold values scheduled by <a href=
-              "#widl-AudioParam-cancelAndHoldAtTime-AudioParam-double-cancelTime">
-              <code>cancelAndHoldAtTime</code></a> are also removed if the hold
-              time occurs after <code>cancelTime</code>.
+              or equal to <code>cancelTime</code>. Cancelling a scheduled
+              parameter change means removing the scheduled event from the
+              event list. Any active automations whose event time is less than
+              <code>cancelTime</code> are also cancelled, and such
+              cancellations may cause discontinuities because the original
+              value (from before such automation) is restored immediately. Any
+              hold values scheduled by <code><a>cancelAndHoldAtTime</a></code>
+              are also removed if the hold time occurs after
+              <code>cancelTime</code>.
             </p>
             <dl class="parameters">
               <dt>


### PR DESCRIPTION
On the W3C public-audio-dev mailing list, I noted that the spec is a bit vague on the behavior of AudioParam.cancelScheduledValues, especially concering currently running automation curves [1].

Since @rtoy agreed that this needs to be clarified in the spec [2], I created this PR as a suggestion.

I think, we should mention all automation methods here, not only `setTargetAtTime`. @joeberkovitz also suggested here [3], that possible discontinuities should be mentioned in the spec.

[1] https://lists.w3.org/Archives/Public/public-audio-dev/2016Nov/0001.html
[2] https://lists.w3.org/Archives/Public/public-audio-dev/2016Nov/0002.html
[3] https://github.com/WebAudio/web-audio-api/issues/344#issuecomment-151034935