### PR TITLE
Fix #908: DynamicsCompressor channelCountMode max

### DIFF
--- a/index.html
+++ b/index.html
@@ -8865,7 +8865,7 @@ function calculateNormalizationScale(buffer)
     numberOfOutputs : 1
 
     channelCount = 2;
-    channelCountMode = "explicit";
+    channelCountMode = "max";
     channelInterpretation = "speakers";
 </pre>
         <p>


### PR DESCRIPTION
Set channelCountMode to max to match what Chrome and Firefox actually
do.