### PR TITLE
#1105 Allow zero for a reference distance

### DIFF
--- a/index.html
+++ b/index.html
@@ -6628,7 +6628,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               A reference distance for reducing volume as source moves further
               from the listener. The default value is 1. A
               <code>RangeError</code> exception must be thrown if this is set
-              to a non-positive value.
+              to a negative value.
             </p>
           </dd>
           <dt>
@@ -6639,7 +6639,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               The maximum distance between source and listener, after which the
               volume will not be reduced any further. The default value is
               10000. A <code>RangeError</code> exception must be thrown if this
-              is set to a non-positive value.
+              is set to a negative value.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
This a continuation for #1105. 
It allows to set 0 for a reference distance, what is useful in a linear mode. 

 <!-- foo -->