### PR TITLE
Fix #1004: Specify copyFrom/To channel behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -4496,11 +4496,11 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               Let <code>buffer</code> be the <a>AudioBuffer</a> buffer with
               \(N_b\) frames, let \(N_f\) be the number of elements in the
               <code>destination</code> array, and \(k\) be the value of
-              <code>startInChannel</code>. Then the number of frames copied from
-              <code>buffer</code> to <code>destination</code> is \(\min(N_b - k,
-              N_f)\).  If this is less than \(N_f\), then the remaining elements
-              of <code>destination</code> are not modified.
-              </p>
+              <code>startInChannel</code>. Then the number of frames copied
+              from <code>buffer</code> to <code>destination</code> is
+              \(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
+              remaining elements of <code>destination</code> are not modified.
+            </p>
             <dl class="parameters">
               <dt>
                 Float32Array destination
@@ -4541,11 +4541,10 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               Let <code>buffer</code> be the <a>AudioBuffer</a> with \(N_b\)
               frames, let \(N_f\) be the number of elements in the
               <code>source</code> array, and \(k\) be the value of
-              <code>startInChannel</code>. Then the number of frames copied from
-              <code>source</code> to the <code>buffer</code> is \(\min(N_b - k,
-              N_f)\).  If this is less than \(N_f\), then the remaining elements
-              of <code>buffer</code> are not modified.
-            </p>
+              <code>startInChannel</code>. Then the number of frames copied
+              from <code>source</code> to the <code>buffer</code> is \(\min(N_b
+              - k, N_f)\). If this is less than \(N_f\), then the remaining
+              elements of <code>buffer</code> are not modified.
             </p>
             <dl class="parameters">
               <dt>

--- a/index.html
+++ b/index.html
@@ -4492,6 +4492,15 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               the specified channel of the <a>AudioBuffer</a> to the
               <code>destination</code> array.
             </p>
+            <p>
+              Let <code>buffer</code> be the <a>AudioBuffer</a> buffer with
+              \(N_b\) frames, let \(N_f\) be the number of elements in the
+              <code>destination</code> array, and \(k\) be the value of
+              <code>startInChannel</code>. Then the number of frames copied from
+              <code>buffer</code> to <code>destination</code> is \(\min(N_b - k,
+              N_f)\).  If this is less than \(N_f\), then the remaining elements
+              of <code>destination</code> are not modified.
+              </p>
             <dl class="parameters">
               <dt>
                 Float32Array destination
@@ -4527,6 +4536,16 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               The <code>copyToChannel</code> method copies the samples to the
               specified channel of the <a>AudioBuffer</a>, from the
               <code>source</code> array.
+            </p>
+            <p>
+              Let <code>buffer</code> be the <a>AudioBuffer</a> with \(N_b\)
+              frames, let \(N_f\) be the number of elements in the
+              <code>source</code> array, and \(k\) be the value of
+              <code>startInChannel</code>. Then the number of frames copied from
+              <code>source</code> to the <code>buffer</code> is \(\min(N_b - k,
+              N_f)\).  If this is less than \(N_f\), then the remaining elements
+              of <code>buffer</code> are not modified.
+            </p>
             </p>
             <dl class="parameters">
               <dt>


### PR DESCRIPTION
Basically specify that copying is done until we run out of frames in
the source or run out of space in the destination.  In either case,
the remaining elements are not modified, so only a part of the array
is modified.