### PR TITLE
Fix #1351: Add corrections to stop algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -6259,9 +6259,9 @@ interface AudioScheduledSourceNode : AudioNode {
                 these steps:</span>
               </p>
               <ol>
-                <li>If <code>stop</code> has been called on this node, or if an
-                earlier call to <code>start</code> has not already occurred, an
-                <code>InvalidStateError</code> exception MUST be thrown.
+                <li>If an earlier call to <code>start</code> has not already
+                occurred, an <code>InvalidStateError</code> exception MUST be
+                thrown.
                 </li>
                 <li>Check for any errors that must be thrown due to parameter
                 constraints described below.
@@ -7662,9 +7662,9 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
                 these steps:</span>
               </p>
               <ol>
-                <li>If <code>stop</code> has been called on this node, or if an
-                earlier call to <code>start</code> has not already occurred, an
-                <code>InvalidStateError</code> exception MUST be thrown.
+                <li>If an earlier call to <code>start</code> has not already
+                occurred, an <code>InvalidStateError</code> exception MUST be
+                thrown.
                 </li>
                 <li>Check for any errors that must be thrown due to parameter
                 constraints described below.


### PR DESCRIPTION
For both an AudioScheduledSourceNode and AudioBufferSourceNode, update
the stop algorithm and rmeove the part that a second call to stop
signals an error.  This isn't true; the last call to stop wins.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1351-better-stop-algo-description.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/2032ef1...rtoy:ee154ed.html)