### PR TITLE
Fix #906: DynamicsCompressor channelCount is at most 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -3005,6 +3005,15 @@ function setupRoutingGraph() {
                 thrown for any attempt to change the value..</span>
               </dd>
               <dt>
+                <a>DynamicsCompressorNode</a>
+              </dt>
+              <dd>
+                The channel count cannot be greater than two, and a
+                <span class="synchronous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to change the to a
+                value greater than two.</span>
+              </dd>
+              <dt>
                 <a>PannerNode</a>
               </dt>
               <dd>
@@ -8868,6 +8877,9 @@ function calculateNormalizationScale(buffer)
     channelCountMode = "explicit";
     channelInterpretation = "speakers";
 </pre>
+        <p>
+          There are <a>channelCount constraints</a> for this node.
+        </p>
         <p>
           This node has no <a>tail-time</a> reference.
         </p>


### PR DESCRIPTION
Specify that DynamicsCompressor channelCount must be 1 or 2 or an
error is thrown.