### PR TITLE
Fix #1210: exponentialRamp should throw RangeError for 0

### DIFF
--- a/index.html
+++ b/index.html
@@ -3735,9 +3735,8 @@ function setupRoutingGraph() {
               </dt>
               <dd>
                 The value the parameter will exponentially ramp to at the given
-                time. <span class="synchronous">A
-                <code>NotSupportedError</code> exception MUST be thrown if this
-                value is equal to 0.</span>
+                time. <span class="synchronous">A <code>RangeError</code>
+                exception MUST be thrown if this value is equal to 0.</span>
               </dd>
               <dt>
                 double endTime


### PR DESCRIPTION
If the value for exponentialRampToValueAtTime is 0, throw a
RangeErrror instead of a NotSupportedError.  This is follow-up of
#1182.