### PR TITLE
Fix #1182: Throw RangeError instead of TypeError

### DIFF
--- a/index.html
+++ b/index.html
@@ -3551,7 +3551,7 @@ function setupRoutingGraph() {
                 <a><code>BaseAudioContext</code></a>'s <a href=
                 "#widl-AudioContext-currentTime">currentTime</a> attribute at
                 which the parameter changes to the given value. <span class=
-                "synchronous">A TypeError exception MUST be thrown if
+                "synchronous">A RangeError exception MUST be thrown if
                 <code>startTime</code> is negative or is not a finite
                 number.</span> If <var>startTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -3616,7 +3616,7 @@ function setupRoutingGraph() {
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute
                 at which the automation ends. <span class="synchronous">A
-                TypeError exception MUST be thrown if <code>endTime</code> is
+                RangeError exception MUST be thrown if <code>endTime</code> is
                 negative or is not a finite number.</span> If
                 <var>endTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -3743,7 +3743,7 @@ function setupRoutingGraph() {
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute
                 where the exponential ramp ends. <span class="synchronous">A
-                TypeError exception MUST be thrown if <code>endTime</code> is
+                RangeError exception MUST be thrown if <code>endTime</code> is
                 negative or is not a finite number.</span> If
                 <var>endTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -3781,7 +3781,7 @@ function setupRoutingGraph() {
                 same time coordinate system as the
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute.
-                <span class="synchronous">A TypeError exception MUST be thrown
+                <span class="synchronous">A RangeError exception MUST be thrown
                 if <code>start</code> is negative or is not a finite
                 number.</span> If <var>startTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -3795,7 +3795,7 @@ function setupRoutingGraph() {
                 The time-constant value of first-order filter (exponential)
                 approach to the target value. The larger this value is, the
                 slower the transition will be. <span class="synchronous">The
-                value must be non-negative or a TypeError exception MUST be
+                value must be non-negative or a RangeError exception MUST be
                 thrown.</span> If <code>timeConstant</code> is zero, the output
                 value jumps immediately to the final value.
                 <p>
@@ -3873,7 +3873,7 @@ function setupRoutingGraph() {
                 <a><code>AudioContext</code></a>'s <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute
                 at which the value curve will be applied. <span class=
-                "synchronous">A TypeError exception MUST be thrown if
+                "synchronous">A RangeError exception MUST be thrown if
                 <code>startTime</code> is negative or is not a finite
                 number.</span>. If <var>startTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -3886,7 +3886,7 @@ function setupRoutingGraph() {
               <dd>
                 The amount of time in seconds (after the <em>time</em>
                 parameter) where values will be calculated according to the
-                <em>values</em> parameter. A <code>TypeError</code> exception
+                <em>values</em> parameter. A <code>RangError</code> exception
                 MUST be thrown if <code>duration</code> is not strictly
                 positive or is not a finite number.
               </dd>
@@ -3948,7 +3948,7 @@ function setupRoutingGraph() {
                 will be cancelled. It is a time in the same time coordinate
                 system as the <a><code>AudioContext</code></a>'s <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute.
-                <span class="synchronous">A TypeError exception MUST be thrown
+                <span class="synchronous">A RangeError exception MUST be thrown
                 if <code>cancelTime</code> is negative or is not a finite
                 number.</span> If <var>cancelTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -4071,7 +4071,7 @@ function setupRoutingGraph() {
                 will be cancelled. It is a time in the same time coordinate
                 system as the <a><code>AudioContext</code></a>'s <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute.
-                <span class="synchronous">A TypeError exception MUST be thrown
+                <span class="synchronous">A RangeError exception MUST be thrown
                 if <code>cancelTime</code> is negative or is not a finite
                 number.</span> If <var>cancelTime</var> is less than <a href=
                 "#widl-BaseAudioContext-currentTime">currentTime</a>, it is
@@ -4292,7 +4292,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 nearest sample frame. If 0 is passed in for this value or if
                 the value is less than <b>currentTime</b>, then the sound will
                 start playing immediately. <span class="synchronous">A
-                TypeError exception MUST be thrown if <code>when</code> is
+                RangeError exception MUST be thrown if <code>when</code> is
                 negative.</span>
               </dd>
             </dl>
@@ -4325,7 +4325,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 <a href=
                 "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>,
                 then the sound will stop playing immediately. <span class=
-                "synchronous">A TypeError exception MUST be thrown if
+                "synchronous">A RangeError exception MUST be thrown if
                 <code>when</code> is negative</span>.
               </dd>
             </dl>
@@ -5051,7 +5051,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 "#widl-BaseAudioContext-currentTime">currentTime</a> attribute.
                 If 0 is passed in for this value or if the value is less than
                 <b>currentTime</b>, then the sound will start playing
-                immediately. <span class="synchronous">A TypeError exception
+                immediately. <span class="synchronous">A RangeError exception
                 MUST be thrown if <code>when</code> is negative.</span>
               </dd>
               <dt>
@@ -5061,7 +5061,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 The <dfn id="dfn-offset">offset</dfn> parameter supplies a
                 <a>playhead position</a> where playback will begin. If 0 is
                 passed in for this value, then playback will start from the
-                beginning of the buffer. <span class="synchronous">A TypeError
+                beginning of the buffer. <span class="synchronous">A RangeError
                 exception MUST be thrown if <code>offset</code> is
                 negative.</span> If <code>offset</code> is greater than
                 <code>loopEnd</code>, playback will begin at
@@ -5081,9 +5081,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 duration of the sound (in seconds) to be played. If this
                 parameter is passed, this method has exactly the same effect as
                 the invocation of <code>start(when, offset)</code> followed by
-                <code>stop(when + duration)</code>. <span class=
-                "synchronous">An TypeError exception MUST be thrown if
-                <code>duration</code> is negative.</span>
+                <code>stop(when + duration)</code>. <span class="synchronous">A
+                RangeError exception MUST be thrown if <code>duration</code> is
+                negative.</span>
               </dd>
             </dl>
           </dd>
@@ -5140,7 +5140,7 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
                 <a href=
                 "#widl-BaseAudioContext-currentTime"><code>currentTime</code></a>,
                 then the sound will stop playing immediately. <span class=
-                "synchronous">A TypeError exception MUST be thrown if
+                "synchronous">A RangeError exception MUST be thrown if
                 <code>when</code> is negative</span>.
               </dd>
             </dl>


### PR DESCRIPTION
Throw a RangeError instead of a TypeError for cases where a value
(such as time or time constants) are outside the allowed range. Typically,
this means the value is negative or zero.