### PR TITLE
Fix #1120: Specify PeriodicWave constructor better

### DIFF
--- a/index.html
+++ b/index.html
@@ -10051,7 +10051,9 @@ odd function with period \(2\pi\).
             the dictionary members</a>. If neither is given, a
             <a><code>PeriodicWave</code></a> is created that must be equivalent
             to an <a><code>OscillatorNode</code></a> with <code><a href=
-            "#widl-OscillatorNode-type">type</a></code> "sine".
+            "#widl-OscillatorNode-type">type</a></code> "sine".  If both are
+            given, the sequences must have the same length; otherwise an <span class="synchronous">error
+            of type <code>NotSupportedError</code> MUST be thrown</span>.
           </p>
           <dl title="dictionary PeriodicWaveOptions : PeriodicWaveConstraints"
           class="idl">
@@ -10063,7 +10065,7 @@ odd function with period \(2\pi\).
               <a><code>real</code></a> parameter to <a href=
               "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
               <code>createPeriodicWave</code></a>. This defaults to a sequence
-              of all zeroes if <a><code>imag</code></a> is given.
+              of all zeroes of the same length as <a><code>imag</code></a> if <a><code>imag</code></a> is given.
             </dd>
             <dt>
               sequence&lt;float&gt; imag
@@ -10073,7 +10075,7 @@ odd function with period \(2\pi\).
               <a><code>imag</code></a> parameter to <a href=
               "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
               <code>createPeriodicWave</code></a>. This defaults to a sequence
-              of all zeroes if <a><code>real</code></a> is given.
+              of all zeroes of the same length as <a><code>real</code></a> if <a><code>real</code></a> is given.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -10051,9 +10051,10 @@ odd function with period \(2\pi\).
             the dictionary members</a>. If neither is given, a
             <a><code>PeriodicWave</code></a> is created that must be equivalent
             to an <a><code>OscillatorNode</code></a> with <code><a href=
-            "#widl-OscillatorNode-type">type</a></code> "sine".  If both are
-            given, the sequences must have the same length; otherwise an <span class="synchronous">error
-            of type <code>NotSupportedError</code> MUST be thrown</span>.
+            "#widl-OscillatorNode-type">type</a></code> "sine". If both are
+            given, the sequences must have the same length; otherwise an
+            <span class="synchronous">error of type
+            <code>NotSupportedError</code> MUST be thrown</span>.
           </p>
           <dl title="dictionary PeriodicWaveOptions : PeriodicWaveConstraints"
           class="idl">
@@ -10065,7 +10066,8 @@ odd function with period \(2\pi\).
               <a><code>real</code></a> parameter to <a href=
               "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
               <code>createPeriodicWave</code></a>. This defaults to a sequence
-              of all zeroes of the same length as <a><code>imag</code></a> if <a><code>imag</code></a> is given.
+              of all zeroes of the same length as <a><code>imag</code></a> if
+              <a><code>imag</code></a> is given.
             </dd>
             <dt>
               sequence&lt;float&gt; imag
@@ -10075,7 +10077,8 @@ odd function with period \(2\pi\).
               <a><code>imag</code></a> parameter to <a href=
               "#widl-BaseAudioContext-createPeriodicWave-PeriodicWave-Float32Array-real-Float32Array-imag-PeriodicWaveConstraints-constraints">
               <code>createPeriodicWave</code></a>. This defaults to a sequence
-              of all zeroes of the same length as <a><code>real</code></a> if <a><code>real</code></a> is given.
+              of all zeroes of the same length as <a><code>real</code></a> if
+              <a><code>real</code></a> is given.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
If both the `real` and `imag` members of the `PeriodicWaveOptions`
dictionary are specified, they must have the same length.  Otherwise a
NotSupportedError is thrown.

(Not sure if NotSupportedError is the right one, though.)