### PR TITLE
Fix #1352: ABSN.detune is of type AudioParam

### DIFF
--- a/index.html
+++ b/index.html
@@ -7443,7 +7443,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dd>
             <dt>
               <dfn><code>detune</code></dfn> of type <span class=
-              "idlAttrType"><a><code>AudioAudioParam</code></a></span>,
+              "idlAttrType"><a><code>AudioParam</code></a></span>,
               readonly
             </dt>
             <dd>

--- a/index.html
+++ b/index.html
@@ -7443,8 +7443,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dd>
             <dt>
               <dfn><code>detune</code></dfn> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>,
-              readonly
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
             </dt>
             <dd>
               An additional parameter, in cents, to modulate the speed at which


### PR DESCRIPTION
Fixes typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1352-fix-typo-absn-detune.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/efadcd0...rtoy:d4f5fc2.html)