### PR TITLE
Fix #1111: Use correct type for ChannelMerger options arg

### DIFF
--- a/index.html
+++ b/index.html
@@ -7889,7 +7889,7 @@ function calculateNormalizationScale(buffer)
           </figcaption>
         </figure>
         <dl title=
-        "[Constructor(BaseAudioContext context, optional ChannelSplitterOptions options)] interface ChannelMergerNode : AudioNode"
+        "[Constructor(BaseAudioContext context, optional ChannelMergerOptions options)] interface ChannelMergerNode : AudioNode"
         class="idl"></dl>
         <section>
           <h2>


### PR DESCRIPTION
The constructor for ChannelMergerNode used ChannelSplitterOptions as
the type of the options arg.  It should have been
ChannelMergerOptions.