### PR TITLE
Prevent connecting an AudioNode to an AudioParam of a different AudioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -2560,7 +2560,12 @@ function setupRoutingGraph() {
                 The <code>destination</code> parameter is the
                 <a><code>AudioParam</code></a> to connect to. This method does
                 not return <code>destination</code>
-                <a><code>AudioParam</code></a> object.
+                <a><code>AudioParam</code></a> object. <span class=
+                "synchronous">If <var>destination</var> belongs to an
+                <a>AudioNode</a> that belongs to a <a>BaseAudioContext</a> that
+                is different from the <a>BaseAudioContext</a> that has created
+                the <a>AudioNode</a> on which this method was called, an
+                <code>InvalidAccessError</code> MUST be thrown.</span>
               </dd>
               <dt>
                 optional unsigned long output = 0


### PR DESCRIPTION
This fixes #1126.