### PR TITLE
Fix #1105: Allow refDistance to be 0 for PannerNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -6494,7 +6494,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
 </pre>
             <p>
               That is, \(d\) is clamped to the interval \([d_{ref},\,
-              \infty)\).
+              \infty)\). If \(d_{ref} = 0\), the value of the inverse model is
+              taken to be 0, independent of the value of \(d\) and \(f\).
             </p>
           </dd>
           <dt>
@@ -6513,7 +6514,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
 </pre>
             <p>
               That is, \(d\) is clamped to the interval \([d_{ref},\,
-              \infty)\).
+              \infty)\). If \(d_{ref} = 0\), the value of the exponential model
+              is taken to be 0, independent of \(d\) and \(f\).
             </p>
           </dd>
         </dl>
@@ -6629,7 +6631,7 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               A reference distance for reducing volume as source moves further
               from the listener. The default value is 1. A
               <code>RangeError</code> exception must be thrown if this is set
-              to a non-positive value.
+              to a non-negative value.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
If refDistance is 0, define the inverse and exponential models to take
the value 0 independent of the values of d and f.

The limit as d and dref go to zero aren't well defined and depends on
the direction of approach.  So I took the lazy way and set the value
to be always be 0.