### PR TITLE
Fix #1380: Update #idl-def-foo links

### DIFF
--- a/index.html
+++ b/index.html
@@ -902,9 +902,9 @@ interface BaseAudioContext : EventTarget {
               </p>
               <p>
                 When the <a><code>BaseAudioContext</code></a> is in the
-                <a href="#idl-def-AudioContextState.running"><code>running</code></a>
-                state, the value of this attribute is monotonically increasing
-                and is updated by the rendering thread in uniform increments,
+                <a data-link-for="AudioContextState">running</a> state, the
+                value of this attribute is monotonically increasing and is
+                updated by the rendering thread in uniform increments,
                 corresponding to one <a href="#dfn-render-quantum">render
                 quantum</a>. Thus, for a running context,
                 <code>currentTime</code> increases steadily as the system
@@ -1525,8 +1525,7 @@ interface BaseAudioContext : EventTarget {
                     constraints
                   </td>
                   <td class="prmType">
-                    <code><a href="#idl-def-PeriodicWaveConstraints" class=
-                    "idlType"><code>PeriodicWaveConstraints</code></a></code>
+                    <a>PeriodicWaveConstraints</a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -1863,8 +1862,7 @@ interface BaseAudioContext : EventTarget {
                     successCallback
                   </td>
                   <td class="prmType">
-                    <code><a href="#idl-def-DecodeSuccessCallback" class=
-                    "idlType"><code>DecodeSuccessCallback</code></a></code>
+                    <a>DecodeSuccessCallback</a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -1883,8 +1881,7 @@ interface BaseAudioContext : EventTarget {
                     errorCallback
                   </td>
                   <td class="prmType">
-                    <code><a href="#idl-def-DecodeErrorCallback" class=
-                    "idlType"><code>DecodeErrorCallback</code></a></code>
+                    <a>DecodeErrorCallback</a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -13864,9 +13861,9 @@ interface BiquadFilterNode : AudioNode {
             <dd>
               The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a> factor
               has a default value of 1. Its <a>nominal range</a> is \((-\infty,
-              \infty)\). This is not used for <a href=
-              "#idl-def-BiquadFilterType.lowshelf">lowshelf</a> or <a href=
-              "#idl-def-BiquadFilterType.highshelf">highshelf</a> filters.
+              \infty)\). This is not used for <a data-link-for=
+              "BiquadFilterType">lowshelf</a> or <a data-link-for=
+              "BiquadFilterType">highshelf</a> filters.
             </dd>
             <dt>
               <code><dfn>detune</dfn></code> of type <span class=
@@ -13895,10 +13892,9 @@ interface BiquadFilterNode : AudioNode {
             <dd>
               The gain has a default value of 0. Its <a>nominal range</a> is
               \((-\infty, \infty)\). Its value is in dB units. The gain is only
-              used for <a href=
-              "#idl-def-BiquadFilterType.lowshelf">lowshelf</a>, <a href=
-              "#idl-def-BiquadFilterType.highshelf">highshelf</a>, and <a href=
-              "#idl-def-BiquadFilterType.peaking">peaking</a> filters.
+              used for <a data-link-for="BiquadFilterType">lowshelf</a>,
+              <a data-link-for="BiquadFilterType">highshelf</a>, and
+              <a data-link-for="BiquadFilterType">peaking</a> filters.
             </dd>
             <dt>
               <code><dfn>type</dfn></code> of type <span class=
@@ -14662,12 +14658,12 @@ dictionary IIRFilterOptions : AudioNodeOptions {
         </p>
         <p>
           If the <a data-link-for="WaveShaperNode">oversample</a> attribute is
-          set to <a href="#idl-def-OverSampleType.none">none</a>, the
+          set to <a data-link-for="OverSampleType">none</a>, the
           <a>WaveShaperNode</a> has no <a>tail-time</a>. If the
           <a data-link-for="WaveShaperNode">oversample</a> attribute is set to
-          <a href="#idl-def-OverSampleType.x2x">2x</a> or <a href=
-          "#idl-def-OverSampleType.x4x">4x</a>, the <a>WaveShaperNode</a> can
-          have <a>tail-time</a> caused by the resampling technique used. The
+          <a data-link-for="OverSampleType">2x</a> or <a data-link-for=
+          "OverSampleType">4x</a>, the <a>WaveShaperNode</a> can have
+          <a>tail-time</a> caused by the resampling technique used. The
           duration of this <a>tail-time</a> is therefore
           implementation-dependent.
         </p>
@@ -16916,28 +16912,22 @@ function playSound() {
           determines how <a><code>computedNumberOfChannels</code></a> will be
           computed. Once this number is computed, all of the connections will
           be up or down-mixed to that many channels. For most nodes, the
-          default value is <a href=
-          "#idl-def-ChannelCountMode.max"><code>"max"</code></a>.
+          default value is "<a data-link-for="ChannelCountMode">max</a>".
           <ul>
-            <li>
-              <a href="#idl-def-ChannelCountMode.max"><code>"max"</code></a>:
-              <a><code>computedNumberOfChannels</code></a> is computed as the
-              maximum of the number of channels of all connections. In this
-              mode <a data-link-for="AudioNode"><code>channelCount</code></a>
-              is ignored.
+            <li>"<a data-link-for="ChannelCountMode">max</a>":
+            <a><code>computedNumberOfChannels</code></a> is computed as the
+            maximum of the number of channels of all connections. In this mode
+            <a data-link-for="AudioNode"><code>channelCount</code></a> is
+            ignored.
             </li>
-            <li>
-              <a href=
-              "#idl-def-ChannelCountMode.clamped-max"><code>"clamped-max"</code></a>:
-              same as “max” up to a limit of the <a data-link-for=
-              "AudioNode"><code>channelCount</code></a>
+            <li>"<a data-link-for="ChannelCountMode">clamped-max</a>": same as
+            “max” up to a limit of the <a data-link-for=
+            "AudioNode"><code>channelCount</code></a>
             </li>
-            <li>
-              <a href=
-              "#idl-def-ChannelCountMode.explicit"><code>"explicit"</code></a>:
-              <a><code>computedNumberOfChannels</code></a> is the exact value
-              as specified in <a data-link-for=
-              "AudioNode"><code>channelCount</code></a>
+            <li>"<a data-link-for="ChannelCountMode">explicit</a>":
+            <a><code>computedNumberOfChannels</code></a> is the exact value as
+            specified in <a data-link-for=
+            "AudioNode"><code>channelCount</code></a>
             </li>
           </ul>
         </li>
@@ -16949,20 +16939,15 @@ function playSound() {
           exactly how the up and down mixing is performed. The default value is
           "speakers".
           <ul>
-            <li>
-              <a href=
-              "#idl-def-ChannelInterpretation.speakers"><code>“speakers”</code></a>:
-              use <a href="#ChannelLayouts">up-down-mix equations for
-              mono/stereo/quad/5.1</a>. In cases where the number of channels
-              do not match any of these basic speaker layouts, revert to
-              "discrete".
+            <li>"<a data-link-for="ChannelInterpretation">speakers</a>": use
+            <a href="#ChannelLayouts">up-down-mix equations for
+            mono/stereo/quad/5.1</a>. In cases where the number of channels do
+            not match any of these basic speaker layouts, revert to "discrete".
             </li>
-            <li>
-              <a href=
-              "#idl-def-ChannelInterpretation.discrete"><code>“discrete”</code></a>:
-              up-mix by filling channels until they run out then zero out
-              remaining channels. down-mix by filling as many channels as
-              possible, then dropping remaining channels
+            <li>"<a data-link-for="ChannelInterpretation">discrete</a>": up-mix
+            by filling channels until they run out then zero out remaining
+            channels. down-mix by filling as many channels as possible, then
+            dropping remaining channels
             </li>
           </ul>
         </li>
@@ -16994,8 +16979,8 @@ function playSound() {
         </h3>
         <p>
           When <a data-link-for=
-          "AudioNode"><code>channelInterpretation</code></a> is <a href=
-          "#idl-def-ChannelInterpretation.speakers">"speakers"</a> then the
+          "AudioNode"><code>channelInterpretation</code></a> is
+          "<a data-link-for="ChannelInterpretation">speakers</a>" then the
           up-mixing and down-mixing is defined for specific channel layouts.
         </p>
         <p>
@@ -17750,10 +17735,10 @@ function distance(panner) {
         <p>
           <em>distance</em> will then be used to calculate
           <em>distanceGain</em> which depends on the <em>distanceModel</em>
-          attribute. See the <a href=
-          "#idl-def-DistanceModelType">distanceModel</a> section for details of
-          how this is calculated for each distance model. The value computed by
-          the <a href="#idl-def-DistanceModelType">distanceModel</a> equations
+          attribute. See the <a data-link-for=
+          "DistanceModelType">DistanceModelType</a> section for details of how
+          this is calculated for each distance model. The value computed by the
+          <a data-link-for="DistanceModelType">DistanceModelType</a> equations
           are to be clamped to [0, 1].
         </p>
         <p>


### PR DESCRIPTION
Update links to the correct locations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1380-fix-links-for-idl-def-foo.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/08f6e14...rtoy:28e6351.html)