### PR TITLE
Clarify behavior of AudioParam.value setter w/r/t exceptions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5004,13 +5004,12 @@ interface AudioDestinationNode : AudioNode {
           </li>
         </ul>
         <p class="note">
-          <code>AudioParam</code>s are read only and must be set using the
-          <a>automation methods</a> or the <a href=
-          "#widl-AudioParam-value">value</a> attribute. Using the <a href=
-          "#widl-AudioParam-value">value</a> attribute is equivalent to calling
-          <code>setValueAtTime()</code> with the current
-          <code>AudioContext</code>'s <code>currentTime</code> and the
-          requested value.
+          <code>AudioParam</code> attributes are read only, with the exception
+          of the <a href="#dom-audioparam-value">value</a> attribute. Setting
+          the <a href="#dom-audioparam-value">value</a> attribute is
+          equivalent to calling the <a href="#dfn-automation-method">automation
+          method</a> <a href=
+          "#dom-audioparam-setvalueattime">setValueAtTime()</a>.
         </p>
         <p>
           Each <a>AudioParam</a> has an internal slot <var>[[current
@@ -5082,9 +5081,13 @@ interface AudioParam {
               <p>
                 Setting this attribute has the effect of assigning the
                 requested value to the <var>[[current value]]</var> slot, and
-                calling <code>setValueAtTime()</code> with the current
-                <code>AudioContext</code>'s <code>currentTime</code> and
-                <var>[[current value]]</var>.
+                calling the <a href=
+                "#dom-audioparam-setvalueattime">setValueAtTime()</a> method
+                with the current <code>AudioContext</code>'s
+                <code>currentTime</code> and <var>[[current value]]</var>. Any
+                exceptions that would be thrown by
+                <code>setValueAtTime()</code> will also be thrown by setting
+                this attribute.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -5005,11 +5005,7 @@ interface AudioDestinationNode : AudioNode {
         </ul>
         <p class="note">
           <code>AudioParam</code> attributes are read only, with the exception
-          of the <a href="#dom-audioparam-value">value</a> attribute. Setting
-          the <a href="#dom-audioparam-value">value</a> attribute is
-          equivalent to calling the <a href="#dfn-automation-method">automation
-          method</a> <a href=
-          "#dom-audioparam-setvalueattime">setValueAtTime()</a>.
+          of the <a data-link-for="AudioParam">value</a> attribute.
         </p>
         <p>
           Each <a>AudioParam</a> has an internal slot <var>[[current
@@ -5081,9 +5077,8 @@ interface AudioParam {
               <p>
                 Setting this attribute has the effect of assigning the
                 requested value to the <var>[[current value]]</var> slot, and
-                calling the <a href=
-                "#dom-audioparam-setvalueattime">setValueAtTime()</a> method
-                with the current <code>AudioContext</code>'s
+                calling the <a data-link-for="AudioParam">setValueAtTime()</a>
+                method with the current <code>AudioContext</code>'s
                 <code>currentTime</code> and <var>[[current value]]</var>. Any
                 exceptions that would be thrown by
                 <code>setValueAtTime()</code> will also be thrown by setting


### PR DESCRIPTION
Fixes #1296


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/1296-audioparam-setter-behavior.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/47294ae...eeea7e7.html)