### PR TITLE
Fix #1392: Fix typo in AudioNodeOptions description

### DIFF
--- a/index.html
+++ b/index.html
@@ -4701,7 +4701,7 @@ dictionary AudioNodeOptions {
                 <span class="idlAttrType"><a>ChannelInterpretation</a></span>
               </dt>
               <dd>
-                Desired mode for the <a>channelCountMode</a> attribute.
+                Desired mode for the <a>channelInterpretation</a> attribute.
               </dd>
             </dl>
           </section>


### PR DESCRIPTION
In the description for channelInterpretation, the link should be to
`channelInterpration` and not `channelCountMode`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1392-fix-typo-audio-node-options-interp.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/95beb6a...rtoy:dfda775.html)