### PR TITLE
Fix #1222: Fix typo in clamping of linear distance model

### DIFF
--- a/index.html
+++ b/index.html
@@ -7086,8 +7086,8 @@ var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
               d'_{max}\), the value of the linear model is taken to be \(1-f\).
             </p>
             <p>
-              Note that \(d\) is clamped to the interval \([d_{ref},\,
-              d_{max}]\).
+              Note that \(d\) is clamped to the interval \([d'_{ref},\,
+              d'_{max}]\).
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
Make the text match what the code says.