### PR TITLE
Fix #1211: add synchronous marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1216,7 +1216,7 @@ function setupRoutingGraph() {
                 pick a good buffer size to balance between <a href=
                 "#latency">latency</a> and audio quality. If the value of this
                 parameter is not one of the allowed power-of-2 values listed
-                above, an <code>IndexSizeError</code> MUST be thrown.
+                above, <span class="synchronous">an <code>IndexSizeError</code> MUST be thrown</span>.
               </dd>
               <dt>
                 optional unsigned long numberOfInputChannels = 2
@@ -1302,10 +1302,10 @@ function setupRoutingGraph() {
               <dd>
                 An array of the feedforward (numerator) coefficients for the
                 transfer function of the IIR filter. The maximum length of this
-                array is 20. If all of the values are zero, an
-                <code>InvalidStateError</code> MUST be thrown. A
+                array is 20. If all of the values are zero, <span class="synchronous">an
+                <code>InvalidStateError</code> MUST be thrown</span>. <span class="synchronous">A
                 <code>NotSupportedError</code> MUST be thrown if the array
-                length is 0 or greater than 20.
+                length is 0 or greater than 20</span>.
               </dd>
               <dt>
                 sequence&lt;double&gt; feedback
@@ -1313,10 +1313,10 @@ function setupRoutingGraph() {
               <dd>
                 An array of the feedback (denominator) coefficients for the
                 transfer function of the IIR filter. The maximum length of this
-                array is 20. If the first element of the array is 0, an
-                <code>InvalidStateError</code> MUST be thrown. A
+                array is 20. If the first element of the array is 0, <span class="synchronous">an
+                <code>InvalidStateError</code> MUST be thrown</span>. <span class="synchronous">A
                 <code>NotSupportedError</code> MUST be thrown if the array
-                length is 0 or greater than 20.
+                length is 0 or greater than 20</span>.
               </dd>
             </dl>
           </dd>
@@ -3886,9 +3886,9 @@ function setupRoutingGraph() {
               <dd>
                 The amount of time in seconds (after the <em>time</em>
                 parameter) where values will be calculated according to the
-                <em>values</em> parameter. A <code>TypeError</code> exception
+                <em>values</em> parameter. <span class="synchronous">A <code>TypeError</code> exception
                 MUST be thrown if <code>duration</code> is not strictly
-                positive or is not a finite number.
+                positive or is not a finite number</span>.
               </dd>
             </dl>
             <p>
@@ -4665,8 +4665,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 The index of the channel to copy the data from. If
                 <code>channelNumber</code> is greater or equal than the number
-                of channel of the <a>AudioBuffer</a>, an
-                <code>IndexSizeError</code> MUST be thrown.
+                of channel of the <a>AudioBuffer</a>, <span class="synchronous">an
+                <code>IndexSizeError</code> MUST be thrown</span>.
               </dd>
               <dt>
                 optional unsigned long startInChannel = 0
@@ -4674,8 +4674,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 An optional offset to copy the data from. If
                 <code>startInChannel</code> is greater than the
-                <code>length</code> of the <a>AudioBuffer</a>, an
-                <code>IndexSizeError</code> MUST be thrown.
+                <code>length</code> of the <a>AudioBuffer</a>, <span class="synchronous">an
+                <code>IndexSizeError</code> MUST be thrown</span>.
               </dd>
             </dl>
           </dd>
@@ -4710,8 +4710,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 The index of the channel to copy the data to. If
                 <code>channelNumber</code> is greater or equal than the number
-                of channel of the <a>AudioBuffer</a>, an
-                <code>IndexSizeError</code> MUST be thrown.
+                of channel of the <a>AudioBuffer</a>, <span class="synchronous">an
+                <code>IndexSizeError</code> MUST be thrown</span>.
               </dd>
               <dt>
                 optional unsigned long startInChannel = 0
@@ -4719,8 +4719,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 An optional offset to copy the data to. If
                 <code>startInChannel</code> is greater than the
-                <code>length</code> of the <a>AudioBuffer</a>, an
-                <code>IndexSizeError</code> MUST be thrown.
+                <code>length</code> of the <a>AudioBuffer</a>, <span class="synchronous">an
+                <code>IndexSizeError</code> MUST be thrown</span>.
               </dd>
             </dl>
           </dd>
@@ -5900,20 +5900,20 @@ window.audioWorklet.import("bypass.js").then(function () {
               </p>
               <ol>
                 <li>If the <code><em>name</em></code> is the empty string,
-                throw a <code>NotSupportedError</code> exception and abort
-                these steps because the empty string is not a valid key.
+                <span class="synchronous">throw a <code>NotSupportedError</code> exception and abort
+                these steps because the empty string is not a valid key</span>.
                 </li>
                 <li>If the <code><em>name</em></code> exists as a key in the
-                <a>node name to processor definition map</a>, throw a
-                <code>NotSupportedError</code> exception and abort these steps
+                <a>node name to processor definition map</a>, <span class="synchronous">throw a
+                <code>NotSupportedError</code> exception and abort these steps</span>
                 because registering a definition with a duplicated key is not
                 allowed.
                 </li>
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-isconstructor">
                   IsConstructor</a>(argument=<em>processorConstructor</em>)</code>
-                  is false, throw a <code>TypeError</code> and abort these
-                  steps.
+                  is false, <span class="synchronous">throw a <code>TypeError</code> and abort these
+                  steps</span>.
                 </li>
                 <li>Let <code><em>prototype</em></code> be the result of <code>
                   <a href=
@@ -5924,21 +5924,21 @@ window.audioWorklet.import("bypass.js").then(function () {
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">
                   Type</a>(argument=<em>prototype</em>)</code> is not
-                  <code>Object</code>, throw a <code>TypeError</code> and abort
-                  all these steps.
+                  <code>Object</code>, <span class="synchronous">throw a <code>TypeError</code> and abort
+                  all these steps</span>.
                 </li>
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
                   IsCallable</a>(argument=Get(O=<em>prototype</em>,
-                  P="process"))</code> is false, throw a <code>TypeError</code>
-                  and abort these steps.
+                  P="process"))</code> is false, <span class="synchronous">throw a <code>TypeError</code>
+                  and abort these steps</span>.
                 </li>
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
                   Get</a>(O=<em>processorConstructor</em>,
                   P="parameterDescriptors")</code> is not an array or
-                  <code>undefined</code>, throw a <code>TypeError</code> and
-                  abort these steps.
+                  <code>undefined</code>, <span class="synchronous">throw a <code>TypeError</code> and
+                  abort these steps</span>.
                 </li>
                 <li>Let <em>definition</em> be a new
                 <a>AudioWorkletProcessor</a> definition with:
@@ -7933,8 +7933,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               assigned to <code>buffer</code>.
               </li>
               <li>If <code>new buffer</code> is not <code>null</code> and
-              <code>buffer set</code> is true, throw an
-              <code>InvalidStateError</code> and abort these steps.
+              <code>buffer set</code> is true, <span class="synchronous">throw an
+              <code>InvalidStateError</code> and abort these steps</span>.
               </li>
               <li>If <code>new buffer</code> is not <code>null</code>, set
               <code>buffer set</code> to true.
@@ -9801,8 +9801,8 @@ $$
               <dd>
                 This parameter specifies an output array receiving the linear
                 magnitude response values. If this array is shorter than
-                <code>frequencyHz</code> a <code>NotSupportedError</code> MUST
-                be signaled.
+                <code>frequencyHz</code> <span class="synchronous">a <code>NotSupportedError</code> MUST
+                be signaled</span>.
               </dd>
               <dt>
                 Float32Array phaseResponse
@@ -9810,8 +9810,8 @@ $$
               <dd>
                 This parameter specifies an output array receiving the phase
                 response values in radians. If this array is shorter than
-                <code>frequencyHz</code> a <code>NotSupportedError</code> MUST
-                be signaled.
+                <code>frequencyHz</code> <span class="synchronous">a <code>NotSupportedError</code> MUST
+                be signaled</span>.
               </dd>
             </dl>
           </dd>

--- a/index.html
+++ b/index.html
@@ -1216,7 +1216,8 @@ function setupRoutingGraph() {
                 pick a good buffer size to balance between <a href=
                 "#latency">latency</a> and audio quality. If the value of this
                 parameter is not one of the allowed power-of-2 values listed
-                above, <span class="synchronous">an <code>IndexSizeError</code> MUST be thrown</span>.
+                above, <span class="synchronous">an <code>IndexSizeError</code>
+                MUST be thrown</span>.
               </dd>
               <dt>
                 optional unsigned long numberOfInputChannels = 2
@@ -1302,8 +1303,9 @@ function setupRoutingGraph() {
               <dd>
                 An array of the feedforward (numerator) coefficients for the
                 transfer function of the IIR filter. The maximum length of this
-                array is 20. If all of the values are zero, <span class="synchronous">an
-                <code>InvalidStateError</code> MUST be thrown</span>. <span class="synchronous">A
+                array is 20. If all of the values are zero, <span class=
+                "synchronous">an <code>InvalidStateError</code> MUST be
+                thrown</span>. <span class="synchronous">A
                 <code>NotSupportedError</code> MUST be thrown if the array
                 length is 0 or greater than 20</span>.
               </dd>
@@ -1313,8 +1315,9 @@ function setupRoutingGraph() {
               <dd>
                 An array of the feedback (denominator) coefficients for the
                 transfer function of the IIR filter. The maximum length of this
-                array is 20. If the first element of the array is 0, <span class="synchronous">an
-                <code>InvalidStateError</code> MUST be thrown</span>. <span class="synchronous">A
+                array is 20. If the first element of the array is 0,
+                <span class="synchronous">an <code>InvalidStateError</code>
+                MUST be thrown</span>. <span class="synchronous">A
                 <code>NotSupportedError</code> MUST be thrown if the array
                 length is 0 or greater than 20</span>.
               </dd>
@@ -3886,9 +3889,10 @@ function setupRoutingGraph() {
               <dd>
                 The amount of time in seconds (after the <em>time</em>
                 parameter) where values will be calculated according to the
-                <em>values</em> parameter. <span class="synchronous">A <code>TypeError</code> exception
-                MUST be thrown if <code>duration</code> is not strictly
-                positive or is not a finite number</span>.
+                <em>values</em> parameter. <span class="synchronous">A
+                <code>TypeError</code> exception MUST be thrown if
+                <code>duration</code> is not strictly positive or is not a
+                finite number</span>.
               </dd>
             </dl>
             <p>
@@ -4665,8 +4669,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 The index of the channel to copy the data from. If
                 <code>channelNumber</code> is greater or equal than the number
-                of channel of the <a>AudioBuffer</a>, <span class="synchronous">an
-                <code>IndexSizeError</code> MUST be thrown</span>.
+                of channel of the <a>AudioBuffer</a>, <span class=
+                "synchronous">an <code>IndexSizeError</code> MUST be
+                thrown</span>.
               </dd>
               <dt>
                 optional unsigned long startInChannel = 0
@@ -4674,8 +4679,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 An optional offset to copy the data from. If
                 <code>startInChannel</code> is greater than the
-                <code>length</code> of the <a>AudioBuffer</a>, <span class="synchronous">an
-                <code>IndexSizeError</code> MUST be thrown</span>.
+                <code>length</code> of the <a>AudioBuffer</a>, <span class=
+                "synchronous">an <code>IndexSizeError</code> MUST be
+                thrown</span>.
               </dd>
             </dl>
           </dd>
@@ -4710,8 +4716,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 The index of the channel to copy the data to. If
                 <code>channelNumber</code> is greater or equal than the number
-                of channel of the <a>AudioBuffer</a>, <span class="synchronous">an
-                <code>IndexSizeError</code> MUST be thrown</span>.
+                of channel of the <a>AudioBuffer</a>, <span class=
+                "synchronous">an <code>IndexSizeError</code> MUST be
+                thrown</span>.
               </dd>
               <dt>
                 optional unsigned long startInChannel = 0
@@ -4719,8 +4726,9 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <dd>
                 An optional offset to copy the data to. If
                 <code>startInChannel</code> is greater than the
-                <code>length</code> of the <a>AudioBuffer</a>, <span class="synchronous">an
-                <code>IndexSizeError</code> MUST be thrown</span>.
+                <code>length</code> of the <a>AudioBuffer</a>, <span class=
+                "synchronous">an <code>IndexSizeError</code> MUST be
+                thrown</span>.
               </dd>
             </dl>
           </dd>
@@ -5900,20 +5908,21 @@ window.audioWorklet.import("bypass.js").then(function () {
               </p>
               <ol>
                 <li>If the <code><em>name</em></code> is the empty string,
-                <span class="synchronous">throw a <code>NotSupportedError</code> exception and abort
-                these steps because the empty string is not a valid key</span>.
+                <span class="synchronous">throw a
+                <code>NotSupportedError</code> exception and abort these steps
+                because the empty string is not a valid key</span>.
                 </li>
                 <li>If the <code><em>name</em></code> exists as a key in the
-                <a>node name to processor definition map</a>, <span class="synchronous">throw a
-                <code>NotSupportedError</code> exception and abort these steps</span>
-                because registering a definition with a duplicated key is not
-                allowed.
+                <a>node name to processor definition map</a>, <span class=
+                "synchronous">throw a <code>NotSupportedError</code> exception
+                and abort these steps</span> because registering a definition
+                with a duplicated key is not allowed.
                 </li>
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-isconstructor">
                   IsConstructor</a>(argument=<em>processorConstructor</em>)</code>
-                  is false, <span class="synchronous">throw a <code>TypeError</code> and abort these
-                  steps</span>.
+                  is false, <span class="synchronous">throw a
+                  <code>TypeError</code> and abort these steps</span>.
                 </li>
                 <li>Let <code><em>prototype</em></code> be the result of <code>
                   <a href=
@@ -5924,21 +5933,22 @@ window.audioWorklet.import("bypass.js").then(function () {
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">
                   Type</a>(argument=<em>prototype</em>)</code> is not
-                  <code>Object</code>, <span class="synchronous">throw a <code>TypeError</code> and abort
-                  all these steps</span>.
+                  <code>Object</code>, <span class="synchronous">throw a
+                  <code>TypeError</code> and abort all these steps</span>.
                 </li>
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
                   IsCallable</a>(argument=Get(O=<em>prototype</em>,
-                  P="process"))</code> is false, <span class="synchronous">throw a <code>TypeError</code>
-                  and abort these steps</span>.
+                  P="process"))</code> is false, <span class=
+                  "synchronous">throw a <code>TypeError</code> and abort these
+                  steps</span>.
                 </li>
                 <li>If the result of <code><a href=
                 "http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
                   Get</a>(O=<em>processorConstructor</em>,
                   P="parameterDescriptors")</code> is not an array or
-                  <code>undefined</code>, <span class="synchronous">throw a <code>TypeError</code> and
-                  abort these steps</span>.
+                  <code>undefined</code>, <span class="synchronous">throw a
+                  <code>TypeError</code> and abort these steps</span>.
                 </li>
                 <li>Let <em>definition</em> be a new
                 <a>AudioWorkletProcessor</a> definition with:
@@ -7933,8 +7943,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               assigned to <code>buffer</code>.
               </li>
               <li>If <code>new buffer</code> is not <code>null</code> and
-              <code>buffer set</code> is true, <span class="synchronous">throw an
-              <code>InvalidStateError</code> and abort these steps</span>.
+              <code>buffer set</code> is true, <span class="synchronous">throw
+              an <code>InvalidStateError</code> and abort these steps</span>.
               </li>
               <li>If <code>new buffer</code> is not <code>null</code>, set
               <code>buffer set</code> to true.
@@ -9801,8 +9811,8 @@ $$
               <dd>
                 This parameter specifies an output array receiving the linear
                 magnitude response values. If this array is shorter than
-                <code>frequencyHz</code> <span class="synchronous">a <code>NotSupportedError</code> MUST
-                be signaled</span>.
+                <code>frequencyHz</code> <span class="synchronous">a
+                <code>NotSupportedError</code> MUST be signaled</span>.
               </dd>
               <dt>
                 Float32Array phaseResponse
@@ -9810,8 +9820,8 @@ $$
               <dd>
                 This parameter specifies an output array receiving the phase
                 response values in radians. If this array is shorter than
-                <code>frequencyHz</code> <span class="synchronous">a <code>NotSupportedError</code> MUST
-                be signaled</span>.
+                <code>frequencyHz</code> <span class="synchronous">a
+                <code>NotSupportedError</code> MUST be signaled</span>.
               </dd>
             </dl>
           </dd>


### PR DESCRIPTION
Some places where we specified that an error was thrown was missing the synchronous marker.  Add the marker.