### PR TITLE
Fix #1300: Describe how to use AudioContextOptions in AudioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -2210,6 +2210,29 @@ interface AudioContext : BaseAudioContext {
                 <li>Let <dfn>pendingResumePromises</dfn> be an empty ordered
                 list of promises.
                 </li>
+                <li>If <code>contextOptions</code> is given, apply the options:
+                  <ol>
+                    <li>Set the internal latency of this <a>AudioContext</a>
+                    according to <code>contextOptions.<a data-link-for=
+                    "AudioContextOptions">latencyHint</a></code>, as described
+                    in <a data-link-for="AudioContextOptions">latencyHint</a>.
+                    </li>
+                    <li>If <code>contextOptions.<a data-link-for=
+                    "AudioContextOptions">sampleRate</a></code> is specified,
+                    set the <a data-link-for="BaseAudioContext">sampleRate</a>
+                    of this <a>AudioContext</a> to this value. Otherwise, use
+                    the sample rate of the default output device. If the
+                    selected sample rate differs from the sample rate of the
+                    output device, this <a>AudioContext</a> MUST resample the
+                    audio output to match the sample rate of the output device.
+                      <p class="note">
+                        If resampling is required, the latency of the
+                        AudioContext may be affected, possibly by a large
+                        amount.
+                      </p>
+                    </li>
+                  </ol>
+                </li>
                 <li>If the <a>AudioContext</a> is not <a>allowed to start</a>,
                 abort these steps.
                 </li>


### PR DESCRIPTION
Describe how to use any specified AudioContextOptions when
constructing an AudioContext.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1300-audiocontext-dictionary-usage.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/97962e6...rtoy:c6329bd.html)