### PR TITLE
Fix #1212: Throw NotSupportedError for invalid number of channels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,6 +1227,8 @@ function setupRoutingGraph() {
               <dd>
                 This parameter determines the number of channels for this
                 node's input. Values of up to 32 must be supported.
+                <span class="synchronous">A <code>NotSupportedError</code> must
+                be thrown if the number of channels is not supported.</span>
               </dd>
               <dt>
                 optional unsigned long numberOfOutputChannels = 2
@@ -1234,6 +1236,8 @@ function setupRoutingGraph() {
               <dd>
                 This parameter determines the number of channels for this
                 node's output. Values of up to 32 must be supported.
+                <span class="synchronous">A <code>NotSupportedError</code> must
+                be thrown if the number of channels is not supported.</span>
               </dd>
             </dl>
             <p>


### PR DESCRIPTION
Specify that a NotSupportedError must be thrown if the number of
channels specified for a ScriptProcessorNode is not supported by the
implementation.