### PR TITLE
Restore maxDelayTime default value removed by mistake in 3554a8.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1305,7 +1305,7 @@ function setupRoutingGraph() {
             </p>
             <dl class="parameters">
               <dt>
-                optional double maxDelayTime
+                optional double maxDelayTime = 1.0
               </dt>
               <dd>
                 The <dfn>maxDelayTime</dfn> parameter is optional and specifies


### PR DESCRIPTION
This fixes #1122.