### PR TITLE
Remove references to the doppler effect and speed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11857,11 +11857,7 @@ Quad up-mix:
           directional and heard only if it is facing the listener.
           <a><code>AudioListener</code></a> objects (representing a person's
           ears) have an <em>orientation</em> and <em>up</em> vector
-          representing in which direction the person is facing. Because both
-          the source stream and the listener can be moving, they both have a
-          <em>velocity</em> vector representing both the speed and direction of
-          movement. Taken together, these two velocities can be used to
-          generate a doppler shift effect which changes the pitch.
+          representing in which direction the person is facing.
         </p>
         <p>
           During rendering, the <a><code>PannerNode</code></a> calculates an


### PR DESCRIPTION
We've removed support for this a while back, but we still had some references in
non-normative text.

This fixes #1206.