### PR TITLE
Fix #1312: Fix typo in descripton nominal range/compound parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -6020,7 +6020,7 @@ interface AudioParam {
             the <a>nominal range</a> for this parameter. <a>Compound
             parameters</a> have their final value clamped to their <a>nominal
             range</a> after having been computed from the different
-            <a>AudioParam</a> value they are composed of.
+            <a>AudioParam</a> values they are composed of.
           </p>
           <p>
             When automation methods are used, clamping is still applied.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1312-fix-typo-nominal-range.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/1563479...rtoy:da18495.html)