### PR TITLE
Rearranging suspend() for AudioContext classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,107 +912,11 @@ function setupRoutingGraph() {
             </p>
           </dd>
           <dt>
-            Promise&lt;void&gt; suspend()
-          </dt>
-          <dd>
-            <p>
-              Suspends the progression of
-              <a><code>BaseAudioContext</code></a>'s <a href=
-              "#widl-BaseAudioContext-currentTime">currentTime</a>, allows any
-              current context processing blocks that are already processed to
-              be played to the destination, and then allows the system to
-              release its claim on audio hardware. This is generally useful
-              when the application knows it will not need the
-              <a>BaseAudioContext</a> for some time, and wishes to temporarily
-              <a>release system resource</a> associated with the
-              <a>BaseAudioContext</a>. The promise resolves when the frame
-              buffer is empty (has been handed off to the hardware), or
-              immediately (with no other effect) if the context is already
-              <code>suspended</code>. The promise is rejected if the context
-              has been closed.
-            </p>
-            <p>
-              <span class="synchronous">When suspend is called, execute these
-              steps:</span>
-            </p>
-            <ol>
-              <li>Let <em>promise</em> be a new Promise.
-              </li>
-              <li>If the <em>control thread state</em> flag on the
-              <a>AudioContext</a> is <code>closed</code> reject the promise
-              with <code>InvalidStateError</code>, abort these steps, returning
-              <em>promise</em>.
-              </li>
-              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
-              of the <a>AudioContext</a> is already <code>suspended</code>,
-              resolve <em>promise</em>, return it, and abort these steps.
-              </li>
-              <li>Set the <em>control thread state</em> flag on the
-              <a>AudioContext</a> to <code>suspended</code>.
-              </li>
-              <li>
-                <a href="#queue">Queue a control message</a> to suspend the
-                <a>AudioContext</a>.
-              </li>
-              <li>Return <em>promise</em>.
-              </li>
-            </ol>
-            <p>
-              Running a <a>control message</a> to suspend an
-              <a>AudioContext</a> means running these steps on the <a>rendering
-              thread</a>:
-            </p>
-            <ol>
-              <li>Attempt to <a>release system resources</a>.
-              </li>
-              <li>Set the <a>rendering thread state</a> on the
-              <a>AudioContext</a> to <code>suspended</code>.
-              </li>
-              <li>Queue a task on the <a>control thread</a>'s event loop, to
-              execute these steps:
-                <ol>
-                  <li>Resolve <em>promise</em>.
-                  </li>
-                  <li>If the <a href="#widl-audiocontext-state">state</a>
-                  attribute of the <a>AudioContext</a> is not already
-                  <code>suspended</code>:
-                    <ol>
-                      <li>Set the <a href="#widl-audiocontext-state">state</a>
-                      attribute of the <a>AudioContext</a> to
-                      <code>suspended</code>.
-                      </li>
-                      <li>Queue a task to fire a simple event named
-                      <code>statechange</code> at the <a>AudioContext</a>.
-                      </li>
-                    </ol>
-                  </li>
-                </ol>
-              </li>
-            </ol>
-            <p>
-              While a <a>BaseAudioContext</a> is suspended,
-              <code>MediaStream</code>s will have their output ignored; that
-              is, data will be lost by the real time nature of media streams.
-              <code>HTMLMediaElement</code>s will similarly have their output
-              ignored until the system is resumed.
-              <a>AudioWorkletProcessor</a>s and <a>ScriptProcessorNode</a>s
-              will cease to have their processing handlers invoked while
-              suspended, but will resume when resumed. For the purpose of
-              <a>AnalyserNode</a> window functions, the data is considered as a
-              continuous stream - i.e. the
-              <code>resume()</code>/<code>suspend()</code> does not cause
-              silence to appear in the <a>AnalyserNode</a>'s stream of data. In
-              particular, calling <a>AnalyserNode</a> functions repeatedly when
-              a <a>BaseAudioContext</a> is suspended MUST return the same data.
-            </p>
-          </dd>
-          <dt>
             Promise&lt;void&gt; resume()
           </dt>
           <dd>
             <p>
-              Resumes the progression of the
-              <a><code>AudioContext</code></a>'s' <a href=
+              Resumes the progression of the <a>BaseAudioContext</a>'s <a href=
               "#widl-AudioContext-currentTime">currentTime</a> when it has been
               suspended.
             </p>
@@ -1024,37 +928,40 @@ function setupRoutingGraph() {
               <li>Let <em>promise</em> be a new Promise.
               </li>
               <li>If the <em>control thread state</em> flag on the
-              <a>AudioContext</a> is <code>closed</code> reject the promise
+              <a>BaseAudioContext</a> is <code>closed</code> reject the promise
               with <code>InvalidStateError</code>, abort these steps, returning
               <em>promise</em>.
               </li>
-              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
-              of the <a>AudioContext</a> is already <code>running</code>,
-              resolve <em>promise</em>, return it, and abort these steps.
+              <li>If the <a href="#widl-BaseAudioContext-state">state</a>
+              attribute of the <a>BaseAudioContext</a> is already
+              <code>running</code>, resolve <em>promise</em>, return it, and
+              abort these steps.
               </li>
-              <li>If the <a>AudioContext</a> is not <a>allowed to start</a>,
-              append <em>promise</em> to <a>pendingResumePromises</a> and abort
-              these steps, returning <em>promise</em>.
+              <li>If the <a>BaseAudioContext</a> is not <a>allowed to
+              start</a>, append <em>promise</em> to
+              <a>pendingResumePromises</a> and abort these steps, returning
+              <em>promise</em>.
               </li>
               <li>Set the <em>control thread state</em> flag on the
-              <a>AudioContext</a> to <code>running</code>.
+              <a>BaseAudioContext</a> to <code>running</code>.
               </li>
               <li>
                 <a href="#queue">Queue a control message</a> to resume the
-                <a>AudioContext</a>.
+                <a>BaseAudioContext</a>.
               </li>
               <li>Return <em>promise</em>.
               </li>
             </ol>
             <p>
-              Running a <a>control message</a> to resume an <a>AudioContext</a>
-              means running these steps on the <a>rendering thread</a>:
+              Running a <a>control message</a> to resume an
+              <a>BaseAudioContext</a> means running these steps on the
+              <a>rendering thread</a>:
             </p>
             <ol>
               <li>Attempt to <a href="#acquiring">acquire system resources</a>.
               </li>
               <li>Set the <a>rendering thread state</a> flag on the
-              <a>AudioContext</a> to <code>running</code>.
+              <a>BaseAudioContext</a> to <code>running</code>.
               </li>
               <li>Start <a href="#rendering-loop">rendering the audio
               graph</a>.
@@ -1077,16 +984,16 @@ function setupRoutingGraph() {
                   </li>
                   <li>Resolve <em>promise</em>.
                   </li>
-                  <li>If the <a href="#widl-audiocontext-state">state</a>
-                  attribute of the <a>AudioContext</a> is not already
+                  <li>If the <a href="#widl-BaseAudioContext-state">state</a>
+                  attribute of the <a>BaseAudioContext</a> is not already
                   <code>running</code>:
                     <ol>
-                      <li>Set the <a href="#widl-audiocontext-state">state</a>
-                      attribute of the <a>AudioContext</a> to
-                      <code>running</code>.
+                      <li>Set the <a href=
+                      "#widl-BaseAudioContext-state">state</a> attribute of the
+                      <a>BaseAudioContext</a> to <code>running</code>.
                       </li>
                       <li>Queue a task to fire a simple event named
-                      <code>statechange</code> at the <a>AudioContext</a>.
+                      <code>statechange</code> at the <a>BaseAudioContext</a>.
                       </li>
                     </ol>
                   </li>
@@ -1873,6 +1780,99 @@ function setupRoutingGraph() {
             </p>
           </dd>
           <dt>
+            Promise&lt;void&gt; suspend()
+          </dt>
+          <dd>
+            <p>
+              Suspends the progression of <a>AudioContext</a>'s <a href=
+              "#widl-BaseAudioContext-currentTime">currentTime</a>, allows any
+              current context processing blocks that are already processed to
+              be played to the destination, and then allows the system to
+              release its claim on audio hardware. This is generally useful
+              when the application knows it will not need the
+              <a>AudioContext</a> for some time, and wishes to temporarily
+              <a>release system resource</a> associated with the
+              <a>AudioContext</a>. The promise resolves when the frame buffer
+              is empty (has been handed off to the hardware), or immediately
+              (with no other effect) if the context is already
+              <code>suspended</code>. The promise is rejected if the context
+              has been closed.
+            </p>
+            <p>
+              <span class="synchronous">When suspend is called, execute these
+              steps:</span>
+            </p>
+            <ol>
+              <li>Let <em>promise</em> be a new Promise.
+              </li>
+              <li>If the <em>control thread state</em> flag on the
+              <a>AudioContext</a> is <code>closed</code> reject the promise
+              with <code>InvalidStateError</code>, abort these steps, returning
+              <em>promise</em>.
+              </li>
+              <li>If the <a href="#widl-AudioContext-state">state</a> attribute
+              of the <a>AudioContext</a> is already <code>suspended</code>,
+              resolve <em>promise</em>, return it, and abort these steps.
+              </li>
+              <li>Set the <em>control thread state</em> flag on the
+              <a>AudioContext</a> to <code>suspended</code>.
+              </li>
+              <li>
+                <a href="#queue">Queue a control message</a> to suspend the
+                <a>AudioContext</a>.
+              </li>
+              <li>Return <em>promise</em>.
+              </li>
+            </ol>
+            <p>
+              Running a <a>control message</a> to suspend an
+              <a>AudioContext</a> means running these steps on the <a>rendering
+              thread</a>:
+            </p>
+            <ol>
+              <li>Attempt to <a>release system resources</a>.
+              </li>
+              <li>Set the <a>rendering thread state</a> on the
+              <a>AudioContext</a> to <code>suspended</code>.
+              </li>
+              <li>Queue a task on the <a>control thread</a>'s event loop, to
+              execute these steps:
+                <ol>
+                  <li>Resolve <em>promise</em>.
+                  </li>
+                  <li>If the <a href="#widl-audiocontext-state">state</a>
+                  attribute of the <a>AudioContext</a> is not already
+                  <code>suspended</code>:
+                    <ol>
+                      <li>Set the <a href="#widl-audiocontext-state">state</a>
+                      attribute of the <a>AudioContext</a> to
+                      <code>suspended</code>.
+                      </li>
+                      <li>Queue a task to fire a simple event named
+                      <code>statechange</code> at the <a>AudioContext</a>.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+            <p>
+              While an <a>AudioContext</a> is suspended,
+              <code>MediaStream</code>s will have their output ignored; that
+              is, data will be lost by the real time nature of media streams.
+              <code>HTMLMediaElement</code>s will similarly have their output
+              ignored until the system is resumed. <a>AudioWorkletNode</a>s and
+              <a>ScriptProcessorNode</a>s will cease to have their processing
+              handlers invoked while suspended, but will resume when the
+              context is resumed. For the purpose of <a>AnalyserNode</a> window
+              functions, the data is considered as a continuous stream - i.e.
+              the <code>resume()</code>/<code>suspend()</code> does not cause
+              silence to appear in the <a>AnalyserNode</a>'s stream of data. In
+              particular, calling <a>AnalyserNode</a> functions repeatedly when
+              a <a>AudioContext</a> is suspended MUST return the same data.
+            </p>
+          </dd>
+          <dt>
             Promise&lt;void&gt; close()
           </dt>
           <dd>
@@ -2054,7 +2054,7 @@ function setupRoutingGraph() {
         </h2>
         <p>
           <a><code>OfflineAudioContext</code></a> is a particular type of
-          <a><code>AudioContext</code></a> for rendering/mixing-down
+          <a><code>BaseAudioContext</code></a> for rendering/mixing-down
           (potentially) faster than real-time. It does not render to the audio
           hardware, but instead renders as quickly as possible, fulfilling the
           returned promise with the rendered result as an
@@ -2178,26 +2178,6 @@ function setupRoutingGraph() {
                 </ol>
               </li>
             </ol>
-          </dd>
-          <dt>
-            Promise&lt;void&gt; resume()
-          </dt>
-          <dd>
-            <p>
-              Resumes the progression of time in an audio context that has been
-              suspended. The promise resolves immediately because the
-              <a><code>OfflineAudioContext</code></a> does not require the
-              audio hardware. If the context is not currently suspended or the
-              rendering has not started, the promise is rejected with
-              <code>InvalidStateError</code>.
-            </p>
-            <p>
-              In contrast to a live <a><code>AudioContext</code></a>, the value
-              of <a href="#widl-BaseAudioContext-currentTime">currentTime</a>
-              always reflects the start time of the next block to be rendered
-              by the audio graph, since the context's audio stream does not
-              advance in time during suspension.
-            </p>
           </dd>
           <dt>
             Promise&lt;void&gt; suspend()


### PR DESCRIPTION
PTAL.

This PR addressed the change of suspend()/resume() methods.
1. The current suspend() method definition moves from `BaseAudioContext` to `AudioContext`.
2. The resume() method belongs to BaseAudioContext: so the original defnition stays in the same place, but I had to change all the instances of `AudioContext` to `BaseAudioContext`.
3. The resume() method is removed from `OffilneAudioContext`.

Preview: https://rawgit.com/hoch/web-audio-api/eb526d1fba81df1b2f6be79e3acec947aa2c18c6/index.html