### PR TITLE
Add missing comma after "Exposed=Window".

### DIFF
--- a/index.html
+++ b/index.html
@@ -6388,7 +6388,7 @@ interface AudioScheduledSourceNode : AudioNode {
           This node has no <a>tail-time</a> reference.
         </p>
         <pre class="idl">
-[Exposed=Window
+[Exposed=Window,
  Constructor (BaseAudioContext context, optional GainOptions options)]
 interface GainNode : AudioNode {
     readonly        attribute AudioParam gain;


### PR DESCRIPTION
This gets rid of the Respec error.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/rtoy-fix-respec-error-missing-comma.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/bd229f3...rtoy:e39f201.html)