### PR TITLE
Fix #1350: Compressor has a tail time ref

### DIFF
--- a/index.html
+++ b/index.html
@@ -12902,7 +12902,9 @@ dictionary ChannelMergerOptions : AudioNodeOptions {
           There are <a>channelCount constraints</a> for this node.
         </p>
         <p>
-          This node has no <a>tail-time</a> reference.
+          This node has a <a>tail-time</a> reference such that this node
+          continues to output non-silent audio with zero input due to the
+          look-ahead delay.
         </p>
         <pre class="idl">
 [Exposed=Window,


### PR DESCRIPTION
The look-ahead delay causes a tail time ref.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1350-compressor-tail-time-ref.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/efadcd0...rtoy:ef6ce2b.html)