### PR TITLE
Fix #1167: WebIDL for AudioContext in a funny place

### DIFF
--- a/index.html
+++ b/index.html
@@ -2266,8 +2266,6 @@ function setupRoutingGraph() {
             </p>
           </dd>
         </dl>
-        <dl title="[Constructor] interface AudioContext : BaseAudioContext"
-        class="idl"></dl>
         <section>
           <h2 id="OfflineAudioCompletionEvent">
             The OfflineAudioCompletionEvent Interface


### PR DESCRIPTION
This was a stray declaration AudioContext constructor.  Remove it.