### PR TITLE
AudioWorkletNodeOptions.outputChannelCount

### DIFF
--- a/index.html
+++ b/index.html
@@ -9109,6 +9109,7 @@ interface AudioWorkletNode : AudioNode {
 dictionary AudioWorkletNodeOptions : AudioNodeOptions {
              unsigned long             numberOfInputs = 1;
              unsigned long             numberOfOutputs = 1;
+             sequence&lt;unsigned long&gt;    outputChannelCount;
              record&lt;DOMString, double&gt;  parameterData;
 };
             </pre>
@@ -9137,6 +9138,20 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
                   <a data-link-for="AudioNode">numberOfOutputs</a> attribute.
                 </dd>
                 <dt>
+                  <code><dfn>outputChannelCount</dfn></code> of type
+                  <span class="idlAttrType"><code>sequence&lt;unsigned
+                  long&gt;</code></span>
+                </dt>
+                <dd>
+                  This is used to configure the number of channels in each
+                  output. <code>IndexSizeError</code> MUST be thrown if the
+                  length of sequence does not match <a data-link-for=
+                  "AudioWorkletNodeOptions">numberOfOutputs</a>. A
+                  <code>NotSupportedError</code> exception MUST be thrown if a
+                  channel count is not in the valid range of <a data-link-for=
+                  "AudioNode">channelCount</a>.
+                </dd>
+                <dt>
                   <code><dfn>parameterData</dfn></code> of type <span class=
                   "idlAttrType"><code>record&lt;DOMString,
                   double&gt;</code></span>
@@ -9149,6 +9164,51 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
                   the node, it is ignored.
                 </dd>
               </dl>
+            </section>
+            <section>
+              <h3>
+                Configuring Channels with <a>AudioWorkletNodeOptions</a>
+              </h3>
+              <p>
+                With a combination of <a data-link-for=
+                "AudioWorkletNodeOptions">numberOfInputs</a>, <a data-link-for=
+                "AudioWorkletNodeOptions">numberOfOutputs</a> and
+                <a data-link-for=
+                "AudioWorkletNodeOptions">outputChannelCount</a>, various
+                channel configurations can be achieved.
+              </p>
+              <ol>
+                <li>
+                  <a data-link-for="AudioWorkletNodeOptions">numberOfInputs</a>
+                  = 0, <a data-link-for=
+                  "AudioWorkletNodeOptions">numberOfOutputs</a> = 0
+                  <ul>
+                    <li>
+                      <code>NotSupportedError</code> MUST be thrown.
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a data-link-for="AudioWorkletNodeOptions">numberOfInputs</a>
+                  = 1, <a data-link-for=
+                  "AudioWorkletNodeOptions">numberOfOutputs</a> = 1
+                  <ul>
+                    <li>If <a data-link-for=
+                    "AudioWorkletNodeOptions">outputChannelCount</a> is
+                    unspecified, the output channel count will match
+                    <a>computedNumberOfChannels</a> from the input.
+                    </li>
+                  </ul>
+                </li>
+                <li>All other cases
+                  <ul>
+                    <li>If <a data-link-for=
+                    "AudioWorkletNodeOptions">outputChannelCount</a> is
+                    unspecified, it will be mono for all outputs.
+                    </li>
+                  </ul>
+                </li>
+              </ol>
             </section>
           </section>
         </section>

--- a/index.html
+++ b/index.html
@@ -9326,9 +9326,9 @@ class MyProcessor extends AudioWorkletProcessor {
                   by the user agent. <code>inputs[n][m]</code> is a
                   <code>Float32Array</code> of audio samples for the
                   <code>m</code>th channel of <code>n</code>th input. While the
-                  number of inputs is fixed at the construction, the number of
+                  number of inputs is fixed at construction, the number of
                   channels can be changed dynamically based on
-                  <a>computedNumberOfChannels</a>
+                  <a>computedNumberOfChannels</a>.
                 </p>
                 <p>
                   If no connections exist to the <code>n</code>th input of the
@@ -9346,8 +9346,9 @@ class MyProcessor extends AudioWorkletProcessor {
                 agent. <code>outputs[n][m]</code> is a
                 <code>Float32Array</code> object containing the audio samples
                 for <code>m</code>th channel of <code>n</code>th output. The
-                number of channels in the output can be dynamically changed
-                only when the node has single output.
+                number of channels in the output will match
+                <a>computedNumberOfChannels</a> only when the node has single
+                output.
               </li>
               <li>
                 <code>parameters</code> of type <code>Object</code><br>

--- a/index.html
+++ b/index.html
@@ -9143,9 +9143,13 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
                   long&gt;</code></span>
                 </dt>
                 <dd>
-                  This is used to configure the number of channels in each
-                  output. <code>IndexSizeError</code> MUST be thrown if the
-                  length of sequence does not match <a data-link-for=
+                  This array is used to configure the number of channels in
+                  each output. For example, <code>outputChannelCount: [n,
+                  m]</code> specifies the number of channels in the first
+                  output to <code>n</code> and the second output to
+                  <code>m</code> respectively. <code>IndexSizeError</code> MUST
+                  be thrown if the length of sequence does not match
+                  <a data-link-for=
                   "AudioWorkletNodeOptions">numberOfOutputs</a>. A
                   <code>NotSupportedError</code> exception MUST be thrown if a
                   channel count is not in the valid range of <a data-link-for=

--- a/index.html
+++ b/index.html
@@ -9152,8 +9152,8 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
                   <a data-link-for=
                   "AudioWorkletNodeOptions">numberOfOutputs</a>. A
                   <code>NotSupportedError</code> exception MUST be thrown if a
-                  channel count is not in the valid range of <a data-link-for=
-                  "AudioNode">channelCount</a>.
+                  channel count is not in the valid range of AudioNode's
+                  <a data-link-for="AudioNode">channelCount</a>.
                 </dd>
                 <dt>
                   <code><dfn>parameterData</dfn></code> of type <span class=
@@ -9188,7 +9188,8 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
                   "AudioWorkletNodeOptions">numberOfOutputs</a> = 0
                   <ul>
                     <li>
-                      <code>NotSupportedError</code> MUST be thrown.
+                      <code>NotSupportedError</code> MUST be thrown by the
+                      constructor.
                     </li>
                   </ul>
                 </li>

--- a/index.html
+++ b/index.html
@@ -9327,7 +9327,8 @@ class MyProcessor extends AudioWorkletProcessor {
                   <code>Float32Array</code> of audio samples for the
                   <code>m</code>th channel of <code>n</code>th input. While the
                   number of inputs is fixed at the construction, the number of
-                  channels can be changed dynamically.
+                  channels can be changed dynamically based on
+                  <a>computedNumberOfChannels</a>
                 </p>
                 <p>
                   If no connections exist to the <code>n</code>th input of the
@@ -9344,9 +9345,9 @@ class MyProcessor extends AudioWorkletProcessor {
                 The output audio buffer that is to be consumed by the user
                 agent. <code>outputs[n][m]</code> is a
                 <code>Float32Array</code> object containing the audio samples
-                for <code>m</code>th channel of <code>n</code>th output. While
-                the number of outputs is fixed at the construction, the number
-                of channels can be changed dynamically.
+                for <code>m</code>th channel of <code>n</code>th output. The
+                number of channels in the output can be dynamically changed
+                only when the node has single output.
               </li>
               <li>
                 <code>parameters</code> of type <code>Object</code><br>


### PR DESCRIPTION
- Fixes #1325.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/hoch/web-audio-api/1325-output-channel-count.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/8d6d807...hoch:9215fc9.html)