### PR TITLE
Fix #1171: setValueCurveAtTime curve is sequence<float>

### DIFF
--- a/index.html
+++ b/index.html
@@ -3836,7 +3836,7 @@ function setupRoutingGraph() {
             </p>
           </dd>
           <dt>
-            AudioParam setValueCurveAtTime(Float32Array values, double
+            AudioParam setValueCurveAtTime(sequence&lt;float&gt; values, double
             startTime, double duration)
           </dt>
           <dd>
@@ -3847,21 +3847,23 @@ function setupRoutingGraph() {
             </p>
             <dl class="parameters">
               <dt>
-                Float32Array values
+                sequence&lt;float&gt; values
               </dt>
               <dd>
                 <p>
-                  A Float32Array representing a parameter value curve. These
-                  values will apply starting at the given time and lasting for
-                  the given duration. When this method is called, an internal
-                  copy of the curve is created for automation purposes.
-                  Subsequent modifications of the contents of the passed-in
-                  array therefore have no effect on the <a>AudioParam</a>.
+                  A sequence of float values representing a parameter value
+                  curve. These values will apply starting at the given time and
+                  lasting for the given duration. When this method is called,
+                  an internal copy of the curve is created for automation
+                  purposes. Subsequent modifications of the contents of the
+                  passed-in array therefore have no effect on the
+                  <a>AudioParam</a>.
                 </p>
                 <p>
-                  An <code>InvalidStateError</code> MUST be thrown if this
-                  attribute is with a Float32Array that has a length less than
-                  2.
+                  <span class="synchronous">An <code>InvalidStateError</code>
+                  MUST be thrown if this attribute is a
+                  <code>sequence&lt;float&gt;</code> object that has a length
+                  less than 2.</span>
                 </p>
               </dd>
               <dt>


### PR DESCRIPTION
Change the type of the curve parameter to sequence<float>.  This
specifies that only finite floats are allowed for the curve.  This is
a backward-compatible change since Float32Array is a sequence<float>
(if all the values in Float32Array are finite floats).