### PR TITLE
Revert "Fix #1157: Add attributes to Media{Element,Stream}AudioSourceNode"

### DIFF
--- a/index.html
+++ b/index.html
@@ -5313,15 +5313,6 @@ if ((loopStart || loopEnd) &amp;& loopStart &gt;= 0 &amp;& loopEnd &gt; 0 &amp;&
               </dd>
             </dl>
           </dd>
-          <dt>
-            readonly attribute HTMLMediaElement mediaElement
-          </dt>
-          <dd>
-            <p>
-              The <code>HTMLMediaElement</code> used when constructing this
-              <a>MediaElementAudioSourceNode</a>.
-            </p>
-          </dd>
         </dl>
         <p>
           A <a>MediaElementAudioSourceNode</a> is created given an
@@ -10304,15 +10295,6 @@ odd function with period \(2\pi\).
                 <a>MediaStreamAudioSourceNode</a>.
               </dd>
             </dl>
-          </dd>
-          <dt>
-            readonly attribute MediaStream mediaStream
-          </dt>
-          <dd>
-            <p>
-              The <code>MediaStream</code> used when constructing this
-              <a>MediaStreamAudioSourceNode</a>.
-            </p>
           </dd>
         </dl>
         <section>


### PR DESCRIPTION
Reverts WebAudio/web-audio-api#1178. Actually, I think this we should name the attribute for `MediaStreamAudioSourceNode` `stream` and not `mediaStream`, so that it's consistent with `MediaStreamAudioDestinationNode`.

Thoughts ?