### PR TITLE
Allow passing `null` to AudioBufferSourceNode.buffer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5136,8 +5136,8 @@ param.setValueCurveAtTime(curve, t7, t8 - t7);
               <code>buffer</code> attribute, execute these steps:
             </p>
             <ol>
-              <li>Let <code>new buffer</code> be the <a>AudioBuffer</a> to be
-              assigned to <code>buffer</code>.
+              <li>Let <code>new buffer</code> be the <a>AudioBuffer</a> or
+              <code>null</code> value to be assigned to <code>buffer</code>.
               </li>
               <li>If <code>new buffer</code> is not <code>null</code> and <var>
                 [[buffer set]]</var> is true, throw an


### PR DESCRIPTION
This fixes #1273.