### PR TITLE
Fix #1309: Fix typo in MSASN options parameter description

### DIFF
--- a/index.html
+++ b/index.html
@@ -15936,9 +15936,9 @@ interface MediaStreamAudioSourceNode : AudioNode {
                   <td class="prmDesc">
                     Initial parameter values for this
                     <a>MediaStreamAudioSourceNode</a>. If the
-                    <code>mediaStreamTrack</code> parameter does not reference
-                    a <code>MediaStreamTrack</code> whose <code>kind</code>
-                    attribute has the value <code>"audio"</code>, <span class=
+                    <code>mediaStream</code> parameter does not reference a
+                    <code>MediaStream</code> whose <code>kind</code> attribute
+                    has the value <code>"audio"</code>, <span class=
                     "synchronous">an <code>InvalidStateError</code> MUST be
                     thrown</span>.
                   </td>


### PR DESCRIPTION
The dictionary member name is `mediaStream` which is a `MediaStream`,
not `mediaStreamTrack` and `MediaStreamTrack`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1309-fix-msasn-description-typo.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/7fec459...rtoy:c986509.html)