### PR TITLE
Fix #1395: ABSN loop limited by duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -7791,7 +7791,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    <dfn>duration</dfn>
+                    duration
                   </td>
                   <td class="prmType">
                     <a><code>double</code></a>
@@ -8014,10 +8014,9 @@ dictionary AudioBufferSourceOptions {
             </li>
             <li>the scheduled stop time has been reached,
             </li>
-            <li>the <a data-link-for="AudioBufferSourceNode">duration</a> has
-            been exceeded, if <a data-link-for=
-            "AudioBufferSourceNode">start</a> was called with a
-            <a data-link-for="AudioBufferSourceNode">duration</a> value.
+            <li>the <code>duration</code> has been exceeded, if
+            <a data-link-for="AudioBufferSourceNode">start</a><code>()</code>
+            was called with a <code>duration</code> value.
             </li>
           </ul>
           <p>

--- a/index.html
+++ b/index.html
@@ -7791,7 +7791,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    duration
+                    <dfn>duration</dfn>
                   </td>
                   <td class="prmType">
                     <a><code>double</code></a>
@@ -8005,9 +8005,21 @@ dictionary AudioBufferSourceOptions {
             <code>loopStart</code> and <code>loopEnd</code> to continue
             indefinitely, once any part of the looped region has been played.
             While <code>loop</code> remains true, looped playback will continue
-            until <code>stop()</code> is called, or the scheduled stop time has
-            been reached.
+            until one of the following occurs:
           </p>
+          <ul>
+            <li>
+              <a data-link-for="AudioBufferSourceNode">stop</a><code>()</code>
+              is called,
+            </li>
+            <li>the scheduled stop time has been reached,
+            </li>
+            <li>the <a data-link-for="AudioBufferSourceNode">duration</a> has
+            been exceeded, if <a data-link-for=
+            "AudioBufferSourceNode">start</a> was called with a
+            <a data-link-for="AudioBufferSourceNode">duration</a> value.
+            </li>
+          </ul>
           <p>
             The body of the loop is considered to occupy a region from
             <code>loopStart</code> up to, but not including,


### PR DESCRIPTION
Add some text that explain the condition where looping stops.  This
includes when a `duration` value is specified when calling `start`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1395-absn-looping-with-duration.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ea86376...rtoy:a0d5d01.html)