### PR TITLE
Fix #1375: Replace "method-algorithm" class with "algorithm"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1441,7 +1441,7 @@ interface BaseAudioContext : EventTarget {
               <a>Factory method</a> to create a
               <a><code>PeriodicWave</code></a>. When calling this method,
               execute these steps:
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>If <var>real</var> and <var>imag</var> are not of the same
                 length, an <var>IndexSizeError</var> MUST be thrown.
                 </li>
@@ -1736,7 +1736,7 @@ interface BaseAudioContext : EventTarget {
                 called, the following steps MUST be performed on the control
                 thread:</span>
               </p>
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>Let <var>promise</var> be a new promise.
                 </li>
                 <li>If the operation <a href=
@@ -1779,7 +1779,7 @@ interface BaseAudioContext : EventTarget {
                 Multiple <em>decoding threads</em> can run in parallel to
                 service multiple calls to <code>decodeAudioData</code>.
               </div>
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>Attempt to decode the encoded <a>audioData</a> into linear
                 PCM.
                 </li>
@@ -1915,7 +1915,7 @@ interface BaseAudioContext : EventTarget {
                 <span class="synchronous">When resume is called, execute these
                 steps:</span>
               </p>
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>Let <em>promise</em> be a new Promise.
                 </li>
                 <li>If the <em>control thread state</em> flag on the
@@ -1948,7 +1948,7 @@ interface BaseAudioContext : EventTarget {
                 <a>BaseAudioContext</a> means running these steps on the
                 <a>rendering thread</a>:
               </p>
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>Attempt to <a href="#acquiring">acquire system
                 resources</a>.
                 </li>
@@ -2201,7 +2201,7 @@ interface AudioContext : BaseAudioContext {
                 <span class="synchronous">When creating an <a>AudioContext</a>,
                 execute these steps:</span>
               </p>
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>Set a <code>control thread state</code> to
                 <code>suspended</code> on the <a>AudioContext</a>.
                 </li>
@@ -2244,7 +2244,7 @@ interface AudioContext : BaseAudioContext {
                 Sending a <a>control message</a> to start processing means
                 executing the following steps:
               </p>
-              <ol class="method-algorithm">
+              <ol class="algorithm">
                 <li>Attempt to <a href="#acquiring">acquire system
                 resources</a>.
                 </li>


### PR DESCRIPTION
Respec doesn't have a class "method-algorithm" for ol tags.  It should
be just "algorithm".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1375-class-method-algorithm-is-algorithm.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/8100cb8...rtoy:8cb2579.html)