### PR TITLE
Fix #1333: Describe stop algorithm correctly.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7620,7 +7620,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
               </p>
               <ol>
                 <li>If <code>stop</code> has been called on this node, or if an
-                earlier call to <code>start</code> has already occurred, an
+                earlier call to <code>start</code> has not already occurred, an
                 <code>InvalidStateError</code> exception MUST be thrown.
                 </li>
                 <li>Check for any errors that must be thrown due to parameter


### PR DESCRIPTION
stop() must throw if start() has not been called.  It used to say it
throws if start() was already called.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1333-absn-stop-requires-start-first.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/47294ae...rtoy:7563350.html)