### PR TITLE
Spell out the parameter in AudioBuffer constructor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4565,9 +4565,17 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
           <a><code>OfflineAudioContext</code></a> and an
           <a><code>AudioContext</code></a>.
         </p>
-        <dl title=
-        "[Constructor(&lt;a&gt;AudioBufferOptions&lt;a&gt; options)]interface AudioBuffer"
-        class="idl">
+        <dl title="interface AudioBuffer" class="idl">
+          <dt>
+            Constructor
+          </dt>
+          <dd>
+            <dl class="parameters">
+              <dt>
+                AudioBufferOptions options
+              </dt>
+            </dl>
+          </dd>
           <dt>
             readonly attribute float sampleRate
           </dt>


### PR DESCRIPTION
PTAL. It is a simple syntax correction PR.