### PR TITLE
Fix #1311: Add math markup for setValueCurveAtTime

### DIFF
--- a/index.html
+++ b/index.html
@@ -5023,7 +5023,8 @@ interface AudioDestinationNode : AudioNode {
             <code>NotSupportedError</code> exception MUST be thrown if any
             <a href="#dfn-automation-method">automation method</a> is called at
             a time which is inside of the time interval of a
-            <em>SetValueCurve</em> event at time T and duration D.</span>
+            <em>SetValueCurve</em> event at time \(T\) and duration
+            \(D\).</span>
           </li>
         </ul>
         <p class="note">


### PR DESCRIPTION
The T and D variables should use math markup style.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1311-fix-math-markup-set-value-curve.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/1563479...rtoy:f86cb7e.html)