### PR TITLE
Define the constructor for AudioNodes (#1117)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4427,6 +4427,31 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;DelayOptions&lt;/a&gt; options)]interface DelayNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>DelayNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>DelayNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional DelayOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>DelayNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             readonly attribute AudioParam delayTime
           </dt>
           <dd>
@@ -4791,6 +4816,31 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;AudioBufferSourceOptions&lt;/a&gt; options)]interface AudioBufferSourceNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>AudioBufferSourceNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>AudioBufferSourceNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional AudioBufferSourceOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>AudioBufferSourceNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             attribute AudioBuffer? buffer
           </dt>
           <dd>
@@ -5113,6 +5163,31 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;ConstantSourceOptions&lt;/a&gt; options)]interface ConstantSourceNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>ConstantSourceNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional ConstantSourceOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>ConstantSourceNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             readonly attribute AudioParam offset
           </dt>
           <dd>
@@ -5169,7 +5244,33 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
         </p>
         <dl title=
         "[Constructor(&lt;a&gt;AudioContext&lt;/a&gt; context, &lt;a&gt;MediaElementAudioSourceOptions&lt;/a&gt; options)]interface MediaElementAudioSourceNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl"></dl>
+        class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>MediaElementAudioSOurceNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>MediaElementAudioSourceNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional MediaElementAudioSourceOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>MediaELementAudioSourceNode</a>.
+            </dd>
+          </dl>
+          </dd>
+      </dl>
         <p>
           A <a>MediaElementAudioSourceNode</a> is created given an
           <code>HTMLMediaElement</code> using the <a>AudioContext</a>
@@ -5508,12 +5609,30 @@ window.audioWorklet.import("bypass.js").then(function () {
               optional <a>AudioWorkletNodeOptions</a> options)
             </dt>
             <dd>
+            <dl class=parameters>
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>AudioWorkletNode</a> will be
+                <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional AudioWorkletOptions options
+              </dt>
+              <dd>
+                Optional initial parameters value for this <a>AudioWorkletNode</a>.
+              </dd>
+            </dl>
               <p>
-                Performs the <a href=
+                Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
+                <a href=#audionode-constructor-common>Initialize the common part</a>
+                of <var>node</var>.  Perform the <a href=
                 "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">construction
                 procedure</a> of an <a><code>AudioWorkletNode</code></a> and
                 the corresponding <a><code>AudioWorkletProcessor</code></a>
                 object.
+                Return <var>node</var>.
               </p>
             </dd>
             <dt>
@@ -6596,6 +6715,31 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;PannerOptions&lt;/a&gt; options)]interface PannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>PannerNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>PannerNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional PannerOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>PannerNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             attribute PanningModelType panningModel
           </dt>
           <dd>
@@ -7219,6 +7363,31 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;StereoPannerOptions&lt;/a&gt; options)]interface StereoPannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>StereoPannerNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>StereoPannerNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional StereoPannerOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>StereoPannerNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             readonly attribute AudioParam pan
           </dt>
           <dd>
@@ -7306,6 +7475,31 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
         <dl title=
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;ConvolverOptions&lt;/a&gt; options)]interface ConvolverNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>ConvolverNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>ConvolverNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional ConvolverOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>ConvolverNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             attribute AudioBuffer? buffer
           </dt>
@@ -7537,6 +7731,31 @@ function calculateNormalizationScale(buffer)
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;AnalyserOptions&lt;/a&gt; options)]interface AnalyserNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <!--<dt> // Real-time frequency-domain data </dt>-->
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>AnalyserNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>AnalyserNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional AnalyserOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>AnalyserNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             void getFloatFrequencyData()
           </dt>
@@ -7998,7 +8217,33 @@ function calculateNormalizationScale(buffer)
         </p>
         <dl title=
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;ChannelSplitterOptions&lt;/a&gt; options)] interface ChannelSplitterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl"></dl>
+        class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>ChannelSplitterNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional ChannelSplitterNode options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>ChannelSplitterNode</a>.
+            </dd>
+          </dl>
+          </dd>
+      </dl>
         <section>
           <h2>
             ChannelSplitterOptions
@@ -8079,7 +8324,33 @@ function calculateNormalizationScale(buffer)
         </figure>
         <dl title=
         "[Constructor(BaseAudioContext context, optional ChannelMergerOptions options)] interface ChannelMergerNode : AudioNode"
-        class="idl"></dl>
+        class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>ChannelMergerNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional ChannelMergerOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>ChannelMergerNode</a>.
+            </dd>
+          </dl>
+          </dd>
+      </dl>
         <section>
           <h2>
             ChannelMergerOptions
@@ -8129,6 +8400,32 @@ function calculateNormalizationScale(buffer)
         <dl title=
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;DynamicsCompressorOptions&lt;/a&gt; options)]interface DynamicsCompressorNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>DynamicsCompressorNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>DynamicsCompressorNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional DynamicsCompressorOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this
+              <a>DynamicsCompressorNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             readonly attribute AudioParam threshold
           </dt>
@@ -8597,6 +8894,31 @@ function calculateNormalizationScale(buffer)
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;BiquadFilterOptions&lt;/a&gt; options)]interface BiquadFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>BiquadFilterNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional BiquadFilterOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>BiquadFilterNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             attribute BiquadFilterType type
           </dt>
           <dd>
@@ -9026,6 +9348,31 @@ $$
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, &lt;a&gt;IIRFilterOptions&lt;/a&gt; options)] interface IIRFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>IIRFilterNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>IIRFilterNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional IIRFilterOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>IIRFilterNode</a>.
+            </dd>
+          </dl>
+          </dd>
+          <dt>
             void getFrequencyResponse()
           </dt>
           <dd>
@@ -9190,6 +9537,31 @@ $$
         <dl title=
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;WaveShaperOptions&lt;/a&gt; options)]interface WaveShaperNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl" data-merge="OverSampleType">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>WaveShaperNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>WaveShaperNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional WaveShaperOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>WaveShaperNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             attribute Float32Array? curve
           </dt>
@@ -9414,6 +9786,31 @@ $$
         <dl title=
         "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;OscillatorOptions&lt;/a&gt; options)] interface OscillatorNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
         class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>OscillatorNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>OscillatorNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional OscillatorOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this <a>OscillatorNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             attribute OscillatorType type
           </dt>
@@ -9825,7 +10222,34 @@ odd function with period \(2\pi\).
         </p>
         <dl title=
         "[Constructor(&lt;a&gt;AudioContext&lt;/a&gt; context, &lt;a&gt;MediaStreamAudioSourceOptions&lt;/a&gt; options)]interface MediaStreamAudioSourceNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl"></dl>
+        class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>MediaStreamAudioSourceNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional MediaStreamAudioSourceOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this
+              <a>MediaStreamAudioSourceNode</a>.
+            </dd>
+          </dl>
+          </dd>
+      </dl>
         <section>
           <h2>
             MediaStreamAudioSourceOptions
@@ -9916,6 +10340,33 @@ odd function with period \(2\pi\).
         <dl title=
         "[Constructor(AudioContext context, optional AudioNodeOptions options)]interface MediaStreamAudioDestinationNode : AudioNode"
         class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>node</var> be a new <a>MediaStreamAudioDestinationNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>node</var>, and return <var>node</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new
+              <a>MediaStreamAudioDestinationNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional AudioNodeOptions options
+            </dt>
+            <dd>
+              Optional initial parameter value for this
+              <a>MediaStreamAudioDestinationNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             readonly attribute MediaStream stream
           </dt>

--- a/index.html
+++ b/index.html
@@ -2398,8 +2398,9 @@ function setupRoutingGraph() {
         </ol>
         <p>
           To create a new <a>AudioNode</a> of a particular type <var>i</var>
-          using its <a>factory method</a>, with a <var>BaseAudioContext</var>
-          <var>c</var> as first argument, execute these steps:
+          using its <a>factory method</a>, called on a
+          <var>BaseAudioContext</var> <var>c</var>, execute
+          these steps:
         </p>
         <ol>
           <li>Let <var>o</var> be a new object of type <var>i</var>.</li>

--- a/index.html
+++ b/index.html
@@ -1162,7 +1162,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates an <a><code>AudioBufferSourceNode</code></a>.
+              <a>Factory method</a> for a
+              <a><code>AudioBufferSourceNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1170,7 +1171,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>ConstantSourceNode</code></a>.
+              <a>Factory method</a> for a
+              <a><code>ConstantSourceNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1178,6 +1180,7 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
+              <a>Factory method</a> for a <a>ScriptProcessorNode</a>.
               This method is DEPRECATED, as it is intended to be replaced by
               <a href="#AudioWorkletNode"><code>AudioWorkletNode</code></a>.
               Creates a <a><code>ScriptProcessorNode</code></a> for direct
@@ -1241,7 +1244,7 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates an <a><code>AnalyserNode</code></a>.
+              <a>Factory method</a> for an <a><code>AnalyserNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1257,8 +1260,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>DelayNode</code></a> representing a variable
-              delay line. The initial default delay time will be 0 seconds.
+              <a>Factory method</a> for a <a>DelayNode</a>. The initial default
+            delay time will be 0 seconds.
             </p>
             <dl class="parameters">
               <dt>
@@ -1278,9 +1281,9 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>BiquadFilterNode</code></a> representing a
-              second order filter which can be configured as one of several
-              common filter types.
+              <a>Factory method</a> for a <a><code>BiquadFilterNode</code></a>
+            representing a second order filter which can be configured as one of
+            several common filter types.
             </p>
           </dd>
           <dt>
@@ -1289,8 +1292,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates an <a><code>IIRFilterNode</code></a> representing a
-              general IIR Filter.
+              <a>Factory method</a> for an <a><code>IIRFilterNode</code></a>
+              representing a general IIR Filter.
             </p>
             <dl class="parameters">
               <dt>
@@ -1322,8 +1325,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>WaveShaperNode</code></a> representing a
-              non-linear distortion.
+              <a>Factory method</a> for a <a><code>WaveShaperNode</code></a>
+              representing a non-linear distortion.
             </p>
           </dd>
           <dt>
@@ -1331,7 +1334,7 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>PannerNode</code></a>.
+              <a>Factory method</a> for a <a><code>PannerNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1339,7 +1342,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>StereoPannerNode</code></a>.
+              <a>Factory method</a> for an a
+              <a><code>StereoPannerNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1347,7 +1351,7 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>ConvolverNode</code></a>.
+              <a>Factory method</a> for a <a><code>ConvolverNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1355,10 +1359,10 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>ChannelSplitterNode</code></a> representing a
-              channel splitter. <span class="synchronous">An
-              <code>IndexSizeError</code> exception MUST be thrown for invalid
-              parameter values.</span>
+              <a>Factory method</a> for a
+              <a><code>ChannelSplitterNode</code></a> representing a channel
+              splitter. <span class="synchronous">An <code>IndexSizeError</code>
+              exception MUST be thrown for invalid parameter values.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -1375,8 +1379,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>ChannelMergerNode</code></a> representing a
-              channel merger. <span class="synchronous">An
+              <a>Factory method</a> for a <a><code>ChannelMergerNode</code></a>
+              representing a channel merger. <span class="synchronous">An
               <code>IndexSizeError</code> exception MUST be thrown for invalid
               parameter values.</span>
             </p>
@@ -1396,7 +1400,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>DynamicsCompressorNode</code></a>
+              <a>Factory method</a> for a
+            <a><code>DynamicsCompressorNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1404,7 +1409,7 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates an <a><code>OscillatorNode</code></a>.
+              <a>Factory method</a> for an <a><code>OscillatorNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1412,30 +1417,28 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>PeriodicWave</code></a> representing a
-              waveform containing arbitrary harmonic content. <span class=
-              "synchronous">The <code>real</code> and <code>imag</code>
-              parameters must be of type <code>Float32Array</code> (described
-              in [[!TYPED-ARRAYS]]) of equal lengths greater than zero or an
+            <a>Factory method</a> a <a><code>PeriodicWave</code></a>
+            representing a waveform containing arbitrary harmonic content. <span
+              class= "synchronous">The <code>real</code> and <code>imag</code>
+              parameters must be of type <code>Float32Array</code> (described in
+              [[!TYPED-ARRAYS]]) of equal lengths greater than zero or an
               <code>IndexSizeError</code> exception MUST be thrown.</span> All
-              implementations must support arrays up to at least 8192. These
-              parameters specify the Fourier coefficients of a <a href=
+            implementations must support arrays up to at least 8192. These
+            parameters specify the Fourier coefficients of a <a href=
               "https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
-              representing the partials of a periodic waveform. The created
-              <a><code>PeriodicWave</code></a> will be used with an
-              <a><code>OscillatorNode</code></a> and, by default, will
-              represent a <em>normalized</em> time-domain waveform having
-              maximum absolute peak value of 1. Another way of saying this is
-              that the generated waveform of an
-              <a><code>OscillatorNode</code></a> will have maximum peak value
-              at 0dBFS. Conveniently, this corresponds to the full-range of the
-              signal values used by the Web Audio API. Because the PeriodicWave
-              is normalized by default on creation, the <code>real</code> and
-              <code>imag</code> parameters represent <em>relative</em> values.
-              If normalization is disabled via the
-              <code>disableNormalization</code> parameter, this normalization
-              is disabled, and the time-domain waveform has the amplitudes as
-              given by the Fourier coefficients.
+            representing the partials of a periodic waveform. The created
+            <a><code>PeriodicWave</code></a> will be used with an
+            <a><code>OscillatorNode</code></a> and, by default, will represent a
+            <em>normalized</em> time-domain waveform having maximum absolute peak
+            value of 1. Another way of saying this is that the generated waveform of
+            an <a><code>OscillatorNode</code></a> will have maximum peak value at
+            0dBFS. Conveniently, this corresponds to the full-range of the signal
+            values used by the Web Audio API. Because the PeriodicWave is normalized
+            by default on creation, the <code>real</code> and <code>imag</code>
+            parameters represent <em>relative</em> values.  If normalization is
+            disabled via the <code>disableNormalization</code> parameter, this
+            normalization is disabled, and the time-domain waveform has the
+            amplitudes as given by the Fourier coefficients.
             </p>
             <p>
               As <a>PeriodicWave</a> objects maintain their own copies of these

--- a/index.html
+++ b/index.html
@@ -10317,8 +10317,37 @@ odd function with period \(2\pi\).
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(AudioContext context, MediaStreamTrackAudioSourceOptions options)]interface MediaStreamTrackAudioSourceNode : AudioNode"
-        class="idl"></dl>
+        "interface MediaStreamTrackAudioSourceNode : AudioNode"
+        class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+            <p>
+              Let <var>node</var> be a new
+              <a>MediaStreamTrackAudioSourceNode</a> object. <a href=
+              "#audionode-constructor-common">Initialize the common part</a> of
+            <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                AudioContext context
+              </dt>
+              <dd>
+                The <a>AudioContext</a> this new
+                <a>MediaStreamTrackAudioSourceNode</a> will be
+                <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                MediaStreamTrackAudioSourceOptions options
+              </dt>
+              <dd>
+                Initial parameter value for this
+                <a>MediaStreamTrackAudioSourceNode</a>.
+              </dd>
+            </dl>
+          </dd>
+      </dl>
         <section>
           <h2>
             MediaStreamTrackAudioSourceOptions

--- a/index.html
+++ b/index.html
@@ -2414,8 +2414,10 @@ function setupRoutingGraph() {
         <ol>
           <li>Let <var>o</var> be a new object of type <var>i</var>.
           </li>
-          <li>Let <var>option</var> be a dictionnary of the type associated to
-          the interface associated to this factory method.
+          <li>Let <var>option</var> be a dictionnary of the type <a
+            href="#dfn-associated-option-object">associated</a> to
+          the interface <a href="#dfn-associated-interface">associated</a> to this
+          factory method.
           </li>
           <li>For each parameter passed to the factory method, set the
           dictionary member of the same name on <var>option</var> to the value

--- a/index.html
+++ b/index.html
@@ -4337,7 +4337,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;GainOptions&lt;/a&gt; options)]interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -4445,7 +4445,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           latency equal to the amount of the delay.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;DelayOptions&lt;/a&gt; options)]interface DelayNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface DelayNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -4549,7 +4549,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>AudioContext</code></a>.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;AudioBufferOptions&lt;a&gt; options)]interface AudioBuffer"
+        "interface AudioBuffer"
         class="idl">
           <dt>
             readonly attribute float sampleRate
@@ -4834,7 +4834,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <code>buffer set</code>, initially set to false.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;AudioBufferSourceOptions&lt;/a&gt; options)]interface AudioBufferSourceNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
+        "interface AudioBufferSourceNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -5183,7 +5183,7 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
   numberOfOutputs : 1
 </pre>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;ConstantSourceOptions&lt;/a&gt; options)]interface ConstantSourceNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
+        "interface ConstantSourceNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -5267,7 +5267,7 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;AudioContext&lt;/a&gt; context, &lt;a&gt;MediaElementAudioSourceOptions&lt;/a&gt; options)]interface MediaElementAudioSourceNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface MediaElementAudioSourceNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -6738,7 +6738,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           </dd>
         </dl>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;PannerOptions&lt;/a&gt; options)]interface PannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface PannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -7386,7 +7386,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;StereoPannerOptions&lt;/a&gt; options)]interface StereoPannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface StereoPannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -7500,7 +7500,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           set</code>, initially set to false.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;ConvolverOptions&lt;/a&gt; options)]interface ConvolverNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface ConvolverNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -7755,7 +7755,7 @@ function calculateNormalizationScale(buffer)
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;AnalyserOptions&lt;/a&gt; options)]interface AnalyserNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface AnalyserNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <!--<dt> // Real-time frequency-domain data </dt>-->
           <dt>
@@ -8243,7 +8243,7 @@ function calculateNormalizationScale(buffer)
           desired.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;ChannelSplitterOptions&lt;/a&gt; options)] interface ChannelSplitterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface ChannelSplitterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -8351,7 +8351,7 @@ function calculateNormalizationScale(buffer)
           </figcaption>
         </figure>
         <dl title=
-        "[Constructor(BaseAudioContext context, optional ChannelMergerOptions options)] interface ChannelMergerNode : AudioNode"
+        "interface ChannelMergerNode : AudioNode"
         class="idl">
           <dt>
             Constructor
@@ -8427,7 +8427,7 @@ function calculateNormalizationScale(buffer)
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;DynamicsCompressorOptions&lt;/a&gt; options)]interface DynamicsCompressorNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface DynamicsCompressorNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -8921,7 +8921,7 @@ function calculateNormalizationScale(buffer)
           <a>a-rate</a> <a><code>AudioParam</code></a>.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;BiquadFilterOptions&lt;/a&gt; options)]interface BiquadFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface BiquadFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -9376,10 +9376,10 @@ $$
           coefficients.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, &lt;a&gt;IIRFilterOptions&lt;/a&gt; options)] interface IIRFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface IIRFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
-            Constructor
+          Constructor
           </dt>
           <dd>
             <p>
@@ -9396,7 +9396,7 @@ $$
                 be <a href="#associated">associated</a> with.
               </dd>
               <dt>
-                optional IIRFilterOptions options
+                IIRFilterOptions options
               </dt>
               <dd>
                 Optional initial parameter value for this <a>IIRFilterNode</a>.
@@ -9566,7 +9566,7 @@ $$
           </dd>
         </dl>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;WaveShaperOptions&lt;/a&gt; options)]interface WaveShaperNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface WaveShaperNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl" data-merge="OverSampleType">
           <dt>
             Constructor
@@ -9816,7 +9816,7 @@ $$
           </dd>
         </dl>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;OscillatorOptions&lt;/a&gt; options)] interface OscillatorNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
+        "interface OscillatorNode : &lt;a&gt;AudioScheduledSourceNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -10254,7 +10254,7 @@ odd function with period \(2\pi\).
           This node has no <a>tail-time</a> reference.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;AudioContext&lt;/a&gt; context, &lt;a&gt;MediaStreamAudioSourceOptions&lt;/a&gt; options)]interface MediaStreamAudioSourceNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        "interface MediaStreamAudioSourceNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -10275,10 +10275,10 @@ odd function with period \(2\pi\).
                 "#associated">associated</a> with.
               </dd>
               <dt>
-                optional MediaStreamAudioSourceOptions options
+                MediaStreamAudioSourceOptions options
               </dt>
               <dd>
-                Optional initial parameter value for this
+                Initial parameter value for this
                 <a>MediaStreamAudioSourceNode</a>.
               </dd>
             </dl>
@@ -10401,7 +10401,7 @@ odd function with period \(2\pi\).
           The number of channels of the input is by default 2 (stereo).
         </p>
         <dl title=
-        "[Constructor(AudioContext context, optional AudioNodeOptions options)]interface MediaStreamAudioDestinationNode : AudioNode"
+        "interface MediaStreamAudioDestinationNode : AudioNode"
         class="idl">
           <dt>
             Constructor

--- a/index.html
+++ b/index.html
@@ -1249,7 +1249,7 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              Creates a <a><code>GainNode</code></a>.
+              <a>Factory method</a> for <a>GainNode</a>.
             </p>
           </dd>
           <dt>
@@ -2363,68 +2363,113 @@ function setupRoutingGraph() {
           value explicitly. <em>block-size</em> is defined to be 128
           sample-frames which corresponds to roughly 3ms at a sample-rate of
           44.1 kHz.
-        </p><a>AudioNode</a>s can be created in two ways:
+        </p>
+        <p>
+          <a>AudioNode</a>s can be created in two ways: using the constructor
+          for this particular interface, or by using the <dfn>factory
+          method</dfn> on the <a>BaseAudioContext</a>.
+        </p>
+        <p>
+          The <a>BaseAudioContext</a> passed as first argument of the
+          constructor of an <a>AudioNode</a>s is called the <dfn
+          id="associated">associated <a>BaseAudioContext</a></dfn> of the
+          <a>AudioNode</a> to be created.  Similarly, when using the factory
+          method, the <a>associated <code>BaseAudioContext</code></a> of the
+          <a>AudioNode</a> is the first argument of the factory
+          method.</a>
+        </p>
+        <p>
+          To create a new <a>AudioNode</a> of a particular type <var>i</var>
+          using its constructor, with a <a>BaseAudioContext</a> <var>c</var>
+          as first argument, and a <a>associated option object</a>
+          <var>option</var> as second argument, from the <a
+            href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">
+          relevant global</a> of <var>c</var>, execute these steps:
+        </p>
         <ol>
-          <li>An <a>AudioNode</a> can be created by calling the corresponding
-          <dfn>factory method</dfn> on the <a>AudioContext</a>, passing in
-          arguments. The <a>AudioNode</a> is associated with the
-          <a>AudioContext</a> it was created from.
-          </li>
-          <li>An <a>AudioNode</a> can be created by calling its constructor,
-          passing in the <a>AudioContext</a> with which the <a>AudioNode</a>
-          being constructed will be associated with. An optional second
-          argument is a dictionary that can contain attributes specific to the
-          type of <a>AudioNode</a> that is being created. When creating an <a>
-            AudioNode</a> using the constructor, the following algorithm MUST
-            be executed atomically:
-            <ol>
-              <li>Let <var>parameters</var> be an array that has a size equal
-              to the number of parameters of the associated <a>factory
-              method</a> function for this <a>AudioNode</a> type. Initialize
-              all elements of this array to <code>null</code>.
-              </li>
+          <li>Let <var>o</var> be a new object of type <var>i</var>.</li>
+          <li><a href=#audionode-constructor-common>Initialize the common
+            part</a> of <var>o</var>, with <var>c</var> and <var>option</var> as
+          arguments.</li>
+          <li>Return <var>o</var></li>
+        </ol>
+        <p>
+          To create a new <a>AudioNode</a> of a particular type <var>i</var>
+          using its <a>factory method</a>, with a <var>BaseAudioContext</var>
+          <var>c</var> as first argument, execute these steps:
+        </p>
+        <ol>
+          <li>Let <var>o</var> be a new object of type <var>i</var>.</li>
+          <li>Let <var>option</var> be a dictionnary of the type associated to
+          the interface associated to this factory method.</li>
+          <li> For each parameter passed to the factory method,
+          set the dictionary member of the same name on <var>option</var>
+          to the value of this parameter.</li>
+          <li><a href=#audionode-constructor-common>Initialize the common
+            part</a> of <var>o</var> with
+          <var>c</var> and <var>option</var> as arguments.</li>
+          <li>Return <var>o</var></li>
+        </ol>
+        <p>
+          <dfn id=audionode-constructor-common>Initializing the common
+            part</dfn> of an object <var>o</var> of interface <var>i</var> that
+          inherits from <a>AudioNode</a> means executing the following steps,
+          given the arguments <var>context</var> and <var>dict</var> passed to
+          the constructor of this interface.
+        </p>
+
+        <ol>
+          <li>Set <var>o</var>'s associated <a>BaseAudioContext</a> to
+          <var>context</var>.
+          <li>Set its value for <a
+              href="#widl-AudioNode-numberOfInputs">numberOfInputs</a>, <a
+              href="#widl-AudioNode-numberOfOutputs">numberOfOutputs</a>, <a
+              href="#widl-AudioNode-channelCount">channelCount</a>, <a
+              href="#widl-AudioNode-channelCountMode">channelCountMode</a>, <a
+              href="#widl-AudioNode-channelInterpretation">channelInterpretation</a> to
+            the default value for this specific interface outlined in
+            the section for each <a>AudioNode</a>.
               <li>If the <a>AudioNode</a> being constructed is a
               <a>ConvolverNode</a>, set its <a href=
               "#widl-ConvolverNode-normalize">normalize</a> attribute with the
               inverse of the value of the <a href=
               "#widl-ConvolverOptions-disableNormalization">disableNormalization</a>
-              dictionary member, and then set its the <a href=
+              in <var>dict</var>, and then set its the <a href=
               "#widl-ConvolverNode-buffer">buffer</a> attribute to the value of
-              the <a href="#widl-ConvolverOptions-buffer">buffer</a> dictionary
-              member, in this order, and jump to the last step of this
-              algorithm.
+              the <a href="#widl-ConvolverOptions-buffer">buffer</a> in
+              <var>dict</var> member, in this order, and jump to the last step
+              of this algorithm.
                 <div class="note">
                   This means that the buffer will be normalized according to
                   the value of the <a href=
                   "#widl-ConvolverNode-normalize">normalize</a> attribute.
                 </div>
               </li>
-              <li>For each dictionary member of the option dictionary passed
-              in, execute these steps, let <var>k</var> be its key, and
-              <var>v</var> be its value:
-                <ol>
-                  <li>If <var>k</var> is the name of an <a>AudioParam</a> on
-                  this <a>AudioNode</a> type, set the <a href=
-                  "#widl-AudioParam-value">value</a> attribute of this
-                  <a>AudioParam</a> to <var>v</var>.
-                  </li>
-                  <li>Else if <var>k</var> is the name of an attribute for this
-                  <a>AudioNode</a> type, set this attribute to <var>v</var>.
-                  </li>
-                  <li>Else if <var>k</var> is the name of a parameter to the
-                  associated <a>factory method</a>, set
-                  <var>parameters[i]</var> to <var>v</var>, where <var>i</var>
-                  is the index of the parameter in the signature for this
-                  <a>AudioNode</a> type.
-                  </li>
-                </ol>
-              </li>
-              <li>Call the corresponding <a>factory method</a> with the
-              parameters in <var>parameters</var>.
-              </li>
-            </ol>
+          <li>For each member of <var>dict</var> passed
+          in, execute these steps, with <var>k</var> the key of the member, and
+          <var>v</var> its value:
+          <ol>
+            <li>If<var>k</var> is <code>disableNormalization</code> or
+            <code>buffer</code>, jump to the beginning of this loop.</li>
+            <li>If <var>k</var> is the name of an <a>AudioParam</a> on
+            on this interface, set the <a href=
+              "#widl-AudioParam-value">value</a> attribute of this
+            <a>AudioParam</a> to <var>v</var>.
+            </li>
+            <li>Else if <var>k</var> is the name of an attribute on this
+            interface, set the object associated with this attribute to <var>v</var>.
+            </li>
+          </ol>
           </li>
         </ol>
+
+        <p>
+          The <dfn>associated interface</dfn> for a factory method is the
+          interface of the objects that are returned from this method. The
+          <dfn>associated option object</dfn> for an interface is the option
+          object that can be passed to the constructor for this interface.
+        </p>
+
         <p>
           <a>AudioNode</a>s are <em>EventTarget</em>s, as described in
           <cite><a href="https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]].
@@ -4268,9 +4313,32 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
         <p>
           This node has no <a>tail-time</a> reference.
         </p>
-        <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;GainOptions&lt;/a&gt; options)]interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl">
+        <dl title="[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;GainOptions&lt;/a&gt; options)]interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;" class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+          <p>
+          Let <var>gain</var> be a new <a>GainNode</a> object.
+          <a href=#audionode-constructor-common>Initialize the common part</a>
+          of <var>gain</var>, and return <var>gain</var>.
+          </p>
+          <dl class=parameters>
+            <dt>
+              BaseAudioContext context
+            </dt>
+            <dd>
+              The <a>BaseAudioContext</a> this new <a>GainNode</a> will be
+              <a href="#associated">associated</a> with.
+            </dd>
+            <dt>
+              optional GainOptions options
+            </dt>
+            <dd>
+              An optional initial gain value for this <a>GainNode</a>.
+            </dd>
+          </dl>
+          </dd>
           <dt>
             readonly attribute AudioParam gain
           </dt>

--- a/index.html
+++ b/index.html
@@ -2371,6 +2371,8 @@ function setupRoutingGraph() {
           sample-frames which corresponds to roughly 3ms at a sample-rate of
           44.1 kHz.
         </p>
+        <section>
+        <h3>AudioNode creation</h3>
         <p>
           <a>AudioNode</a>s can be created in two ways: by using the
           constructor for this particular interface, or by using the
@@ -2487,6 +2489,7 @@ function setupRoutingGraph() {
           <dfn>associated option object</dfn> for an interface is the option
           object that can be passed to the constructor for this interface.
         </p>
+        </section>
         <p>
           <a>AudioNode</a>s are <em>EventTarget</em>s, as described in
           <cite><a href="https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]].

--- a/index.html
+++ b/index.html
@@ -2368,9 +2368,9 @@ function setupRoutingGraph() {
           44.1 kHz.
         </p>
         <p>
-          <a>AudioNode</a>s can be created in two ways: using the constructor
+          <a>AudioNode</a>s can be created in two ways: by using the constructor
           for this particular interface, or by using the <dfn>factory
-          method</dfn> on the <a>BaseAudioContext</a>.
+          method</dfn> on the <a>BaseAudioContext</a> or <a>AudioContext</a>.
         </p>
         <p>
           The <a>BaseAudioContext</a> passed as first argument of the
@@ -2384,7 +2384,7 @@ function setupRoutingGraph() {
         <p>
           To create a new <a>AudioNode</a> of a particular type <var>i</var>
           using its constructor, with a <a>BaseAudioContext</a> <var>c</var>
-          as first argument, and a <a>associated option object</a>
+          as first argument, and an <a>associated option object</a>
           <var>option</var> as second argument, from the <a
             href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">
           relevant global</a> of <var>c</var>, execute these steps:
@@ -2438,7 +2438,7 @@ function setupRoutingGraph() {
               "#widl-ConvolverNode-normalize">normalize</a> attribute with the
               inverse of the value of the <a href=
               "#widl-ConvolverOptions-disableNormalization">disableNormalization</a>
-              in <var>dict</var>, and then set its the <a href=
+              in <var>dict</var>, and then set its <a href=
               "#widl-ConvolverNode-buffer">buffer</a> attribute to the value of
               the <a href="#widl-ConvolverOptions-buffer">buffer</a> in
               <var>dict</var> member, in this order, and jump to the last step
@@ -2453,7 +2453,7 @@ function setupRoutingGraph() {
           in, execute these steps, with <var>k</var> the key of the member, and
           <var>v</var> its value:
           <ol>
-            <li>If<var>k</var> is <code>disableNormalization</code> or
+            <li>If <var>k</var> is <code>disableNormalization</code> or
             <code>buffer</code>, jump to the beginning of this loop.</li>
             <li>If <var>k</var> is the name of an <a>AudioParam</a> on
             on this interface, set the <a href=
@@ -4339,7 +4339,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               optional GainOptions options
             </dt>
             <dd>
-              An optional initial gain value for this <a>GainNode</a>.
+              Optional initial parameter values for this <a>GainNode</a>.
             </dd>
           </dl>
           </dd>

--- a/index.html
+++ b/index.html
@@ -2372,126 +2372,128 @@ function setupRoutingGraph() {
           44.1 kHz.
         </p>
         <section>
-        <h3>AudioNode creation</h3>
-        <p>
-          <a>AudioNode</a>s can be created in two ways: by using the
-          constructor for this particular interface, or by using the
-          <dfn>factory method</dfn> on the <a>BaseAudioContext</a> or
-          <a>AudioContext</a>.
-        </p>
-        <p>
-          The <a>BaseAudioContext</a> passed as first argument of the
-          constructor of an <a>AudioNode</a>s is called the <dfn id=
-          "associated">associated <a>BaseAudioContext</a></dfn> of the
-          <a>AudioNode</a> to be created. Similarly, when using the factory
-          method, the <a>associated <code>BaseAudioContext</code></a> of the
-          <a>AudioNode</a> is the first argument of the factory method.
-        </p>
-        <p>
-          To create a new <a>AudioNode</a> of a particular type <var>i</var>
-          using its constructor, with a <a>BaseAudioContext</a> <var>c</var> as
-          first argument, and an <a>associated option object</a>
-          <var>option</var> as second argument, from the <a href=
-          "https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">
-          relevant global</a> of <var>c</var>, execute these steps:
-        </p>
-        <ol>
-          <li>Let <var>o</var> be a new object of type <var>i</var>.
-          </li>
-          <li>
-            <a href="#audionode-constructor-init">Initialize the common
-            part</a> of <var>o</var>, with <var>c</var> and <var>option</var>
-            as arguments.
-          </li>
-          <li>Return <var>o</var>
-          </li>
-        </ol>
-        <p>
-          To create a new <a>AudioNode</a> of a particular type <var>i</var>
-          using its <a>factory method</a>, called on a
-          <var>BaseAudioContext</var> <var>c</var>, execute these steps:
-        </p>
-        <ol>
-          <li>Let <var>o</var> be a new object of type <var>i</var>.
-          </li>
-          <li>Let <var>option</var> be a dictionnary of the type <a
-            href="#dfn-associated-option-object">associated</a> to
-          the interface <a href="#dfn-associated-interface">associated</a> to this
-          factory method.
-          </li>
-          <li>For each parameter passed to the factory method, set the
-          dictionary member of the same name on <var>option</var> to the value
-          of this parameter.
-          </li>
-          <li>
-            <a href="#audionode-constructor-init">Initialize the common
-            part</a> of <var>o</var> with <var>c</var> and <var>option</var> as
-            arguments.
-          </li>
-          <li>Return <var>o</var>
-          </li>
-        </ol>
-        <p>
-          <dfn id="audionode-constructor-init">Initializing</dfn> an object
-          <var>o</var> of interface <var>i</var> that
-          inherits from <a>AudioNode</a> means executing the following steps,
-          given the arguments <var>context</var> and <var>dict</var> passed to
-          the constructor of this interface.
-        </p>
-        <ol>
-          <li>Set <var>o</var>'s associated <a>BaseAudioContext</a> to
-          <var>context</var>.
-          </li>
-          <li>Set its value for <a href=
-          "#widl-AudioNode-numberOfInputs">numberOfInputs</a>, <a href=
-          "#widl-AudioNode-numberOfOutputs">numberOfOutputs</a>, <a href=
-          "#widl-AudioNode-channelCount">channelCount</a>, <a href=
-          "#widl-AudioNode-channelCountMode">channelCountMode</a>, <a href=
-          "#widl-AudioNode-channelInterpretation">channelInterpretation</a> to
-          the default value for this specific interface outlined in the section
-          for each <a>AudioNode</a>.
-          </li>
-          <li>If the <a>AudioNode</a> being constructed is a
-          <a>ConvolverNode</a>, set its <a href=
-          "#widl-ConvolverNode-normalize">normalize</a> attribute with the
-          inverse of the value of the <a href=
-          "#widl-ConvolverOptions-disableNormalization">disableNormalization</a>
-          in <var>dict</var>, and then set its <a href=
-          "#widl-ConvolverNode-buffer">buffer</a> attribute to the value of the
-          <a href="#widl-ConvolverOptions-buffer">buffer</a> in <var>dict</var>
-          member, in this order, and jump to the last step of this algorithm.
-            <div class="note">
-              This means that the buffer will be normalized according to the
-              value of the <a href=
-              "#widl-ConvolverNode-normalize">normalize</a> attribute.
-            </div>
-          </li>
-          <li>For each member of <var>dict</var> passed in, execute these
-          steps, with <var>k</var> the key of the member, and <var>v</var> its
-          value:
-            <ol>
-              <li>If <var>k</var> is <code>disableNormalization</code> or
-              <code>buffer</code> and <var>i</var> is <a>ConvolverNode</a>, jump
-              to the beginning of this loop.
-              </li>
-              <li>If <var>k</var> is the name of an <a>AudioParam</a> on
-              this interface, set the <a href=
-              "#widl-AudioParam-value">value</a> attribute of this
-              <a>AudioParam</a> to <var>v</var>.
-              </li>
-              <li>Else if <var>k</var> is the name of an attribute on this
-              interface, set the object associated with this attribute to <var>
-                v</var>.
-              </li>
-            </ol>
-          </li>
-        </ol>
-        <p>
-          The <dfn>associated interface</dfn> for a factory method is the
-          interface of the objects that are returned from this method. The
-          <dfn>associated option object</dfn> for an interface is the option
-          object that can be passed to the constructor for this interface.
-        </p>
+          <h3>
+            AudioNode creation
+          </h3>
+          <p>
+            <a>AudioNode</a>s can be created in two ways: by using the
+            constructor for this particular interface, or by using the
+            <dfn>factory method</dfn> on the <a>BaseAudioContext</a> or
+            <a>AudioContext</a>.
+          </p>
+          <p>
+            The <a>BaseAudioContext</a> passed as first argument of the
+            constructor of an <a>AudioNode</a>s is called the <dfn id=
+            "associated">associated <a>BaseAudioContext</a></dfn> of the
+            <a>AudioNode</a> to be created. Similarly, when using the factory
+            method, the <a>associated <code>BaseAudioContext</code></a> of the
+            <a>AudioNode</a> is the first argument of the factory method.
+          </p>
+          <p>
+            To create a new <a>AudioNode</a> of a particular type <var>i</var>
+            using its constructor, with a <a>BaseAudioContext</a> <var>c</var>
+            as first argument, and an <a>associated option object</a>
+            <var>option</var> as second argument, from the <a href=
+            "https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">
+            relevant global</a> of <var>c</var>, execute these steps:
+          </p>
+          <ol>
+            <li>Let <var>o</var> be a new object of type <var>i</var>.
+            </li>
+            <li>
+              <a href="#audionode-constructor-init">Initialize the common
+              part</a> of <var>o</var>, with <var>c</var> and <var>option</var>
+              as arguments.
+            </li>
+            <li>Return <var>o</var>
+            </li>
+          </ol>
+          <p>
+            To create a new <a>AudioNode</a> of a particular type <var>i</var>
+            using its <a>factory method</a>, called on a
+            <var>BaseAudioContext</var> <var>c</var>, execute these steps:
+          </p>
+          <ol>
+            <li>Let <var>o</var> be a new object of type <var>i</var>.
+            </li>
+            <li>Let <var>option</var> be a dictionnary of the type <a href=
+            "#dfn-associated-option-object">associated</a> to the interface
+            <a href="#dfn-associated-interface">associated</a> to this factory
+            method.
+            </li>
+            <li>For each parameter passed to the factory method, set the
+            dictionary member of the same name on <var>option</var> to the
+            value of this parameter.
+            </li>
+            <li>
+              <a href="#audionode-constructor-init">Initialize the common
+              part</a> of <var>o</var> with <var>c</var> and <var>option</var>
+              as arguments.
+            </li>
+            <li>Return <var>o</var>
+            </li>
+          </ol>
+          <p>
+            <dfn id="audionode-constructor-init">Initializing</dfn> an object
+            <var>o</var> of interface <var>i</var> that inherits from
+            <a>AudioNode</a> means executing the following steps, given the
+            arguments <var>context</var> and <var>dict</var> passed to the
+            constructor of this interface.
+          </p>
+          <ol>
+            <li>Set <var>o</var>'s associated <a>BaseAudioContext</a> to <var>
+              context</var>.
+            </li>
+            <li>Set its value for <a href=
+            "#widl-AudioNode-numberOfInputs">numberOfInputs</a>, <a href=
+            "#widl-AudioNode-numberOfOutputs">numberOfOutputs</a>, <a href=
+            "#widl-AudioNode-channelCount">channelCount</a>, <a href=
+            "#widl-AudioNode-channelCountMode">channelCountMode</a>, <a href=
+            "#widl-AudioNode-channelInterpretation">channelInterpretation</a>
+            to the default value for this specific interface outlined in the
+            section for each <a>AudioNode</a>.
+            </li>
+            <li>If the <a>AudioNode</a> being constructed is a
+            <a>ConvolverNode</a>, set its <a href=
+            "#widl-ConvolverNode-normalize">normalize</a> attribute with the
+            inverse of the value of the <a href=
+            "#widl-ConvolverOptions-disableNormalization">disableNormalization</a>
+            in <var>dict</var>, and then set its <a href=
+            "#widl-ConvolverNode-buffer">buffer</a> attribute to the value of
+            the <a href="#widl-ConvolverOptions-buffer">buffer</a> in
+            <var>dict</var> member, in this order, and jump to the last step of
+            this algorithm.
+              <div class="note">
+                This means that the buffer will be normalized according to the
+                value of the <a href=
+                "#widl-ConvolverNode-normalize">normalize</a> attribute.
+              </div>
+            </li>
+            <li>For each member of <var>dict</var> passed in, execute these
+            steps, with <var>k</var> the key of the member, and <var>v</var>
+            its value:
+              <ol>
+                <li>If <var>k</var> is <code>disableNormalization</code> or
+                <code>buffer</code> and <var>i</var> is <a>ConvolverNode</a>,
+                jump to the beginning of this loop.
+                </li>
+                <li>If <var>k</var> is the name of an <a>AudioParam</a> on this
+                interface, set the <a href="#widl-AudioParam-value">value</a>
+                attribute of this <a>AudioParam</a> to <var>v</var>.
+                </li>
+                <li>Else if <var>k</var> is the name of an attribute on this
+                interface, set the object associated with this attribute to
+                <var>v</var>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+          <p>
+            The <dfn>associated interface</dfn> for a factory method is the
+            interface of the objects that are returned from this method. The
+            <dfn>associated option object</dfn> for an interface is the option
+            object that can be passed to the constructor for this interface.
+          </p>
         </section>
         <p>
           <a>AudioNode</a>s are <em>EventTarget</em>s, as described in
@@ -4336,17 +4338,16 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
         <p>
           This node has no <a>tail-time</a> reference.
         </p>
-        <dl title=
-        "interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl">
+        <dl title="interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;" class=
+        "idl">
           <dt>
             Constructor
           </dt>
           <dd>
             <p>
               Let <var>gain</var> be a new <a>GainNode</a> object. <a href=
-              "#audionode-constructor-init">Initialize</a>
-              <var>gain</var>, and return <var>gain</var>.
+              "#audionode-constructor-init">Initialize</a> <var>gain</var>, and
+              return <var>gain</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -4444,17 +4445,16 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           By definition, a <a>DelayNode</a> introduces an audio processing
           latency equal to the amount of the delay.
         </p>
-        <dl title=
-        "interface DelayNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl">
+        <dl title="interface DelayNode : &lt;a&gt;AudioNode&lt;/a&gt;" class=
+        "idl">
           <dt>
             Constructor
           </dt>
           <dd>
             <p>
               Let <var>node</var> be a new <a>DelayNode</a> object. <a href=
-              "#audionode-constructor-init">Initialize</a>
-              <var>node</var>, and return <var>node</var>.
+              "#audionode-constructor-init">Initialize</a> <var>node</var>, and
+              return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -4548,9 +4548,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>OfflineAudioContext</code></a> and an
           <a><code>AudioContext</code></a>.
         </p>
-        <dl title=
-        "interface AudioBuffer"
-        class="idl">
+        <dl title="interface AudioBuffer" class="idl">
           <dt>
             readonly attribute float sampleRate
           </dt>
@@ -6737,17 +6735,16 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             </p>
           </dd>
         </dl>
-        <dl title=
-        "interface PannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl">
+        <dl title="interface PannerNode : &lt;a&gt;AudioNode&lt;/a&gt;" class=
+        "idl">
           <dt>
             Constructor
           </dt>
           <dd>
             <p>
               Let <var>node</var> be a new <a>PannerNode</a> object. <a href=
-              "#audionode-constructor-init">Initialize</a>
-              <var>node</var>, and return <var>node</var>.
+              "#audionode-constructor-init">Initialize</a> <var>node</var>, and
+              return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -7385,8 +7382,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
         <p>
           This node has no <a>tail-time</a> reference.
         </p>
-        <dl title=
-        "interface StereoPannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        <dl title="interface StereoPannerNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -7499,8 +7495,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <a>ConvolverNode</a>s are created with an internal flag <code>buffer
           set</code>, initially set to false.
         </p>
-        <dl title=
-        "interface ConvolverNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        <dl title="interface ConvolverNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -7754,8 +7749,7 @@ function calculateNormalizationScale(buffer)
         <p>
           This node has no <a>tail-time</a> reference.
         </p>
-        <dl title=
-        "interface AnalyserNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        <dl title="interface AnalyserNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <!--<dt> // Real-time frequency-domain data </dt>-->
           <dt>
@@ -7764,8 +7758,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>AnalyserNode</a> object. <a href=
-              "#audionode-constructor-init">Initialize</a>
-              <var>node</var>, and return <var>node</var>.
+              "#audionode-constructor-init">Initialize</a> <var>node</var>, and
+              return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -8243,8 +8237,8 @@ function calculateNormalizationScale(buffer)
           desired.
         </p>
         <dl title=
-        "interface ChannelSplitterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
-        class="idl">
+        "interface ChannelSplitterNode : &lt;a&gt;AudioNode&lt;/a&gt;" class=
+        "idl">
           <dt>
             Constructor
           </dt>
@@ -8350,9 +8344,7 @@ function calculateNormalizationScale(buffer)
             A diagram of ChannelMerger
           </figcaption>
         </figure>
-        <dl title=
-        "interface ChannelMergerNode : AudioNode"
-        class="idl">
+        <dl title="interface ChannelMergerNode : AudioNode" class="idl">
           <dt>
             Constructor
           </dt>
@@ -8920,8 +8912,7 @@ function calculateNormalizationScale(buffer)
           All attributes of the <a><code>BiquadFilterNode</code></a> are
           <a>a-rate</a> <a><code>AudioParam</code></a>.
         </p>
-        <dl title=
-        "interface BiquadFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        <dl title="interface BiquadFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
             Constructor
@@ -9375,11 +9366,10 @@ $$
           is sufficiently close to zero. The actual time depends on the filter
           coefficients.
         </p>
-        <dl title=
-        "interface IIRFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        <dl title="interface IIRFilterNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl">
           <dt>
-          Constructor
+            Constructor
           </dt>
           <dd>
             <p>
@@ -9565,8 +9555,7 @@ $$
             Oversample four times
           </dd>
         </dl>
-        <dl title=
-        "interface WaveShaperNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        <dl title="interface WaveShaperNode : &lt;a&gt;AudioNode&lt;/a&gt;"
         class="idl" data-merge="OverSampleType">
           <dt>
             Constructor
@@ -10322,8 +10311,7 @@ odd function with period \(2\pi\).
         <p>
           This node has no <a>tail-time</a> reference.
         </p>
-        <dl title=
-        "interface MediaStreamTrackAudioSourceNode : AudioNode"
+        <dl title="interface MediaStreamTrackAudioSourceNode : AudioNode"
         class="idl">
           <dt>
             Constructor
@@ -10332,8 +10320,8 @@ odd function with period \(2\pi\).
             <p>
               Let <var>node</var> be a new
               <a>MediaStreamTrackAudioSourceNode</a> object. <a href=
-              "#audionode-constructor-init">Initialize</a>
-            <var>node</var>, and return <var>node</var>.
+              "#audionode-constructor-init">Initialize</a> <var>node</var>, and
+              return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -10341,8 +10329,8 @@ odd function with period \(2\pi\).
               </dt>
               <dd>
                 The <a>AudioContext</a> this new
-                <a>MediaStreamTrackAudioSourceNode</a> will be
-                <a href="#associated">associated</a> with.
+                <a>MediaStreamTrackAudioSourceNode</a> will be <a href=
+                "#associated">associated</a> with.
               </dd>
               <dt>
                 MediaStreamTrackAudioSourceOptions options
@@ -10353,7 +10341,7 @@ odd function with period \(2\pi\).
               </dd>
             </dl>
           </dd>
-      </dl>
+        </dl>
         <section>
           <h2>
             MediaStreamTrackAudioSourceOptions
@@ -10400,8 +10388,7 @@ odd function with period \(2\pi\).
         <p>
           The number of channels of the input is by default 2 (stereo).
         </p>
-        <dl title=
-        "interface MediaStreamAudioDestinationNode : AudioNode"
+        <dl title="interface MediaStreamAudioDestinationNode : AudioNode"
         class="idl">
           <dt>
             Constructor
@@ -10410,8 +10397,8 @@ odd function with period \(2\pi\).
             <p>
               Let <var>node</var> be a new
               <a>MediaStreamAudioDestinationNode</a> object. <a href=
-              "#audionode-constructor-init">Initialize</a>
-              <var>node</var>, and return <var>node</var>.
+              "#audionode-constructor-init">Initialize</a> <var>node</var>, and
+              return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>

--- a/index.html
+++ b/index.html
@@ -1180,8 +1180,8 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-              <a>Factory method</a> for a <a>ScriptProcessorNode</a>.
-              This method is DEPRECATED, as it is intended to be replaced by
+              <a>Factory method</a> for a <a>ScriptProcessorNode</a>. This
+              method is DEPRECATED, as it is intended to be replaced by
               <a href="#AudioWorkletNode"><code>AudioWorkletNode</code></a>.
               Creates a <a><code>ScriptProcessorNode</code></a> for direct
               audio processing using JavaScript. <span class="synchronous">An
@@ -1261,7 +1261,7 @@ function setupRoutingGraph() {
           <dd>
             <p>
               <a>Factory method</a> for a <a>DelayNode</a>. The initial default
-            delay time will be 0 seconds.
+              delay time will be 0 seconds.
             </p>
             <dl class="parameters">
               <dt>
@@ -1282,8 +1282,8 @@ function setupRoutingGraph() {
           <dd>
             <p>
               <a>Factory method</a> for a <a><code>BiquadFilterNode</code></a>
-            representing a second order filter which can be configured as one of
-            several common filter types.
+              representing a second order filter which can be configured as one
+              of several common filter types.
             </p>
           </dd>
           <dt>
@@ -1361,8 +1361,9 @@ function setupRoutingGraph() {
             <p>
               <a>Factory method</a> for a
               <a><code>ChannelSplitterNode</code></a> representing a channel
-              splitter. <span class="synchronous">An <code>IndexSizeError</code>
-              exception MUST be thrown for invalid parameter values.</span>
+              splitter. <span class="synchronous">An
+              <code>IndexSizeError</code> exception MUST be thrown for invalid
+              parameter values.</span>
             </p>
             <dl class="parameters">
               <dt>
@@ -1401,7 +1402,7 @@ function setupRoutingGraph() {
           <dd>
             <p>
               <a>Factory method</a> for a
-            <a><code>DynamicsCompressorNode</code></a>.
+              <a><code>DynamicsCompressorNode</code></a>.
             </p>
           </dd>
           <dt>
@@ -1417,28 +1418,31 @@ function setupRoutingGraph() {
           </dt>
           <dd>
             <p>
-            <a>Factory method</a> a <a><code>PeriodicWave</code></a>
-            representing a waveform containing arbitrary harmonic content. <span
-              class= "synchronous">The <code>real</code> and <code>imag</code>
-              parameters must be of type <code>Float32Array</code> (described in
-              [[!TYPED-ARRAYS]]) of equal lengths greater than zero or an
-              <code>IndexSizeError</code> exception MUST be thrown.</span> All
-            implementations must support arrays up to at least 8192. These
-            parameters specify the Fourier coefficients of a <a href=
+              <a>Factory method</a> a <a><code>PeriodicWave</code></a>
+              representing a waveform containing arbitrary harmonic content.
+              <span class="synchronous">The <code>real</code> and
+              <code>imag</code> parameters must be of type
+              <code>Float32Array</code> (described in [[!TYPED-ARRAYS]]) of
+              equal lengths greater than zero or an <code>IndexSizeError</code>
+              exception MUST be thrown.</span> All implementations must support
+              arrays up to at least 8192. These parameters specify the Fourier
+              coefficients of a <a href=
               "https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
-            representing the partials of a periodic waveform. The created
-            <a><code>PeriodicWave</code></a> will be used with an
-            <a><code>OscillatorNode</code></a> and, by default, will represent a
-            <em>normalized</em> time-domain waveform having maximum absolute peak
-            value of 1. Another way of saying this is that the generated waveform of
-            an <a><code>OscillatorNode</code></a> will have maximum peak value at
-            0dBFS. Conveniently, this corresponds to the full-range of the signal
-            values used by the Web Audio API. Because the PeriodicWave is normalized
-            by default on creation, the <code>real</code> and <code>imag</code>
-            parameters represent <em>relative</em> values.  If normalization is
-            disabled via the <code>disableNormalization</code> parameter, this
-            normalization is disabled, and the time-domain waveform has the
-            amplitudes as given by the Fourier coefficients.
+              representing the partials of a periodic waveform. The created
+              <a><code>PeriodicWave</code></a> will be used with an
+              <a><code>OscillatorNode</code></a> and, by default, will
+              represent a <em>normalized</em> time-domain waveform having
+              maximum absolute peak value of 1. Another way of saying this is
+              that the generated waveform of an
+              <a><code>OscillatorNode</code></a> will have maximum peak value
+              at 0dBFS. Conveniently, this corresponds to the full-range of the
+              signal values used by the Web Audio API. Because the PeriodicWave
+              is normalized by default on creation, the <code>real</code> and
+              <code>imag</code> parameters represent <em>relative</em> values.
+              If normalization is disabled via the
+              <code>disableNormalization</code> parameter, this normalization
+              is disabled, and the time-domain waveform has the amplitudes as
+              given by the Fourier coefficients.
             </p>
             <p>
               As <a>PeriodicWave</a> objects maintain their own copies of these
@@ -2368,112 +2372,121 @@ function setupRoutingGraph() {
           44.1 kHz.
         </p>
         <p>
-          <a>AudioNode</a>s can be created in two ways: by using the constructor
-          for this particular interface, or by using the <dfn>factory
-          method</dfn> on the <a>BaseAudioContext</a> or <a>AudioContext</a>.
+          <a>AudioNode</a>s can be created in two ways: by using the
+          constructor for this particular interface, or by using the
+          <dfn>factory method</dfn> on the <a>BaseAudioContext</a> or
+          <a>AudioContext</a>.
         </p>
         <p>
           The <a>BaseAudioContext</a> passed as first argument of the
-          constructor of an <a>AudioNode</a>s is called the <dfn
-          id="associated">associated <a>BaseAudioContext</a></dfn> of the
-          <a>AudioNode</a> to be created.  Similarly, when using the factory
+          constructor of an <a>AudioNode</a>s is called the <dfn id=
+          "associated">associated <a>BaseAudioContext</a></dfn> of the
+          <a>AudioNode</a> to be created. Similarly, when using the factory
           method, the <a>associated <code>BaseAudioContext</code></a> of the
-          <a>AudioNode</a> is the first argument of the factory
-          method.</a>
+          <a>AudioNode</a> is the first argument of the factory method.
         </p>
         <p>
           To create a new <a>AudioNode</a> of a particular type <var>i</var>
-          using its constructor, with a <a>BaseAudioContext</a> <var>c</var>
-          as first argument, and an <a>associated option object</a>
-          <var>option</var> as second argument, from the <a
-            href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">
+          using its constructor, with a <a>BaseAudioContext</a> <var>c</var> as
+          first argument, and an <a>associated option object</a>
+          <var>option</var> as second argument, from the <a href=
+          "https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">
           relevant global</a> of <var>c</var>, execute these steps:
         </p>
         <ol>
-          <li>Let <var>o</var> be a new object of type <var>i</var>.</li>
-          <li><a href=#audionode-constructor-common>Initialize the common
-            part</a> of <var>o</var>, with <var>c</var> and <var>option</var> as
-          arguments.</li>
-          <li>Return <var>o</var></li>
+          <li>Let <var>o</var> be a new object of type <var>i</var>.
+          </li>
+          <li>
+            <a href="#audionode-constructor-common">Initialize the common
+            part</a> of <var>o</var>, with <var>c</var> and <var>option</var>
+            as arguments.
+          </li>
+          <li>Return <var>o</var>
+          </li>
         </ol>
         <p>
           To create a new <a>AudioNode</a> of a particular type <var>i</var>
           using its <a>factory method</a>, called on a
-          <var>BaseAudioContext</var> <var>c</var>, execute
-          these steps:
+          <var>BaseAudioContext</var> <var>c</var>, execute these steps:
         </p>
         <ol>
-          <li>Let <var>o</var> be a new object of type <var>i</var>.</li>
+          <li>Let <var>o</var> be a new object of type <var>i</var>.
+          </li>
           <li>Let <var>option</var> be a dictionnary of the type associated to
-          the interface associated to this factory method.</li>
-          <li> For each parameter passed to the factory method,
-          set the dictionary member of the same name on <var>option</var>
-          to the value of this parameter.</li>
-          <li><a href=#audionode-constructor-common>Initialize the common
-            part</a> of <var>o</var> with
-          <var>c</var> and <var>option</var> as arguments.</li>
-          <li>Return <var>o</var></li>
+          the interface associated to this factory method.
+          </li>
+          <li>For each parameter passed to the factory method, set the
+          dictionary member of the same name on <var>option</var> to the value
+          of this parameter.
+          </li>
+          <li>
+            <a href="#audionode-constructor-common">Initialize the common
+            part</a> of <var>o</var> with <var>c</var> and <var>option</var> as
+            arguments.
+          </li>
+          <li>Return <var>o</var>
+          </li>
         </ol>
         <p>
-          <dfn id=audionode-constructor-common>Initializing the common
-            part</dfn> of an object <var>o</var> of interface <var>i</var> that
+          <dfn id="audionode-constructor-common">Initializing the common
+          part</dfn> of an object <var>o</var> of interface <var>i</var> that
           inherits from <a>AudioNode</a> means executing the following steps,
           given the arguments <var>context</var> and <var>dict</var> passed to
           the constructor of this interface.
         </p>
-
         <ol>
           <li>Set <var>o</var>'s associated <a>BaseAudioContext</a> to
           <var>context</var>.
-          <li>Set its value for <a
-              href="#widl-AudioNode-numberOfInputs">numberOfInputs</a>, <a
-              href="#widl-AudioNode-numberOfOutputs">numberOfOutputs</a>, <a
-              href="#widl-AudioNode-channelCount">channelCount</a>, <a
-              href="#widl-AudioNode-channelCountMode">channelCountMode</a>, <a
-              href="#widl-AudioNode-channelInterpretation">channelInterpretation</a> to
-            the default value for this specific interface outlined in
-            the section for each <a>AudioNode</a>.
-              <li>If the <a>AudioNode</a> being constructed is a
-              <a>ConvolverNode</a>, set its <a href=
-              "#widl-ConvolverNode-normalize">normalize</a> attribute with the
-              inverse of the value of the <a href=
-              "#widl-ConvolverOptions-disableNormalization">disableNormalization</a>
-              in <var>dict</var>, and then set its <a href=
-              "#widl-ConvolverNode-buffer">buffer</a> attribute to the value of
-              the <a href="#widl-ConvolverOptions-buffer">buffer</a> in
-              <var>dict</var> member, in this order, and jump to the last step
-              of this algorithm.
-                <div class="note">
-                  This means that the buffer will be normalized according to
-                  the value of the <a href=
-                  "#widl-ConvolverNode-normalize">normalize</a> attribute.
-                </div>
+          </li>
+          <li>Set its value for <a href=
+          "#widl-AudioNode-numberOfInputs">numberOfInputs</a>, <a href=
+          "#widl-AudioNode-numberOfOutputs">numberOfOutputs</a>, <a href=
+          "#widl-AudioNode-channelCount">channelCount</a>, <a href=
+          "#widl-AudioNode-channelCountMode">channelCountMode</a>, <a href=
+          "#widl-AudioNode-channelInterpretation">channelInterpretation</a> to
+          the default value for this specific interface outlined in the section
+          for each <a>AudioNode</a>.
+          </li>
+          <li>If the <a>AudioNode</a> being constructed is a
+          <a>ConvolverNode</a>, set its <a href=
+          "#widl-ConvolverNode-normalize">normalize</a> attribute with the
+          inverse of the value of the <a href=
+          "#widl-ConvolverOptions-disableNormalization">disableNormalization</a>
+          in <var>dict</var>, and then set its <a href=
+          "#widl-ConvolverNode-buffer">buffer</a> attribute to the value of the
+          <a href="#widl-ConvolverOptions-buffer">buffer</a> in <var>dict</var>
+          member, in this order, and jump to the last step of this algorithm.
+            <div class="note">
+              This means that the buffer will be normalized according to the
+              value of the <a href=
+              "#widl-ConvolverNode-normalize">normalize</a> attribute.
+            </div>
+          </li>
+          <li>For each member of <var>dict</var> passed in, execute these
+          steps, with <var>k</var> the key of the member, and <var>v</var> its
+          value:
+            <ol>
+              <li>If <var>k</var> is <code>disableNormalization</code> or
+              <code>buffer</code>, jump to the beginning of this loop.
               </li>
-          <li>For each member of <var>dict</var> passed
-          in, execute these steps, with <var>k</var> the key of the member, and
-          <var>v</var> its value:
-          <ol>
-            <li>If <var>k</var> is <code>disableNormalization</code> or
-            <code>buffer</code>, jump to the beginning of this loop.</li>
-            <li>If <var>k</var> is the name of an <a>AudioParam</a> on
-            on this interface, set the <a href=
+              <li>If <var>k</var> is the name of an <a>AudioParam</a> on on
+              this interface, set the <a href=
               "#widl-AudioParam-value">value</a> attribute of this
-            <a>AudioParam</a> to <var>v</var>.
-            </li>
-            <li>Else if <var>k</var> is the name of an attribute on this
-            interface, set the object associated with this attribute to <var>v</var>.
-            </li>
-          </ol>
+              <a>AudioParam</a> to <var>v</var>.
+              </li>
+              <li>Else if <var>k</var> is the name of an attribute on this
+              interface, set the object associated with this attribute to <var>
+                v</var>.
+              </li>
+            </ol>
           </li>
         </ol>
-
         <p>
           The <dfn>associated interface</dfn> for a factory method is the
           interface of the objects that are returned from this method. The
           <dfn>associated option object</dfn> for an interface is the option
           object that can be passed to the constructor for this interface.
         </p>
-
         <p>
           <a>AudioNode</a>s are <em>EventTarget</em>s, as described in
           <cite><a href="https://dom.spec.whatwg.org/">DOM</a></cite> [[!DOM]].
@@ -4317,31 +4330,33 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
         <p>
           This node has no <a>tail-time</a> reference.
         </p>
-        <dl title="[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;GainOptions&lt;/a&gt; options)]interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;" class="idl">
+        <dl title=
+        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;GainOptions&lt;/a&gt; options)]interface GainNode : &lt;a&gt;AudioNode&lt;/a&gt;"
+        class="idl">
           <dt>
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>gain</var> be a new <a>GainNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>gain</var>, and return <var>gain</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>GainNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional GainOptions options
-            </dt>
-            <dd>
-              Optional initial parameter values for this <a>GainNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>gain</var> be a new <a>GainNode</a> object. <a href=
+              "#audionode-constructor-common">Initialize the common part</a> of
+              <var>gain</var>, and return <var>gain</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>GainNode</a> will be
+                <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional GainOptions options
+              </dt>
+              <dd>
+                Optional initial parameter values for this <a>GainNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             readonly attribute AudioParam gain
@@ -4430,26 +4445,26 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>DelayNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>DelayNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional DelayOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>DelayNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>DelayNode</a> object. <a href=
+              "#audionode-constructor-common">Initialize the common part</a> of
+              <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>DelayNode</a> will be
+                <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional DelayOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this <a>DelayNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             readonly attribute AudioParam delayTime
@@ -4819,26 +4834,28 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>AudioBufferSourceNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>AudioBufferSourceNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional AudioBufferSourceOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>AudioBufferSourceNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>AudioBufferSourceNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new
+                <a>AudioBufferSourceNode</a> will be <a href=
+                "#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional AudioBufferSourceOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>AudioBufferSourceNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             attribute AudioBuffer? buffer
@@ -5166,26 +5183,27 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>ConstantSourceNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional ConstantSourceOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>ConstantSourceNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>ConstantSourceNode</a>
+                will be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional ConstantSourceOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>ConstantSourceNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             readonly attribute AudioParam offset
@@ -5249,28 +5267,30 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>MediaElementAudioSOurceNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>MediaElementAudioSourceNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional MediaElementAudioSourceOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>MediaELementAudioSourceNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>MediaElementAudioSOurceNode</a>
+              object. <a href="#audionode-constructor-common">Initialize the
+              common part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new
+                <a>MediaElementAudioSourceNode</a> will be <a href=
+                "#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional MediaElementAudioSourceOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>MediaELementAudioSourceNode</a>.
+              </dd>
+            </dl>
           </dd>
-      </dl>
+        </dl>
         <p>
           A <a>MediaElementAudioSourceNode</a> is created given an
           <code>HTMLMediaElement</code> using the <a>AudioContext</a>
@@ -5609,30 +5629,30 @@ window.audioWorklet.import("bypass.js").then(function () {
               optional <a>AudioWorkletNodeOptions</a> options)
             </dt>
             <dd>
-            <dl class=parameters>
-              <dt>
-                BaseAudioContext context
-              </dt>
-              <dd>
-                The <a>BaseAudioContext</a> this new <a>AudioWorkletNode</a> will be
-                <a href="#associated">associated</a> with.
-              </dd>
-              <dt>
-                optional AudioWorkletOptions options
-              </dt>
-              <dd>
-                Optional initial parameters value for this <a>AudioWorkletNode</a>.
-              </dd>
-            </dl>
+              <dl class="parameters">
+                <dt>
+                  BaseAudioContext context
+                </dt>
+                <dd>
+                  The <a>BaseAudioContext</a> this new <a>AudioWorkletNode</a>
+                  will be <a href="#associated">associated</a> with.
+                </dd>
+                <dt>
+                  optional AudioWorkletOptions options
+                </dt>
+                <dd>
+                  Optional initial parameters value for this
+                  <a>AudioWorkletNode</a>.
+                </dd>
+              </dl>
               <p>
                 Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
-                <a href=#audionode-constructor-common>Initialize the common part</a>
-                of <var>node</var>.  Perform the <a href=
+                <a href="#audionode-constructor-common">Initialize the common
+                part</a> of <var>node</var>. Perform the <a href=
                 "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">construction
                 procedure</a> of an <a><code>AudioWorkletNode</code></a> and
                 the corresponding <a><code>AudioWorkletProcessor</code></a>
-                object.
-                Return <var>node</var>.
+                object. Return <var>node</var>.
               </p>
             </dd>
             <dt>
@@ -6718,26 +6738,26 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>PannerNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>PannerNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional PannerOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>PannerNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>PannerNode</a> object. <a href=
+              "#audionode-constructor-common">Initialize the common part</a> of
+              <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>PannerNode</a> will be
+                <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional PannerOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this <a>PannerNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             attribute PanningModelType panningModel
@@ -7366,26 +7386,27 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>StereoPannerNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>StereoPannerNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional StereoPannerOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>StereoPannerNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>StereoPannerNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>StereoPannerNode</a>
+                will be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional StereoPannerOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>StereoPannerNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             readonly attribute AudioParam pan
@@ -7479,26 +7500,26 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>ConvolverNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>ConvolverNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional ConvolverOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>ConvolverNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>ConvolverNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>ConvolverNode</a> will
+                be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional ConvolverOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this <a>ConvolverNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             attribute AudioBuffer? buffer
@@ -7735,26 +7756,26 @@ function calculateNormalizationScale(buffer)
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>AnalyserNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>AnalyserNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional AnalyserOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>AnalyserNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>AnalyserNode</a> object. <a href=
+              "#audionode-constructor-common">Initialize the common part</a> of
+              <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>AnalyserNode</a> will
+                be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional AnalyserOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this <a>AnalyserNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             void getFloatFrequencyData()
@@ -8222,28 +8243,29 @@ function calculateNormalizationScale(buffer)
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>ChannelSplitterNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional ChannelSplitterNode options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>ChannelSplitterNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>ChannelSplitterNode</a>
+                will be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional ChannelSplitterNode options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>ChannelSplitterNode</a>.
+              </dd>
+            </dl>
           </dd>
-      </dl>
+        </dl>
         <section>
           <h2>
             ChannelSplitterOptions
@@ -8329,28 +8351,29 @@ function calculateNormalizationScale(buffer)
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>ChannelMergerNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional ChannelMergerOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>ChannelMergerNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>ChannelMergerNode</a>
+                will be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional ChannelMergerOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>ChannelMergerNode</a>.
+              </dd>
+            </dl>
           </dd>
-      </dl>
+        </dl>
         <section>
           <h2>
             ChannelMergerOptions
@@ -8404,27 +8427,28 @@ function calculateNormalizationScale(buffer)
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>DynamicsCompressorNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>DynamicsCompressorNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional DynamicsCompressorOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this
-              <a>DynamicsCompressorNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>DynamicsCompressorNode</a>
+              object. <a href="#audionode-constructor-common">Initialize the
+              common part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new
+                <a>DynamicsCompressorNode</a> will be <a href=
+                "#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional DynamicsCompressorOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>DynamicsCompressorNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             readonly attribute AudioParam threshold
@@ -8897,26 +8921,27 @@ function calculateNormalizationScale(buffer)
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>BiquadFilterNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional BiquadFilterOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>BiquadFilterNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>BiquadFilterNode</a>
+                will be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional BiquadFilterOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>BiquadFilterNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             attribute BiquadFilterType type
@@ -9351,26 +9376,26 @@ $$
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>IIRFilterNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>IIRFilterNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional IIRFilterOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>IIRFilterNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>IIRFilterNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>IIRFilterNode</a> will
+                be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional IIRFilterOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this <a>IIRFilterNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             void getFrequencyResponse()
@@ -9541,26 +9566,27 @@ $$
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>WaveShaperNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>WaveShaperNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional WaveShaperOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>WaveShaperNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>WaveShaperNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>WaveShaperNode</a> will
+                be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional WaveShaperOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>WaveShaperNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             attribute Float32Array? curve
@@ -9790,26 +9816,27 @@ $$
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>OscillatorNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>OscillatorNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional OscillatorOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this <a>OscillatorNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>OscillatorNode</a> object.
+              <a href="#audionode-constructor-common">Initialize the common
+              part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new <a>OscillatorNode</a> will
+                be <a href="#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional OscillatorOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>OscillatorNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             attribute OscillatorType type
@@ -10227,29 +10254,30 @@ odd function with period \(2\pi\).
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new <a>MediaStreamAudioSourceNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional MediaStreamAudioSourceOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this
-              <a>MediaStreamAudioSourceNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a>
+              object. <a href="#audionode-constructor-common">Initialize the
+              common part</a> of <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new
+                <a>MediaStreamAudioSourceNode</a> will be <a href=
+                "#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional MediaStreamAudioSourceOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>MediaStreamAudioSourceNode</a>.
+              </dd>
+            </dl>
           </dd>
-      </dl>
+        </dl>
         <section>
           <h2>
             MediaStreamAudioSourceOptions
@@ -10344,28 +10372,29 @@ odd function with period \(2\pi\).
             Constructor
           </dt>
           <dd>
-          <p>
-          Let <var>node</var> be a new <a>MediaStreamAudioDestinationNode</a> object.
-          <a href=#audionode-constructor-common>Initialize the common part</a>
-          of <var>node</var>, and return <var>node</var>.
-          </p>
-          <dl class=parameters>
-            <dt>
-              BaseAudioContext context
-            </dt>
-            <dd>
-              The <a>BaseAudioContext</a> this new
-              <a>MediaStreamAudioDestinationNode</a> will be
-              <a href="#associated">associated</a> with.
-            </dd>
-            <dt>
-              optional AudioNodeOptions options
-            </dt>
-            <dd>
-              Optional initial parameter value for this
-              <a>MediaStreamAudioDestinationNode</a>.
-            </dd>
-          </dl>
+            <p>
+              Let <var>node</var> be a new
+              <a>MediaStreamAudioDestinationNode</a> object. <a href=
+              "#audionode-constructor-common">Initialize the common part</a> of
+              <var>node</var>, and return <var>node</var>.
+            </p>
+            <dl class="parameters">
+              <dt>
+                BaseAudioContext context
+              </dt>
+              <dd>
+                The <a>BaseAudioContext</a> this new
+                <a>MediaStreamAudioDestinationNode</a> will be <a href=
+                "#associated">associated</a> with.
+              </dd>
+              <dt>
+                optional AudioNodeOptions options
+              </dt>
+              <dd>
+                Optional initial parameter value for this
+                <a>MediaStreamAudioDestinationNode</a>.
+              </dd>
+            </dl>
           </dd>
           <dt>
             readonly attribute MediaStream stream

--- a/index.html
+++ b/index.html
@@ -2399,7 +2399,7 @@ function setupRoutingGraph() {
           <li>Let <var>o</var> be a new object of type <var>i</var>.
           </li>
           <li>
-            <a href="#audionode-constructor-common">Initialize the common
+            <a href="#audionode-constructor-init">Initialize the common
             part</a> of <var>o</var>, with <var>c</var> and <var>option</var>
             as arguments.
           </li>
@@ -2424,7 +2424,7 @@ function setupRoutingGraph() {
           of this parameter.
           </li>
           <li>
-            <a href="#audionode-constructor-common">Initialize the common
+            <a href="#audionode-constructor-init">Initialize the common
             part</a> of <var>o</var> with <var>c</var> and <var>option</var> as
             arguments.
           </li>
@@ -2432,8 +2432,8 @@ function setupRoutingGraph() {
           </li>
         </ol>
         <p>
-          <dfn id="audionode-constructor-common">Initializing the common
-          part</dfn> of an object <var>o</var> of interface <var>i</var> that
+          <dfn id="audionode-constructor-init">Initializing</dfn> an object
+          <var>o</var> of interface <var>i</var> that
           inherits from <a>AudioNode</a> means executing the following steps,
           given the arguments <var>context</var> and <var>dict</var> passed to
           the constructor of this interface.
@@ -2471,9 +2471,10 @@ function setupRoutingGraph() {
           value:
             <ol>
               <li>If <var>k</var> is <code>disableNormalization</code> or
-              <code>buffer</code>, jump to the beginning of this loop.
+              <code>buffer</code> and <var>i</var> is <a>ConvolverNode</a>, jump
+              to the beginning of this loop.
               </li>
-              <li>If <var>k</var> is the name of an <a>AudioParam</a> on on
+              <li>If <var>k</var> is the name of an <a>AudioParam</a> on
               this interface, set the <a href=
               "#widl-AudioParam-value">value</a> attribute of this
               <a>AudioParam</a> to <var>v</var>.
@@ -4344,7 +4345,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <dd>
             <p>
               Let <var>gain</var> be a new <a>GainNode</a> object. <a href=
-              "#audionode-constructor-common">Initialize the common part</a> of
+              "#audionode-constructor-init">Initialize</a>
               <var>gain</var>, and return <var>gain</var>.
             </p>
             <dl class="parameters">
@@ -4452,7 +4453,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <dd>
             <p>
               Let <var>node</var> be a new <a>DelayNode</a> object. <a href=
-              "#audionode-constructor-common">Initialize the common part</a> of
+              "#audionode-constructor-init">Initialize</a>
               <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -4841,7 +4842,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <dd>
             <p>
               Let <var>node</var> be a new <a>AudioBufferSourceNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -5190,7 +5191,7 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           <dd>
             <p>
               Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -5274,7 +5275,7 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           <dd>
             <p>
               Let <var>node</var> be a new <a>MediaElementAudioSOurceNode</a>
-              object. <a href="#audionode-constructor-common">Initialize the
+              object. <a href="#audionode-constructor-init">Initialize the
               common part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -5652,7 +5653,7 @@ window.audioWorklet.import("bypass.js").then(function () {
               </dl>
               <p>
                 Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
-                <a href="#audionode-constructor-common">Initialize the common
+                <a href="#audionode-constructor-init">Initialize the common
                 part</a> of <var>node</var>. Perform the <a href=
                 "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">construction
                 procedure</a> of an <a><code>AudioWorkletNode</code></a> and
@@ -6745,7 +6746,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dd>
             <p>
               Let <var>node</var> be a new <a>PannerNode</a> object. <a href=
-              "#audionode-constructor-common">Initialize the common part</a> of
+              "#audionode-constructor-init">Initialize</a>
               <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -7393,7 +7394,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dd>
             <p>
               Let <var>node</var> be a new <a>StereoPannerNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -7507,7 +7508,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dd>
             <p>
               Let <var>node</var> be a new <a>ConvolverNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -7763,7 +7764,7 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>AnalyserNode</a> object. <a href=
-              "#audionode-constructor-common">Initialize the common part</a> of
+              "#audionode-constructor-init">Initialize</a>
               <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -8250,7 +8251,7 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -8358,7 +8359,7 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -8434,7 +8435,7 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>DynamicsCompressorNode</a>
-              object. <a href="#audionode-constructor-common">Initialize the
+              object. <a href="#audionode-constructor-init">Initialize the
               common part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -8928,7 +8929,7 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -9383,7 +9384,7 @@ $$
           <dd>
             <p>
               Let <var>node</var> be a new <a>IIRFilterNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -9573,7 +9574,7 @@ $$
           <dd>
             <p>
               Let <var>node</var> be a new <a>WaveShaperNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -9823,7 +9824,7 @@ $$
           <dd>
             <p>
               Let <var>node</var> be a new <a>OscillatorNode</a> object.
-              <a href="#audionode-constructor-common">Initialize the common
+              <a href="#audionode-constructor-init">Initialize the common
               part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -10261,7 +10262,7 @@ odd function with period \(2\pi\).
           <dd>
             <p>
               Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a>
-              object. <a href="#audionode-constructor-common">Initialize the
+              object. <a href="#audionode-constructor-init">Initialize the
               common part</a> of <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -10331,7 +10332,7 @@ odd function with period \(2\pi\).
             <p>
               Let <var>node</var> be a new
               <a>MediaStreamTrackAudioSourceNode</a> object. <a href=
-              "#audionode-constructor-common">Initialize the common part</a> of
+              "#audionode-constructor-init">Initialize</a>
             <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
@@ -10409,7 +10410,7 @@ odd function with period \(2\pi\).
             <p>
               Let <var>node</var> be a new
               <a>MediaStreamAudioDestinationNode</a> object. <a href=
-              "#audionode-constructor-common">Initialize the common part</a> of
+              "#audionode-constructor-init">Initialize</a>
               <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">

--- a/index.html
+++ b/index.html
@@ -2373,7 +2373,7 @@ function setupRoutingGraph() {
         </p>
         <section>
           <h3>
-            AudioNode creation
+            AudioNode Creation
           </h3>
           <p>
             <a>AudioNode</a>s can be created in two ways: by using the
@@ -2387,10 +2387,11 @@ function setupRoutingGraph() {
             "associated">associated <a>BaseAudioContext</a></dfn> of the
             <a>AudioNode</a> to be created. Similarly, when using the factory
             method, the <a>associated <code>BaseAudioContext</code></a> of the
-            <a>AudioNode</a> is the first argument of the factory method.
+            <a>AudioNode</a> is the <a>BaseAudioContext</a> this factory method
+            is called on.
           </p>
           <p>
-            To create a new <a>AudioNode</a> of a particular type <var>i</var>
+            To create a new <a>AudioNode</a> of a particular type <var>n</var>
             using its constructor, with a <a>BaseAudioContext</a> <var>c</var>
             as first argument, and an <a>associated option object</a>
             <var>option</var> as second argument, from the <a href=
@@ -2398,23 +2399,23 @@ function setupRoutingGraph() {
             relevant global</a> of <var>c</var>, execute these steps:
           </p>
           <ol>
-            <li>Let <var>o</var> be a new object of type <var>i</var>.
+            <li>Let <var>o</var> be a new object of type <var>n</var>.
             </li>
             <li>
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>o</var>, with <var>c</var> and <var>option</var>
-              as arguments.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>o</var>, with <var>c</var> and <var>option</var> as
+              arguments.
             </li>
             <li>Return <var>o</var>
             </li>
           </ol>
           <p>
-            To create a new <a>AudioNode</a> of a particular type <var>i</var>
+            To create a new <a>AudioNode</a> of a particular type <var>n</var>
             using its <a>factory method</a>, called on a
             <var>BaseAudioContext</var> <var>c</var>, execute these steps:
           </p>
           <ol>
-            <li>Let <var>o</var> be a new object of type <var>i</var>.
+            <li>Let <var>o</var> be a new object of type <var>n</var>.
             </li>
             <li>Let <var>option</var> be a dictionnary of the type <a href=
             "#dfn-associated-option-object">associated</a> to the interface
@@ -2426,16 +2427,15 @@ function setupRoutingGraph() {
             value of this parameter.
             </li>
             <li>
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>o</var> with <var>c</var> and <var>option</var>
-              as arguments.
+              <a href="#audionode-constructor-init">Initialize</a> <var>o</var>
+              with <var>c</var> and <var>option</var> as arguments.
             </li>
             <li>Return <var>o</var>
             </li>
           </ol>
           <p>
             <dfn id="audionode-constructor-init">Initializing</dfn> an object
-            <var>o</var> of interface <var>i</var> that inherits from
+            <var>o</var> of interface <var>n</var> that inherits from
             <a>AudioNode</a> means executing the following steps, given the
             arguments <var>context</var> and <var>dict</var> passed to the
             constructor of this interface.
@@ -2474,7 +2474,7 @@ function setupRoutingGraph() {
             its value:
               <ol>
                 <li>If <var>k</var> is <code>disableNormalization</code> or
-                <code>buffer</code> and <var>i</var> is <a>ConvolverNode</a>,
+                <code>buffer</code> and <var>n</var> is <a>ConvolverNode</a>,
                 jump to the beginning of this loop.
                 </li>
                 <li>If <var>k</var> is the name of an <a>AudioParam</a> on this
@@ -4548,7 +4548,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>OfflineAudioContext</code></a> and an
           <a><code>AudioContext</code></a>.
         </p>
-        <dl title="interface AudioBuffer" class="idl">
+        <dl title=
+        "[Constructor(&lt;a&gt;AudioBufferOptions&lt;a&gt; options)]interface AudioBuffer"
+        class="idl">
           <dt>
             readonly attribute float sampleRate
           </dt>
@@ -4840,8 +4842,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <dd>
             <p>
               Let <var>node</var> be a new <a>AudioBufferSourceNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -5189,8 +5191,8 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           <dd>
             <p>
               Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -5272,9 +5274,9 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
           </dt>
           <dd>
             <p>
-              Let <var>node</var> be a new <a>MediaElementAudioSOurceNode</a>
-              object. <a href="#audionode-constructor-init">Initialize the
-              common part</a> of <var>node</var>, and return <var>node</var>.
+              Let <var>node</var> be a new <a>MediaElementAudioSourceNode</a>
+              object. <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -5286,11 +5288,10 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
                 "#associated">associated</a> with.
               </dd>
               <dt>
-                optional MediaElementAudioSourceOptions options
+                MediaElementAudioSourceOptions options
               </dt>
               <dd>
-                Optional initial parameter value for this
-                <a>MediaELementAudioSourceNode</a>.
+                Parameter value for this <a>MediaElementAudioSourceNode</a>.
               </dd>
             </dl>
           </dd>
@@ -5651,8 +5652,8 @@ window.audioWorklet.import("bypass.js").then(function () {
               </dl>
               <p>
                 Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
-                <a href="#audionode-constructor-init">Initialize the common
-                part</a> of <var>node</var>. Perform the <a href=
+                <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>. Perform the <a href=
                 "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">construction
                 procedure</a> of an <a><code>AudioWorkletNode</code></a> and
                 the corresponding <a><code>AudioWorkletProcessor</code></a>
@@ -7390,8 +7391,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dd>
             <p>
               Let <var>node</var> be a new <a>StereoPannerNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -7503,8 +7504,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
           <dd>
             <p>
               Let <var>node</var> be a new <a>ConvolverNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -8245,8 +8246,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a> of
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -8351,8 +8352,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -8427,8 +8428,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>DynamicsCompressorNode</a>
-              object. <a href="#audionode-constructor-init">Initialize the
-              common part</a> of <var>node</var>, and return <var>node</var>.
+              object. <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -8920,8 +8921,8 @@ function calculateNormalizationScale(buffer)
           <dd>
             <p>
               Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -9374,8 +9375,8 @@ $$
           <dd>
             <p>
               Let <var>node</var> be a new <a>IIRFilterNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -9563,8 +9564,8 @@ $$
           <dd>
             <p>
               Let <var>node</var> be a new <a>WaveShaperNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -9813,8 +9814,8 @@ $$
           <dd>
             <p>
               Let <var>node</var> be a new <a>OscillatorNode</a> object.
-              <a href="#audionode-constructor-init">Initialize the common
-              part</a> of <var>node</var>, and return <var>node</var>.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>
@@ -10251,8 +10252,8 @@ odd function with period \(2\pi\).
           <dd>
             <p>
               Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a>
-              object. <a href="#audionode-constructor-init">Initialize the
-              common part</a> of <var>node</var>, and return <var>node</var>.
+              object. <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
             </p>
             <dl class="parameters">
               <dt>


### PR DESCRIPTION
The first commit is the most important of this PR, it defines what happens when constructing AudioNodes (either via the factory method or the ctor). The second fixes the descriptions of the various factory method to link back to the algorithm used (this is mostly a mechanical change). The third patch fixes a mistake in the first patch, and the fourth one defines the constructors in terms of all the above, linking back to the definitions appropriately: it's mostly mechanical, but adjustments have been performed for the AudioWorklet.