### PR TITLE
Fix #1226: IIRFilter.getFrequency inconsistent with BiquadFilter

### DIFF
--- a/index.html
+++ b/index.html
@@ -9796,7 +9796,7 @@ $$
           </dt>
           <dd>
             <p>
-              <span class="syncrhonous">Given the current filter parameter
+              <span class="synchronous">Given the current filter parameter
               settings, synchronously calculates the frequency response for the
               specified frequencies.</span> The three parameters MUST be
               <code>Float32Array</code>s of the same length, or an

--- a/index.html
+++ b/index.html
@@ -9796,8 +9796,11 @@ $$
           </dt>
           <dd>
             <p>
-              Given the current filter parameter settings, calculates the
-              frequency response for the specified frequencies.
+              <span class="syncrhonous">Given the current filter parameter
+              settings, synchronously calculates the frequency response for the
+              specified frequencies.</span> The three parameters MUST be
+              <code>Float32Array</code>s of the same length, or an
+              <code>InvalidAccessError</code> MUST be thrown.
             </p>
             <dl class="parameters">
               <dt>
@@ -9811,19 +9814,37 @@ $$
                 Float32Array magResponse
               </dt>
               <dd>
-                This parameter specifies an output array receiving the linear
-                magnitude response values. If this array is shorter than
-                <code>frequencyHz</code> <span class="synchronous">a
-                <code>NotSupportedError</code> MUST be signaled</span>.
+                <p>
+                  This parameter specifies an output array receiving the linear
+                  magnitude response values.
+                </p>
+                <p>
+                  If a value in the <code>frequencyHz</code> parameter is not
+                  within [0; sampleRate/2], where <code>sampleRate</code> is
+                  the value of the <a href=
+                  "#widl-BaseAudioContext-sampleRate"><code>sampleRate</code></a>
+                  property of the <a>AudioContext</a>, the corresponding value
+                  at the same index of the <code>magResponse</code> array MUST
+                  be <code>NaN</code>.
+                </p>
               </dd>
               <dt>
                 Float32Array phaseResponse
               </dt>
               <dd>
-                This parameter specifies an output array receiving the phase
-                response values in radians. If this array is shorter than
-                <code>frequencyHz</code> <span class="synchronous">a
-                <code>NotSupportedError</code> MUST be signaled</span>.
+                <p>
+                  This parameter specifies an output array receiving the phase
+                  response values in radians.
+                </p>
+                <p>
+                  If a value in the <code>frequencyHz</code> parameter is not
+                  within [0; sampleRate/2], where <code>sampleRate</code> is
+                  the value of the <a href=
+                  "#widl-BaseAudioContext-sampleRate"><code>sampleRate</code></a>
+                  property of the <a>AudioContext</a>, the corresponding value
+                  at the same index of the <code>phaseResponse</code> array
+                  MUST be <code>NaN</code>.
+                </p>
               </dd>
             </dl>
           </dd>


### PR DESCRIPTION
`IIRFilter.getFrequency` should return NaN for invalid frequencies
just like `BiquadFilter.getFrequency` does.

Basically just copied the text from biquad to iirfilter.

Also took this opportunity to mark the computation as being
synchronous just like BiquadFilter.