### PR TITLE
Fix #1173: periodicWave overrides type setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -9938,9 +9938,14 @@ $$
             </dt>
             <dd>
               The type of oscillator to be constructed. If this is set to
-              "custom" without also specifying a
-              <a><code>periodicWave</code></a>, then an
-              <code>InvalidStateError</code> exception MUST be thrown.
+              "custom" without also specifying a <a href=
+              "#widl-OscillatorOptions-periodicWave"><code>periodicWave</code></a>,
+              then an <span class="synchronous"><code>InvalidStateError</code>
+              exception MUST be thrown</span>. If <a href=
+              "#widl-OscillatorOptions-periodicWave"><code>periodicWave</code></a>
+              is specified, then any valid value for <a href=
+              "#widl-OscillatorOptions-type"><code>type</code></a> is ignored;
+              it is treated as if it were set to "custom".
             </dd>
             <dt>
               float frequency = 440
@@ -9961,9 +9966,9 @@ $$
             <dd>
               The <a><code>PeriodicWave</code></a> for the
               <a><code>OscillatorNode</code></a>. If this is specified, then
-              the <a><code>type</code></a> member must either be unspecified or
-              set to "custom". If this is not true, an
-              <code>InvalidStateError</code> exception MUST be thrown.
+              any valid value for <a href=
+              "#widl-OscillatorOptions-type"><code>type</code></a> is ignored;
+              it is treated as if "custom" were specified.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
In the OscillatorOptions dictionary, if both type and periodicWave are
specified, the actual type is ignored and treated as if it were set to
"custom".

This implements option three from #1173.

Also added a synchronous flag around the text about throwing errors.