### PR TITLE
Fix #1262: Clarify text for AudioContextOptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -2047,7 +2047,7 @@ function setupRoutingGraph() {
           </h3>
           <p>
             The <a><code>AudioContextOptions</code></a> dictionary is used to
-            specify a requested latency for an <a>AudioContext</a>.
+            specify user-specified options for an <a>AudioContext</a>.
           </p>
           <dl title="dictionary AudioContextOptions" class="idl">
             <dt>


### PR DESCRIPTION
Just say that AudioContextOptions allows users to specify some options
for an AudioContext, without explicitly saying what.