### PR TITLE
Fix #1195: createPeriodicWave takes `sequence<float>` arrays

### DIFF
--- a/index.html
+++ b/index.html
@@ -1422,14 +1422,13 @@ function setupRoutingGraph() {
               representing a waveform containing arbitrary harmonic content.
               <span class="synchronous">The <code>real</code> and
               <code>imag</code> parameters must be of type
-              <code>Float32Array</code> (described in [[!TYPED-ARRAYS]]) of
-              equal lengths greater than zero or an <code>IndexSizeError</code>
-              exception MUST be thrown.</span> All implementations must support
-              arrays up to at least 8192. These parameters specify the Fourier
-              coefficients of a <a href=
-              "https://en.wikipedia.org/wiki/Fourier_series">Fourier series</a>
-              representing the partials of a periodic waveform. The created
-              <a><code>PeriodicWave</code></a> will be used with an
+              <code>sequence&lt;float&gt;</code> of equal lengths greater than
+              zero or an <code>IndexSizeError</code> exception MUST be
+              thrown.</span> All implementations must support arrays up to at
+              least 8192. These parameters specify the Fourier coefficients of
+              a <a href="https://en.wikipedia.org/wiki/Fourier_series">Fourier
+              series</a> representing the partials of a periodic waveform. The
+              created <a><code>PeriodicWave</code></a> will be used with an
               <a><code>OscillatorNode</code></a> and, by default, will
               represent a <em>normalized</em> time-domain waveform having
               maximum absolute peak value of 1. Another way of saying this is
@@ -1455,7 +1454,7 @@ function setupRoutingGraph() {
             </p>
             <dl class="parameters">
               <dt>
-                Float32Array real
+                sequence&lt;float&gt; real
               </dt>
               <dd>
                 The <dfn id="dfn-real">real</dfn> parameter represents an array
@@ -1467,7 +1466,7 @@ function setupRoutingGraph() {
                 ignored and implementations must set it to zero internally.
               </dd>
               <dt>
-                Float32Array imag
+                sequence&lt;float&gt; imag
               </dt>
               <dd>
                 The <dfn id="dfn-imag">imag</dfn> parameter represents an array


### PR DESCRIPTION
Instead of using `Float32Array`'s for the real and imaginary
coefficients, use `sequence<float>`.  This will cause errors to be
signaled if non-finite values are used, just like for the
`PeriodicWave` constructor.