### PR TITLE
Fix #1116: Make PeriodicWaveOptions optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -9525,7 +9525,7 @@ odd function with period \(2\pi\).
           setPeriodicWave()</a> and for more details.
         </p>
         <dl title=
-        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, &lt;a&gt;PeriodicWaveOptions&lt;/a&gt; options)]interface PeriodicWave"
+        "[Constructor(&lt;a&gt;BaseAudioContext&lt;/a&gt; context, optional &lt;a&gt;PeriodicWaveOptions&lt;/a&gt; options)]interface PeriodicWave"
         class="idl"></dl>
         <section>
           <h2>
@@ -9549,9 +9549,14 @@ odd function with period \(2\pi\).
           </h2>
           <p>
             The <code>PeriodicWaveOptions</code> dictionary is used to specify
-            how the waveform is constructed. At least one of <code>real</code>
-            or <code>imag</code> must be specified. If not given, it is the
-            array of all zeroes of the same length as the other.
+            how the waveform is constructed. If only one of <code>real</code>
+            or <code>imag</code> is specified. the other is treated as if it
+            were an array of all zeroes of the same length, as specified below
+            in <a href="#dictionary-periodicwaveoptions-members">description of
+            the dictionary members</a>. If neither is given, a
+            <a><code>PeriodicWave</code></a> is created that must be equivalent
+            to an <a><code>OscillatorNode</code></a> with <code><a href=
+            "#widl-OscillatorNode-type">type</a></code> "sine".
           </p>
           <dl title="dictionary PeriodicWaveOptions : PeriodicWaveConstraints"
           class="idl">


### PR DESCRIPTION
Make the PeriodicwaveOptions options actually optional and specify
that if neither the real or imag members of the PeriodicWaveOptions
dictionary is specified, a PeriodicWave is created that would produce
the same output as an Oscillator of type "sine".