### PR TITLE
Fix #1360: Define AudioParam downmixing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4143,6 +4143,14 @@ interface AudioNode : EventTarget {
                 for the parameter.
               </p>
               <p>
+                The down-mixing to mono is equivalent to the down-mixing for an
+                <a>AudioNode</a> with <a>channelCount</a> = 1,
+                <a>channelCountMode</a> = "<a data-link-for=
+                "ChannelCountMode">explicit</a>", and
+                <a>channelInterpetation</a> = "<a data-link-for=
+                "ChannelInterpretation">speakers</a>".
+              </p>
+              <p>
                 There can only be one connection between a given output of one
                 specific node and a specific <a><code>AudioParam</code></a>.
                 Multiple connections with the same termini are ignored. For


### PR DESCRIPTION
Define the mixing of the inputs of an AudioParam more precisely.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1360-define-audio-param-downmixing.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/b7ca241...rtoy:0c61ebb.html)