### PR TITLE
`{PannerNode,AudioListener}.{setPosition,setOrientation}` should throw when set while an automation curve is active.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10595,8 +10595,19 @@ interface PannerNode : AudioNode {
             <dd>
               <p>
                 This method is DEPRECATED. It is equivalent to setting
-                <code>orientationX</code>, <code>orientationY</code>, and
-                <code>orientationZ</code> AudioParams directly.
+                <code>orientationX.value</code>,
+                <code>orientationY.value</code>, and
+                <code>orientationZ.value</code> attribute directly, with the
+                <code>x</code>, <code>y</code> and <code>z</code> parameters,
+                respectively.
+              </p>
+              <p>
+                Consequently, if any of the <code>orientationX</code>,
+                <code>orientationY</code>, and <code>orientationZ</code>
+                <a>AudioParam</a> have an automation curve set using <a href=
+                "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
+                at the time this method is called, a
+                <code>NotSupportedError</code> MUST be thrown.
               </p>
               <p>
                 Describes which direction the audio source is pointing in the
@@ -10686,8 +10697,18 @@ interface PannerNode : AudioNode {
             <dd>
               <p>
                 This method is DEPRECATED. It is equivalent to setting
-                <code>positionX</code>, <code>positionY</code>, and
-                <code>positionZ</code> AudioParams directly.
+                <code>positionX.value</code>, <code>positionY.value</code>, and
+                <code>positionZ.value</code> attribute directly with the
+                <code>x</code>, <code>y</code> and <code>z</code> parameters,
+                respectively.
+              </p>
+              <p>
+                Consequently, if any of the <code>positionX</code>,
+                <code>positionY</code>, and <code>positionZ</code>
+                <a>AudioParam</a> have an automation curve set using <a href=
+                "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
+                at the time this method is called, a
+                <code>NotSupportedError</code> MUST be thrown.
               </p>
               <p>
                 Sets the position of the audio source relative to the
@@ -11117,6 +11138,15 @@ interface AudioListener {
                 values, respectively.
               </p>
               <p>
+                Consequently, if any of the <code>orientationX</code>,
+                <code>orientationY</code>, <code>orientationZ</code>,
+                <code>upX</code>, <code>upY</code> and <code>upZ</code>
+                <a>AudioParam</a> have an automation curve set using <a href=
+                "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
+                at the time this method is called, a
+                <code>NotSupportedError</code> MUST be thrown.
+              </p>
+              <p>
                 Describes which direction the listener is pointing in the 3D
                 cartesian coordinate space. Both a <b>front</b> vector and an
                 <b>up</b> vector are provided. In simple human terms, the
@@ -11261,6 +11291,15 @@ interface AudioListener {
                 <code>positionZ.value</code> directly with the given
                 <code>x</code>, <code>y</code>, and <code>z</code> values,
                 respectively.
+              </p>
+              <p>
+                Consequently, any of the <code>positionX</code>,
+                <code>positionY</code>, and <code>positionZ</code>
+                <a>AudioParam</a> for this <a>AudioListenerNode</a> have an
+                automation curve set using <a href=
+                "#dom-AudioParam-setValueCurveAtTime">setValueCurveAtTime()</a>
+                at the time this method is called, a
+                <code>NotSupportedError</code> MUST be thrown.
               </p>
               <p>
                 Sets the position of the listener in a 3D cartesian coordinate

--- a/index.html
+++ b/index.html
@@ -10602,12 +10602,13 @@ interface PannerNode : AudioNode {
                 respectively.
               </p>
               <p>
-                Consequently, if any of the <code>orientationX</code>,
-                <code>orientationY</code>, and <code>orientationZ</code>
-                <a>AudioParam</a> have an automation curve set using <a href=
-                "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
-                at the time this method is called, a
-                <code>NotSupportedError</code> MUST be thrown.
+                Consequently, if any of the <a data-link-for=
+                "AudioPanner">orientationX</a>, <a data-link-for=
+                "AudioPanner">orientationY</a>, and <a data-link-for=
+                "AudioPanner">orientationZ</a> <a>AudioParam</a>s have an
+                automation curve set using <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a>() at the time this method
+                is called, a <code>NotSupportedError</code> MUST be thrown.
               </p>
               <p>
                 Describes which direction the audio source is pointing in the
@@ -10696,19 +10697,19 @@ interface PannerNode : AudioNode {
             </dt>
             <dd>
               <p>
-                This method is DEPRECATED. It is equivalent to setting
-                <code>positionX.value</code>, <code>positionY.value</code>, and
-                <code>positionZ.value</code> attribute directly with the
-                <code>x</code>, <code>y</code> and <code>z</code> parameters,
+                This method is DEPRECATED. It is equivalent to setting <a href=
+                "#dom-pannernode-positionx">positionX.value</a>, <a href=
+                "#dom-pannernode-positiony">positionY.value</a>, and <a href=
+                "#dom-pannernode-positionz">positionZ.value</a> attribute
+                directly with the <a>x</a>, <a>y</a> and <a>z</a> parameters,
                 respectively.
               </p>
               <p>
-                Consequently, if any of the <code>positionX</code>,
-                <code>positionY</code>, and <code>positionZ</code>
-                <a>AudioParam</a> have an automation curve set using <a href=
-                "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
-                at the time this method is called, a
-                <code>NotSupportedError</code> MUST be thrown.
+                Consequently, if any of the <a>positionX</a>, <a>positionY</a>,
+                and <a>positionZ</a> <a>AudioParam</a>s have an automation
+                curve set using <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a>() at the time this method
+                is called, a <code>NotSupportedError</code> MUST be thrown.
               </p>
               <p>
                 Sets the position of the audio source relative to the
@@ -11128,20 +11129,22 @@ interface AudioListener {
             </dt>
             <dd>
               <p>
-                This method is DEPRECATED. It is equivalent to setting
-                <code>orientationX.value</code>,
-                <code>orientationY.value</code>,
-                <code>orientationZ.value</code>, <code>upX.value</code>,
-                <code>upY.value</code>, and <code>upZ.value</code> directly
-                with the given <code>x</code>, <code>y</code>, <code>z</code>,
+                This method is DEPRECATED. It is equivalent to setting <a href=
+                "#dom-audiolistener-forwardx">forwardX.value</a>, <a href=
+                "#dom-audiolistener-forwardy">forwardY.value</a>, <a href=
+                "#dom-audiolistener-forwardz">forwardZ.value</a>, <a href=
+                "#dom-audiolistener-upx">upX.value</a>, <a href=
+                "#dom-audiolistener-upx">upY.value</a>, and <a href=
+                "#dom-audiolistener-upz">upZ.value</a> directly with the given
+                <code>x</code>, <code>y</code>, <code>z</code>,
                 <code>xUp</code>, <code>yUp</code>, and <code>zUp</code>
                 values, respectively.
               </p>
               <p>
-                Consequently, if any of the <code>orientationX</code>,
-                <code>orientationY</code>, <code>orientationZ</code>,
-                <code>upX</code>, <code>upY</code> and <code>upZ</code>
-                <a>AudioParam</a> have an automation curve set using <a href=
+                Consequently, if any of the <a>orientationX</a>,
+                <a>orientationY</a>, <a>orientationZ</a>, <a>upX</a>,
+                <a>upY</a> and <a>upZ</a> <a>AudioParam</a>s have an automation
+                curve set using <a href=
                 "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
                 at the time this method is called, a
                 <code>NotSupportedError</code> MUST be thrown.
@@ -11286,20 +11289,20 @@ interface AudioListener {
             </dt>
             <dd>
               <p>
-                This method is DEPRECATED. It is equivalent to setting
-                <code>positionX.value</code>, <code>positionY.value</code>, and
-                <code>positionZ.value</code> directly with the given
-                <code>x</code>, <code>y</code>, and <code>z</code> values,
-                respectively.
+                This method is DEPRECATED. It is equivalent to setting <a href=
+                "#dom-AudioListener-positionx">positionX.value</a>, <a href=
+                "#dom-AudioListener-positiony">positionY.value</a>, and
+                <a href="#dom-AudioListener-positionz">positionZ.value</a>
+                directly with the given <code>x</code>, <code>y</code>, and
+                <code>z</code> values, respectively.
               </p>
               <p>
-                Consequently, any of the <code>positionX</code>,
-                <code>positionY</code>, and <code>positionZ</code>
-                <a>AudioParam</a> for this <a>AudioListenerNode</a> have an
-                automation curve set using <a href=
-                "#dom-AudioParam-setValueCurveAtTime">setValueCurveAtTime()</a>
-                at the time this method is called, a
-                <code>NotSupportedError</code> MUST be thrown.
+                Consequently, any of the <a>positionX</a>, <a>positionY</a>,
+                and <a>positionZ</a> <a>AudioParam</a>s for this
+                <a>AudioListenerNode</a> have an automation curve set using
+                <a data-link-for="AudioParam">setValueCurveAtTime</a>() at the
+                time this method is called, a <code>NotSupportedError</code>
+                MUST be thrown.
               </p>
               <p>
                 Sets the position of the listener in a 3D cartesian coordinate


### PR DESCRIPTION
This fixes #1268.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/padenot/web-audio-api/1268-throw-setPosition-and-al.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ad70087...padenot:730940f.html)