### PR TITLE
Fix #1361: Clarify nominal range for simple parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -4945,8 +4945,8 @@ interface AudioDestinationNode : AudioNode {
           Each <code>AudioParam</code> includes <a data-link-for=
           "AudioParam"><code>minValue</code></a> and <a data-link-for=
           "AudioParam"><code>maxValue</code></a> attributes that together form
-          the <a>nominal range</a> for the parameter. In effect, value of the
-          parameter is clamped to the range \([\mathrm{minValue},
+          the <dfn>simple nominal range</dfn> for the parameter. In effect,
+          value of the parameter is clamped to the range \([\mathrm{minValue},
           \mathrm{maxValue}]\). See the section <a href=
           "#computation-of-value">Computation of Value</a> for full details.
         </p>
@@ -6001,7 +6001,7 @@ interface AudioParam {
             The <dfn>nominal range</dfn> for a <a>computedValue</a> are the
             lower and higher values this parameter can effectively have. For
             <a>simple parameters</a>, the <a>computedValue</a> is clamped to
-            the <a>nominal range</a> for this parameter. <a>Compound
+            the <a>simple nominal range</a> for this parameter. <a>Compound
             parameters</a> have their final value clamped to their <a>nominal
             range</a> after having been computed from the different
             <a>AudioParam</a> values they are composed of.


### PR DESCRIPTION
Basically define a new term `simple nominal range` that says the
AudioParam `minValue` and `maxValue` form the valid range, and use
that in the description of the full `nominal range` term that includes
both simple and compound parameters.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1361-clarify-nominal-range-with-min-max.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/b7ca241...rtoy:5fde671.html)