### PR TITLE
Fix #1355: Remove code snippet from ScriptProcessorNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1629,7 +1629,7 @@ interface BaseAudioContext : EventTarget {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    numberOfInputChannels
+                    <dfn>numberOfInputChannels</dfn>
                   </td>
                   <td class="prmType">
                     <code>unsigned long = 2</code>
@@ -1650,7 +1650,7 @@ interface BaseAudioContext : EventTarget {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    numberOfOutputChannels
+                    <dfn>numberOfOutputChannels</dfn>
                   </td>
                   <td class="prmType">
                     <code>unsigned long = 2</code>
@@ -9946,16 +9946,11 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
           <code>createScriptProcessor</code> is not passed in, or is set to 0.
         </p>
         <p>
-          <dfn>numberOfInputChannels</dfn> and
-          <dfn>numberOfOutputChannels</dfn> determine the number of input and
-          output channels. It is invalid for both
-          <code>numberOfInputChannels</code> and
-          <code>numberOfOutputChannels</code> to be zero.
+          <a>numberOfInputChannels</a> and <a>numberOfOutputChannels</a>
+          determine the number of input and output channels. It is invalid for
+          both <a>numberOfInputChannels</a> and <a>numberOfOutputChannels</a>
+          to be zero.
         </p>
-        <pre>
-var node = context.createScriptProcessor(bufferSize, numberOfInputChannels,
-  numberOfOutputChannels);
-</pre>
         <pre class="idl">
 [Exposed=Window]
 interface ScriptProcessorNode : AudioNode {


### PR DESCRIPTION
Also changes the dfn's for `numberOfInputChannels` and
`numberOfOutputChannels` so that these are defined as the args to
`createScriptProcessor`.  The current definitions were rather circular
and not helpful.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1355-remove-spn-code-snippet.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/b7ca241...rtoy:62ca4e0.html)