### PR TITLE
Fix #1157: Add attributes to  Media{Element,Stream}AudioSourceNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5659,6 +5659,15 @@ function process(numberOfFrames) {
               </dd>
             </dl>
           </dd>
+          <dt>
+            [SameObject] readonly attribute HTMLMediaElement mediaElement
+          </dt>
+          <dd>
+            <p>
+              the <code>HTMLMediaElement</code> used when constructing this
+              <a>MediaElementAudioSourceNode</a>.
+            </p>
+          </dd>
         </dl>
         <p>
           A <a>MediaElementAudioSourceNode</a> is created given an
@@ -10650,6 +10659,15 @@ odd function with period \(2\pi\).
                 <a>MediaStreamAudioSourceNode</a>.
               </dd>
             </dl>
+          </dd>
+          <dt>
+            [SameObject] readonly attribute MediaStream mediaStream
+          </dt>
+          <dd>
+            <p>
+              The <code>MediaStream</code> used when constructing this
+              <a>MediaStreamAudioSourceNode</a>.
+            </p>
           </dd>
         </dl>
         <section>


### PR DESCRIPTION
Add readonly attribute to each of these nodes to hold a reference to
the media element or stream used to create the node.