### PR TITLE
Fix #1348: Remove default constructor for AudioContext

### DIFF
--- a/index.html
+++ b/index.html
@@ -2167,7 +2167,6 @@ enum <dfn>AudioContextLatencyCategory</dfn> {
         </table>
         <pre class="idl">
 [Exposed=Window,
- Constructor,
  Constructor (optional AudioContextOptions contextOptions)]
 interface AudioContext : BaseAudioContext {
     readonly        attribute double baseLatency;


### PR DESCRIPTION
Remove the zero-arg constructor for AudioContext.  Since the
AudioContextOptions argument is optional, the result is the same as
the zero-arg constructor.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1348-remove-default-ctor-for-audiocontext.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/95beb6a...rtoy:cc86945.html)