### PR TITLE
Fix #1373: Fix bad links in FFT Windowing section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12365,11 +12365,13 @@ dictionary AnalyserOptions : AudioNodeOptions {
               <a href="#channel-up-mixing-and-down-mixing">Down-mix</a> all
               channels of the time domain input data to mono assuming a
               <a data-link-for="AudioNode">channelCount</a> of 1,
-              <a>channelCountMode</a> of "max" and <a>channelInterpetation</a>
-              of "speakers". This is independent of the settings for the
-              <a>AnalyserNode</a> itself. The most recent <a data-link-for=
-              "AnalyserNode"><code>fftSize</code></a>frames are used for the
-              down-mixing operation.
+              <a data-link-for="AudioNode">channelCountMode</a> of
+              "<a data-link-for="ChannelCountMode">max</a>" and
+              <a data-link-for="AudioNode">channelInterpretation</a> of
+              "<a data-link-for="ChannelInterpretation">speakers</a>". This is
+              independent of the settings for the <a>AnalyserNode</a> itself.
+              The most recent <a data-link-for="AnalyserNode">fftSize</a>
+              frames are used for the down-mixing operation.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the


### PR DESCRIPTION
Also add a necessary space in "fftSizeframes" which should be "fftSize
frames".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1373-fix-bad-links.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/8100cb8...rtoy:7145bf2.html)