### PR TITLE
Fix #1230: Add `required` keyword and default min/max values in `AudioParamDescriptor`

### DIFF
--- a/index.html
+++ b/index.html
@@ -6383,7 +6383,7 @@ class MyProcessor extends AudioWorkletProcessor {
             </p>
             <dl title="dictionary AudioParamDescriptor" class="idl">
               <dt>
-                DOMString name
+                required DOMString name
               </dt>
               <dd>
                 Represents the name of a parameter. An
@@ -6400,20 +6400,24 @@ class MyProcessor extends AudioWorkletProcessor {
                 <code>NotSupportedError</code> exception MUST be thrown.
               </dd>
               <dt>
-                float minValue
+                float minValue = -3.4028235e38
               </dt>
               <dd>
                 Represents the minimum value. An <code>NotSupportedError</code>
                 exception MUST be thrown if this value is out of range of float
-                data type or it is greater than <code>maxValue</code>.
+                data type or it is greater than <code>maxValue</code>. This
+                value is a negative minimum number for the single precision
+                floating-point number.
               </dd>
               <dt>
-                float maxValue
+                float maxValue = 3.4028235e38
               </dt>
               <dd>
                 Represents the maximum value. An <code>NotSupportedError</code>
                 exception MUST be thrown if this value is out of range of float
-                data type or it is smaller than <code>minValue</code>.
+                data type or it is smaller than <code>minValue</code>. This
+                value is a positive maximum number for the single precision
+                floating-point number.
               </dd>
             </dl>
           </section>

--- a/index.html
+++ b/index.html
@@ -6406,7 +6406,7 @@ class MyProcessor extends AudioWorkletProcessor {
                 Represents the minimum value. An <code>NotSupportedError</code>
                 exception MUST be thrown if this value is out of range of float
                 data type or it is greater than <code>maxValue</code>. This
-                value is a negative minimum number for the single precision
+                value is the most negative finite single precision
                 floating-point number.
               </dd>
               <dt>
@@ -6416,7 +6416,7 @@ class MyProcessor extends AudioWorkletProcessor {
                 Represents the maximum value. An <code>NotSupportedError</code>
                 exception MUST be thrown if this value is out of range of float
                 data type or it is smaller than <code>minValue</code>. This
-                value is a positive maximum number for the single precision
+                value is the most positive finite single precision
                 floating-point number.
               </dd>
             </dl>


### PR DESCRIPTION
PTAL.