### PR TITLE
Fix #1166: decodeAudioData throws DataCloneError for detached buffer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@ function setupRoutingGraph() {
               </li>
               <li>Else, execute the following steps:
                 <ol>
-                  <li>Let <var>error</var> be a <code>TypeError</code>.
+                  <li>Let <var>error</var> be a <code>DataCloneError</code>.
                   </li>
                   <li>Reject <var>promise</var> with <var>error</var>.
                   </li>


### PR DESCRIPTION
Throw DataCloneError instead of TypeError.