### PR TITLE
Fix #1246: Adding record<DOMString, double>

### DIFF
--- a/index.html
+++ b/index.html
@@ -6102,7 +6102,7 @@ window.audioWorklet.addModule("bypass.js").then(function () {
             <dl title="dictionary AudioWorkletNodeOptions : AudioNodeOptions"
             class="idl">
               <dt>
-                unsigned long numberOfInputs
+                unsigned long numberOfInputs = 1
               </dt>
               <dd>
                 This is used to initialize the value of <a>AudioNode</a>
@@ -6110,12 +6110,21 @@ window.audioWorklet.addModule("bypass.js").then(function () {
                 attribute.
               </dd>
               <dt>
-                unsigned long numberOfOutputs
+                unsigned long numberOfOutputs = 1
               </dt>
               <dd>
                 This is used to initialize the value of <a>AudioNode</a>
                 <a href="#widl-AudioNode-numberOfOutputs">numberOfOutputs</a>
                 attribute.
+              </dd>
+              <dt>
+                record&lt;DOMString, double&gt; parameterData
+              </dt>
+              <dd>
+                This is a list of user-defined key-value pairs, that is used to
+                initialize <a>AudioParam</a> values in <a>AudioWorkletNode</a>.
+                If the string key of an entry in the list does not match any
+                name of <a>AudioParam</a> objects in the node, it is ignored.
               </dd>
             </dl>
           </section>

--- a/index.html
+++ b/index.html
@@ -6121,7 +6121,7 @@ window.audioWorklet.addModule("bypass.js").then(function () {
                 record&lt;DOMString, double&gt; parameterData
               </dt>
               <dd>
-                This is a list of user-defined key-value pairs, that is used to
+                This is a list of user-defined key-value pairs that are used to
                 initialize <a>AudioParam</a> values in <a>AudioWorkletNode</a>.
                 If the string key of an entry in the list does not match any
                 name of <a>AudioParam</a> objects in the node, it is ignored.


### PR DESCRIPTION
Note: Respec does not support `record<K, V>` yet. Not sure how to resolve this.