### PR TITLE
Fix #1267: DynamicsCompressor mode cannot be "max"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3200,6 +3200,15 @@ new AudioBuffer({
                 value.</span>
               </dd>
               <dt>
+                <a>DynamicsCompressorNode</a>
+              </dt>
+              <dd>
+                The channel count mode cannot be set to "max", and a
+                <span class="synchronous"><code>NotSupportedError</code>
+                exception MUST be thrown for any attempt to set it to
+                "max".</span>
+              </dd>
+              <dt>
                 <a>PannerNode</a>
               </dt>
               <dd>
@@ -9066,7 +9075,7 @@ function calculateNormalizationScale(buffer)
     numberOfOutputs : 1
 
     channelCount = 2;
-    channelCountMode = "max";
+    channelCountMode = "clamped-max";
     channelInterpretation = "speakers";
 </pre>
         <p>


### PR DESCRIPTION
Add channelCountMode constraint for DynamicsCompressor so that it can
not be set to "max".  Also change the default channelCountMode from
"max" to "clamped-max".

These changes make the compressor work just like PannerNode and
StereoPannerNode.