### PR TITLE
Fix #1302: Describe AudioScheduledSource start/stop methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -6164,10 +6164,25 @@ interface AudioScheduledSourceNode : AudioNode {
             <dd>
               <p>
                 Schedules a sound to playback at an exact time.
-                <code>start</code> may only be called one time and <span class=
-                "synchronous">MUST be called before <code>stop</code> is called
-                or an InvalidStateError exception MUST be thrown.</span>
               </p>
+              <p>
+                <span class="synchronous">When this method is called, execute
+                these steps:</span>
+              </p>
+              <ol>
+                <li>If <code>stop</code> has been called on this node, or if an
+                earlier call to <code>start</code> has already occurred, an
+                <code>InvalidStateError</code> exception MUST be thrown.
+                </li>
+                <li>Check for any errors that must be thrown due to parameter
+                constraints described below.
+                </li>
+                <li>
+                  <a href="#queue">Queue a control message</a> to start the
+                  <a>AudioScheduledSourceNode</a>, including the parameter
+                  values in the messsage.
+                </li>
+              </ol>
               <table class="parameters">
                 <tr>
                   <th>
@@ -6236,6 +6251,24 @@ interface AudioScheduledSourceNode : AudioNode {
                 reached prior to the scheduled start time, the sound will not
                 play.
               </p>
+              <p>
+                <span class="synchronous">When this method is called, execute
+                these steps:</span>
+              </p>
+              <ol>
+                <li>If <code>stop</code> has been called on this node, or if an
+                earlier call to <code>start</code> has not already occurred, an
+                <code>InvalidStateError</code> exception MUST be thrown.
+                </li>
+                <li>Check for any errors that must be thrown due to parameter
+                constraints described below.
+                </li>
+                <li>
+                  <a href="#queue">Queue a control message</a> to stop the
+                  <a>AudioScheduledSourceNode</a>, including the parameter
+                  values in the messsage.
+                </li>
+              </ol>
               <table class="parameters">
                 <tr>
                   <th>


### PR DESCRIPTION
Add algorithm for the start and stop methods for an
AudioScheduledSourceNode.  These were basically copied from
AudiobufferSourceNode with a minor tweak to say ASSN instead of ABSN.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1302-scheduled-source-start-stop-defn.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/97962e6...rtoy:2b9acfc.html)