### PR TITLE
Fix #1369: Use correct dfn for channelInterpretation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3930,10 +3930,10 @@ interface AudioNode : EventTarget {
             </dt>
             <dd>
               <p>
-                <dfn>channelInterpetation</dfn> determines how individual
-                channels will be treated when up-mixing and down-mixing
-                connections to any inputs to the node. This attribute has no
-                effect for nodes with no inputs.
+                <a>channelInterpretation</a> determines how individual channels
+                will be treated when up-mixing and down-mixing connections to
+                any inputs to the node. This attribute has no effect for nodes
+                with no inputs.
               </p>
               <p>
                 See the <a href="#channel-up-mixing-and-down-mixing"></a>


### PR DESCRIPTION
Replaces an incorrect `<dfn>` with `<a>` for `channelInterpretation`.
Links to `channelInterpretation` will not be properly highlighted
similar to `channelCount`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1369-correct-dfn-for-channel-interpretation.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/e669c8f...rtoy:6cb5e44.html)