### PR TITLE
Fix #1097: Move AudioContextLatencyCategory and baseLatency to AudioC…

### DIFF
--- a/index.html
+++ b/index.html
@@ -779,28 +779,6 @@ function setupRoutingGraph() {
             decodeAudioData</a>.)
           </dd>
         </dl>
-        <dl title="enum AudioContextLatencyCategory" class="idl">
-          <dt>
-            balanced
-          </dt>
-          <dd>
-            Balance audio output latency and power consumption.
-          </dd>
-          <dt>
-            interactive
-          </dt>
-          <dd>
-            Provide the lowest audio output latency possible without glitching.
-            This is the default.
-          </dd>
-          <dt>
-            playback
-          </dt>
-          <dd>
-            Prioritize sustained playback without interruption over audio
-            output latency. Lowest power consumption.
-          </dd>
-        </dl>
         <dl title="interface BaseAudioContext : EventTarget" class="idl"
         data-merge="DecodeSuccessCallback DecodeErrorCallback">
           <dt>
@@ -894,27 +872,6 @@ function setupRoutingGraph() {
             <p>
               Describes the current state of the <a>AudioContext</a>, on the
               <a>control thread</a>.
-            </p>
-          </dd>
-          <dt>
-            readonly attribute double baseLatency
-          </dt>
-          <dd>
-            <p>
-              This represents the number of seconds of processing latency
-              incurred by the <a>AudioContext</a> passing the audio from the
-              <a>AudioDestinationNode</a> to the audio subsystem. It does not
-              include any additional latency that might be caused by any other
-              processing between the output of the <a>AudioDestinationNode</a>
-              and the audio hardware and specifically does not include any
-              latency incurred the audio graph itself.
-            </p>
-            <p>
-              For example, if the audio context is running at 44.1 kHz and the
-              <a>AudioDestinationNode</a> implements double buffering
-              internally and can process and output audio every 128 sample
-              frames, then the processing latency is \((2\cdot128)/44100 =
-              5.805 \mathrm{ ms}\), approximately.
             </p>
           </dd>
           <dt>
@@ -1725,6 +1682,28 @@ function setupRoutingGraph() {
           "https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">
           triggered by a user activation</a> (as described in [[HTML]]).
         </p>
+        <dl title="enum AudioContextLatencyCategory" class="idl">
+          <dt>
+            balanced
+          </dt>
+          <dd>
+            Balance audio output latency and power consumption.
+          </dd>
+          <dt>
+            interactive
+          </dt>
+          <dd>
+            Provide the lowest audio output latency possible without glitching.
+            This is the default.
+          </dd>
+          <dt>
+            playback
+          </dt>
+          <dd>
+            Prioritize sustained playback without interruption over audio
+            output latency. Lowest power consumption.
+          </dd>
+        </dl>
         <dl title=
         '[Constructor(optional AudioContextOptions contextOptions)] interface AudioContext : BaseAudioContext'
         class='idl'>
@@ -1782,6 +1761,27 @@ function setupRoutingGraph() {
               User-Agents are encouraged to log an informative message if they
               have access to a logging mechanism, such as a developer tools
               console.
+            </p>
+          </dd>
+          <dt>
+            readonly attribute double baseLatency
+          </dt>
+          <dd>
+            <p>
+              This represents the number of seconds of processing latency
+              incurred by the <a>AudioContext</a> passing the audio from the
+              <a>AudioDestinationNode</a> to the audio subsystem. It does not
+              include any additional latency that might be caused by any other
+              processing between the output of the <a>AudioDestinationNode</a>
+              and the audio hardware and specifically does not include any
+              latency incurred the audio graph itself.
+            </p>
+            <p>
+              For example, if the audio context is running at 44.1 kHz and the
+              <a>AudioDestinationNode</a> implements double buffering
+              internally and can process and output audio every 128 sample
+              frames, then the processing latency is \((2\cdot128)/44100 =
+              5.805 \mathrm{ ms}\), approximately.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
…ontext

Move the definition of AudioContextLatencyCategory and baseLatency
from BaseAudioContext to AudioContext because these really only make
sense for an AudioContext.  These don't apply to an
OfflineAudioContext.

Just moved the sections; no other changes.