### PR TITLE
Fix broken link identifier for "rendering a audio graph"

### DIFF
--- a/index.html
+++ b/index.html
@@ -11271,8 +11271,8 @@ odd function with period \(2\pi\).
         </p>
         <p>
           The <a>rendering thread</a> uses a specialized rendering loop,
-          described in the section <a href="#rendering-audio">Rendering an
-          audio graph</a>
+          described in the section <a href="#rendering-loop">Rendering an audio
+          graph</a>
         </p>
         <p>
           Communication from the <a>control thread</a> to the <a>rendering


### PR DESCRIPTION
Fixes #1275 