### PR TITLE
Fix #1378: Define computedPlaybackRate compound parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -7619,6 +7619,19 @@ dictionary AudioBufferOptions {
           between 0 and the duration of the buffer.
         </p>
         <p>
+          The <a data-link-for="AudioBufferSourceNode">playbackRate</a> and
+          <a data-link-for="AudioBufferSourceNode">detune</a> attributes form a
+          <a>compound parameter</a>. They are used together to determine a
+          <dfn>computedPlaybackRate</dfn> value:
+        </p>
+        <pre class="highlight">
+computedPlaybackRate(t) = playbackRate(t) * pow(2, detune(t) / 1200)
+        </pre>
+        <p>
+          The <a>nominal range</a> for this <a>compound parameter</a> is
+          \((-\infty, \infty)\).
+        </p>
+        <p>
           <a>AudioBufferSourceNode</a>s are created with an internal boolean
           slot <code>[[buffer set]]</code>, initially set to false.
         </p>
@@ -7756,7 +7769,8 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
               <p>
                 An additional parameter, in cents, to modulate the speed at
                 which is rendered the audio stream. This parameter is a
-                <a>compound parameter</a> with <code>playbackRate</code>.
+                <a>compound parameter</a> with <a>playbackRate</a> to form a
+                <a>computedPlaybackRate</a>.
               </p>
               <div class="audioparam-info">
                 <table>
@@ -7857,7 +7871,8 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             <dd>
               <p>
                 The speed at which to render the audio stream. This is a
-                <a>compound parameter</a> with <code>detune</code>.
+                <a>compound parameter</a> with <a>detune</a> to form a
+                <a>computedPlaybackRate</a>.
               </p>
               <div class="audioparam-info">
                 <table>

--- a/index.html
+++ b/index.html
@@ -7313,6 +7313,19 @@ dictionary AudioBufferOptions {
           between 0 and the duration of the buffer.
         </p>
         <p>
+          The <a data-link-for="AudioBufferSourceNode">playbackRate</a> and
+          <a data-link-for="AudioBufferSourceNode">detune</a> attributes form a
+          <a>compound parameter</a>. They are used together to determine a
+          <dfn>computedPlaybackRate</dfn> value:
+        </p>
+        <pre class="highlight">
+computedPlaybackRate(t) = playbackRate(t) * pow(2, detune(t) / 1200)
+        </pre>
+        <p>
+          The <a>nominal range</a> for this <a>compound parameter</a> is
+          \([-\infty, \infty]\).
+        </p>
+        <p>
           <a>AudioBufferSourceNode</a>s are created with an internal boolean
           slot <code>[[buffer set]]</code>, initially set to false.
         </p>
@@ -7450,8 +7463,9 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
               An additional parameter, in cents, to modulate the speed at which
               is rendered the audio stream. Its default value is 0. This
               parameter is <a>k-rate</a>. This parameter is a <a>compound
-              parameter</a> with <code>playbackRate</code>. Its <a>nominal
-              range</a> is \((-\infty, \infty)\).
+              parameter</a> with <code>playbackRate</code> to form a
+              <a>computedPlaybackRate</a>. Its <a>nominal range</a> is
+              \((-\infty, \infty)\).
             </dd>
             <dt>
               <code><dfn>loop</dfn></code> of type <span class=
@@ -7496,8 +7510,9 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             <dd>
               The speed at which to render the audio stream. Its default
               <code>value</code> is 1. This parameter is <a>k-rate</a>. This is
-              a <a>compound parameter</a> with <code>detune</code>. Its
-              <a>nominal range</a> is \([-\infty, \infty]\).
+              a <a>compound parameter</a> with <code>detune</code> to form a
+              <a>computedPlaybackRate</a>. Its <a>nominal range</a> is
+              \([-\infty, \infty]\).
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Define the compound parameter for the AudioBufferSourceNode, and link
to it in the description of the parameters.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1378-absn-define-compound-parameter.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:5787822.html)