### PR TITLE
Fix #1162: MediaStream to continue when context is closed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1970,6 +1970,13 @@ function setupRoutingGraph() {
                 </ol>
               </li>
             </ol>
+            <p>
+              When an <a>AudioContext</a> is closed, any
+              <code>MediaStream</code>s and <code>HTMLMediaElement</code>s that
+              were connected to an <a>AudioContext</a> are effectively
+              disconnected from the <a>AudioContext</a>. These will continue to
+              behave as if they were never connected to an <a>AudioContext</a>.
+            </p>
             <p class="note">
               When an <a>AudioContext</a> has been closed, implementation can
               choose to aggressively release more resources than when

--- a/index.html
+++ b/index.html
@@ -1973,9 +1973,12 @@ function setupRoutingGraph() {
             <p>
               When an <a>AudioContext</a> is closed, any
               <code>MediaStream</code>s and <code>HTMLMediaElement</code>s that
-              were connected to an <a>AudioContext</a> are effectively
-              disconnected from the <a>AudioContext</a>. These will continue to
-              behave as if they were never connected to an <a>AudioContext</a>.
+              were connected to an <a>AudioContext</a> will have their output
+              ignored. That is, these will no longer cause any output to
+              speakers or other output devices. For more flexibility in
+              behavior, consider using <a href=
+              "https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream()">
+              <code>HTMLEMediaElement.captureStream()</code></a>.
             </p>
             <p class="note">
               When an <a>AudioContext</a> has been closed, implementation can


### PR DESCRIPTION
When a context is closed any MediaStreams or HTMLMediaElements are
effectively disconnected from the context and continue as if they were
never connected.