### PR TITLE
Fix #1157: Add attributes to Media{Element,Stream}AudioSourceNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5295,6 +5295,15 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
               </dd>
             </dl>
           </dd>
+          <dt>
+            readonly attribute HTMLMediaElement mediaElement
+          </dt>
+          <dd>
+            <p>
+              The <code>HTMLMediaElement</code> used when constructing this
+              <a>MediaElementAudioSourceNode</a>.
+            </p>
+          </dd>
         </dl>
         <p>
           A <a>MediaElementAudioSourceNode</a> is created given an
@@ -10272,6 +10281,15 @@ odd function with period \(2\pi\).
                 <a>MediaStreamAudioSourceNode</a>.
               </dd>
             </dl>
+          </dd>
+          <dt>
+            readonly attribute MediaStream mediaStream
+          </dt>
+          <dd>
+            <p>
+              The <code>MediaStream</code> used when constructing this
+              <a>MediaStreamAudioSourceNode</a>.
+            </p>
           </dd>
         </dl>
         <section>


### PR DESCRIPTION
Add readonly attribute to each of these nodes to hold a reference to
the media element or stream used to create these nodes.