### PR TITLE
Remove reference to dead interface AudioMediaStreamTrack.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2019,10 +2019,13 @@ function setupRoutingGraph() {
             </p>
             <dl class="parameters">
               <dt>
-                AudioMediaStreamTrack mediaStreamTrack
+                MediaStreamTrack mediaStreamTrack
               </dt>
               <dd>
-                The audio media stream track that will act as source.
+                The <code>MediaStreamTrack</code> that will act as source.
+                <span class="synchronous">The value of its <code>kind</code>
+                attribute must be equal to <code>"audio"</code>, or an
+                <code>InvalidStateError</code> exception MUST be thrown.</span>
               </dd>
             </dl>
           </dd>
@@ -10599,10 +10602,11 @@ odd function with period \(2\pi\).
           This interface represents an audio source from a
           <code>MediaStream</code>. The track that will be used as the source
           of audio and will be output from this node is the first
-          <code>AudioMediaStreamTrack</code>, when alphabetically sorting the
+          <code>MediaStreamTrack</code> whose <code>kind</code> attribute has
+          the value <code>"audio"</code>, when alphabetically sorting the
           tracks of this <code>MediaStream</code> by their <code>id</code>
-          attribute. will be used as a source of audio. Those interfaces are
-          described in [[!mediacapture-streams]].
+          attribute. Those interfaces are described in
+          [[!mediacapture-streams]].
         </p>
         <p class="note">
           The behaviour for picking the track to output is weird for legacy
@@ -10615,9 +10619,9 @@ odd function with period \(2\pi\).
 </pre>
         <p>
           The number of channels of the output corresponds to the number of
-          channels of the <code>AudioMediaStreamTrack</code>. If there is no
-          valid audio track, then the number of channels output will be one
-          silent channel.
+          channels of the <code>MediaStreamTrack</code>. If there is no valid
+          audio track, then the number of channels output will be one silent
+          channel.
         </p>
         <p>
           This node has no <a>tail-time</a> reference.
@@ -10647,8 +10651,13 @@ odd function with period \(2\pi\).
                 MediaStreamAudioSourceOptions options
               </dt>
               <dd>
-                Initial parameter value for this
-                <a>MediaStreamAudioSourceNode</a>.
+                Initial parameter values for this
+                <a>MediaStreamAudioSourceNode</a>. If the
+                <code>mediaStreamTrack</code> parameter does not reference a
+                <code>MediaStreamTrack</code> whose <code>kind</code> attribute
+                has the value <code>"audio"</code>, <span class=
+                "synchronous">an <code>InvalidStateError</code> MUST be
+                thrown</span>.
               </dd>
             </dl>
           </dd>
@@ -10687,7 +10696,7 @@ odd function with period \(2\pi\).
         </h2>
         <p>
           This interface represents an audio source from a
-          <code>AudioMediaStreamTrack</code>.
+          <code>MediaStreamTrack</code>.
         </p>
         <pre>
     numberOfInputs  : 0
@@ -10695,7 +10704,7 @@ odd function with period \(2\pi\).
 </pre>
         <p>
           The number of channels of the output corresponds to the number of
-          channels of the <code>AudioMediaStreamTrack</code>.
+          channels of the <code>MediaStreamTrack</code>.
         </p>
         <p>
           This node has no <a>tail-time</a> reference.
@@ -10743,7 +10752,7 @@ odd function with period \(2\pi\).
           <dl title="dictionary MediaStreamTrackAudioSourceOptions" class=
           "idl">
             <dt>
-              required AudioMediaStreamTrack mediaStreamTrack
+              required MediaStreamTrack mediaStreamTrack
             </dt>
             <dd>
               The audio media stream track that will act as a source.
@@ -10757,14 +10766,14 @@ odd function with period \(2\pi\).
         </h2>
         <p>
           This interface is an audio destination representing a
-          <code>MediaStream</code> with a single
-          <code>AudioMediaStreamTrack</code>. This MediaStream is created when
-          the node is created and is accessible via the <dfn>stream</dfn>
-          attribute. This stream can be used in a similar way as a
-          <code>MediaStream</code> obtained via <code>getUserMedia()</code>,
-          and can, for example, be sent to a remote peer using the
-          <code>RTCPeerConnection</code> (described in [[!webrtc]])
-          <code>addStream()</code> method.
+          <code>MediaStream</code> with a single <code>MediaStreamTrack</code>
+          whose <code>kind</code> is <code>"audio"</code>. This MediaStream is
+          created when the node is created and is accessible via the
+          <dfn>stream</dfn> attribute. This stream can be used in a similar way
+          as a <code>MediaStream</code> obtained via
+          <code>getUserMedia()</code>, and can, for example, be sent to a
+          remote peer using the <code>RTCPeerConnection</code> (described in
+          [[!webrtc]]) <code>addStream()</code> method.
         </p>
         <pre>
     numberOfInputs  : 1
@@ -10812,8 +10821,9 @@ odd function with period \(2\pi\).
           </dt>
           <dd>
             <p>
-              A MediaStream containing a single AudioMediaStreamTrack with the
-              same number of channels as the node itself.
+              A MediaStream containing a single MediaStreamTrack with the same
+              number of channels as the node itself, and whose
+              <code>kind</code> attribute has the value <code>"audio"</code>.
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
Fixes #1217.

Use MediaStreamTrack instead with condition that its kind equal “audio”.