### PR TITLE
Rename .import() in examples to addModule()

### DIFF
--- a/index.html
+++ b/index.html
@@ -5823,7 +5823,7 @@ registerProcessor("Bypass", class extends AudioWorkletProcessor {
           <pre class="example" title=
           "Importing a script and creating AudioWorkletNode">
 // The main global scope
-window.audioWorklet.import("bypass.js").then(function () {
+window.audioWorklet.addModule("bypass.js").then(function () {
   var context = new AudioContext();
   var bypass = new AudioWorkletNode(context, "Bypass");
 });
@@ -6596,7 +6596,7 @@ class MyProcessor extends AudioWorkletProcessor {
               <a><code>AudioWorkletProcessor</code></a>.
             </p>
             <pre class="example" title="BitCrusher - Global Scope">
-window.audioWorklet.import('bitcrusher.js').then(function () {
+window.audioWorklet.addModule('bitcrusher.js').then(function () {
   let context = new AudioContext();
   let osc = new OscillatorNode(context);
   let amp = new GainNode(context);
@@ -6722,7 +6722,7 @@ class VUMeterNode extends AudioWorkletNode {
 }
 
 // The application can use the node when this promise resolves.
-let importAudioWorkletNode = window.audioWorklet.import('vumeterprocessor.js');
+let importAudioWorkletNode = window.audioWorklet.addModule('vumeterprocessor.js');
 </pre>
             <pre class="example" title=
             "VUMeterNode - AudioWorkletGlobalScope (vumeterprocessor.js)">


### PR DESCRIPTION
A simple/mechanical change based on the worklet spec change.

Reference: https://github.com/w3c/css-houdini-drafts/issues/374