### PR TITLE
Fix #1307: Periodically extend square and sawtooth wave

### DIFF
--- a/index.html
+++ b/index.html
@@ -15426,8 +15426,11 @@ dictionary OscillatorOptions : AudioNodeOptions {
                          -1 & \mbox{for } -\pi &lt; t &lt; 0.
                          \end{cases}
                 $$
-
-</pre>
+              </pre>
+              <p>
+                This is extended to all \(t\) by using the fact that the
+                waveform is an odd function with period \(2\pi\).
+              </p>
             </dd>
             <dt>
               "sawtooth"
@@ -15438,8 +15441,11 @@ dictionary OscillatorOptions : AudioNodeOptions {
                 $$
                   x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi;
                 $$
-
-</pre>
+              </pre>
+              <p>
+                This is extended to all \(t\) by using the fact that the
+                waveform is an odd function with period \(2\pi\).
+              </p>
             </dd>
             <dt>
               "triangle"
@@ -15454,9 +15460,11 @@ dictionary OscillatorOptions : AudioNodeOptions {
                            \frac{\pi}{2} &lt; t ≤ \pi.
                          \end{cases}
                 $$
-
-</pre>This is extended to all \(t\) by using the fact that the waveform is an
-odd function with period \(2\pi\).
+              </pre>
+              <p>
+                This is extended to all \(t\) by using the fact that the
+                waveform is an odd function with period \(2\pi\).
+              </p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Add text to say the square and sawtooth waves are periodic extensions
of the basic wave forms.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1307-periodically-extend-square-sawtooth.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/7fec459...rtoy:e48da71.html)