### PR TITLE
Disallow empty string as AWP registration key.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5782,7 +5782,7 @@ function process(numberOfFrames) {
               string key</a> to the corresponding <a>AudioWorkletProcessor</a>
               definition. Initially this map is empty and becomes populated
               when <a href=
-              "widl-AudioWorkletGlobalScope-registerProcessor-void-DOMString-name-VoidFunction-processorConstructor">
+              "#widl-AudioWorkletGlobalScope-registerProcessor-void-DOMString-name-VoidFunction-processorCtor">
               registerProcessor</a> method is called.
             </dd>
           </dl>
@@ -5886,6 +5886,10 @@ window.audioWorklet.import("bypass.js").then(function () {
                 user agent must run the following steps:
               </p>
               <ol>
+                <li>If the <code><em>name</em></code> is the empty string,
+                throw a <code>NotSupportedError</code> exception and abort
+                these steps because the empty string is not a valid key.
+                </li>
                 <li>If the <code><em>name</em></code> exists as a key in the
                 <a>node name to processor definition map</a>, throw a
                 <code>NotSupportedError</code> exception and abort these steps


### PR DESCRIPTION
Fixes #1172.
Also corrects missing # in link to registerProcessor() definition.