### PR TITLE
Fix #300: Configurable sample rate for AudioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -2063,16 +2063,17 @@ function setupRoutingGraph() {
               <p>
                 Set the <a href=
                 "#widl-BaseAudioContext-sampleRate"><code>sampleRate</code></a>
-                of the context to this value. The supported values are the same
-                as the sample rates for an <a>AudioBuffer</a>. <span class=
-                "synchronous">A <code>NotSupportedError</code> exception MUST
-                be thrown if the specified sample rate is not supported.</span>
+                to this value for the <a>AudioContext</a> that will be created.
+                The supported values are the same as the sample rates for an
+                <a>AudioBuffer</a>. <span class="synchronous">A
+                <code>NotSupportedError</code> exception MUST be thrown if the
+                specified sample rate is not supported.</span>
               </p>
               <p>
                 If <a href=
                 "#widl-AudioContextOptions-sampleRate"><code>sampleRate</code></a>
-                is not specified, the sample rate of the audio hardware is
-                used.
+                is not specified, the preferred sample rate of the output
+                device for this <a>AudioContext</a> is used.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -2056,6 +2056,25 @@ function setupRoutingGraph() {
                 "#widl-BaseAudioContext-baseLatency">baseLatency</a> attribute.
               </p>
             </dd>
+            <dt>
+              float sampleRate
+            </dt>
+            <dd>
+              <p>
+                Set the <a href=
+                "#widl-BaseAudioContext-sampleRate"><code>sampleRate</code></a>
+                of the context to this value. The supported values are the same
+                as the sample rates for an <a>AudioBuffer</a>. <span class=
+                "synchronous">A <code>NotSupportedError</code> exception MUST
+                be thrown if the specified sample rate is not supported.</span>
+              </p>
+              <p>
+                If <a href=
+                "#widl-AudioContextOptions-sampleRate"><code>sampleRate</code></a>
+                is not specified, the sample rate of the audio hardware is
+                used.
+              </p>
+            </dd>
           </dl>
         </section>
         <section>


### PR DESCRIPTION
Add a new sampleRate attribute to AudioContextOptions to specify the
sample rate of the AudioContext.