### PR TITLE
Fix #1394: Define time domain down mixing for Analyser

### DIFF
--- a/index.html
+++ b/index.html
@@ -12661,7 +12661,7 @@ interface AnalyserNode : AudioNode {
             </dt>
             <dd>
               <p>
-                Copies the current down-mixed time-domain (waveform) data into
+                Copies the <a>current time-domain data<a> (waveform data) into
                 the passed unsigned byte array. If the array has fewer elements
                 than the value of <a data-link-for=
                 "AnalyserNode"><code>fftSize</code></a>, the excess elements
@@ -12796,7 +12796,7 @@ interface AnalyserNode : AudioNode {
             </dt>
             <dd>
               <p>
-                Copies the current down-mixed time-domain (waveform) data into
+                Copies the <a>current time-domain data<a> (waveform data) into
                 the passed floating-point array. If the array has fewer
                 elements than the value of <a data-link-for=
                 "AnalyserNode"><code>fftSize</code></a>, the excess elements
@@ -12907,12 +12907,12 @@ dictionary AnalyserOptions : AudioNodeOptions {
             </dl>
           </section>
         </section>
-        <section data-link-for="AnalyserNode">
+        <section>
           <h3>
-            <dfn>Time-Domain Down-Mixing</dfn>
+            Time-Domain Down-Mixing
           </h3>
           <p>
-          For each of the time-domain and frequency-domain methods, the incoming
+            When the <dfn>current time-domain data</dfn> are computed, the input
           signal must be <a
           href="#channel-up-mixing-and-down-mixing">down-mixed</a> to mono as if <a
               data-link-for="AudioNode">channelCount</a> is 1, <a
@@ -12933,7 +12933,7 @@ dictionary AnalyserOptions : AudioNodeOptions {
           performed:
           <ol>
             <li>
-              Apply <a>time-domain down-mixing</a>.
+              Compute the <a>current time-domain data</a>.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the

--- a/index.html
+++ b/index.html
@@ -12357,22 +12357,31 @@ dictionary AnalyserOptions : AudioNodeOptions {
         </section>
         <section data-link-for="AnalyserNode">
           <h3>
+            <dfn>Time-Domain Down-Mixing</dfn>
+          </h3>
+          <p>
+          For each of the time-domain and frequency-domain methods, the incoming
+          signal must be <a
+          href="#channel-up-mixing-and-down-mixing">down-mixed</a> to mono as if <a
+              data-link-for="AudioNode">channelCount</a> is 1, <a
+              data-link-for="AudioNode">channelCountMode</a> is "<a
+              data-link-for="ChannelCountMode">max</a>" and <a
+              data-link-for="AudioNode">channelInterpretation</a> is "<a
+              data-link-for="ChannelInterpretation">speakers</a>". This is
+              independent of the settings for the <a>AnalyserNode</a> itself.
+              The most recent <a data-link-for="AnalyserNode">fftSize</a> frames
+              are used for the down-mixing operation.
+          </p>
+        </section>
+        <section data-link-for="AnalyserNode">
+          <h3>
             FFT Windowing and smoothing over time
           </h3>When the <dfn id="current-frequency-data">current frequency
           data</dfn> are computed, the following operations are to be
           performed:
           <ol>
             <li>
-              <a href="#channel-up-mixing-and-down-mixing">Down-mix</a> all
-              channels of the time domain input data to mono assuming a
-              <a data-link-for="AudioNode">channelCount</a> of 1,
-              <a data-link-for="AudioNode">channelCountMode</a> of
-              "<a data-link-for="ChannelCountMode">max</a>" and
-              <a data-link-for="AudioNode">channelInterpretation</a> of
-              "<a data-link-for="ChannelInterpretation">speakers</a>". This is
-              independent of the settings for the <a>AnalyserNode</a> itself.
-              The most recent <a data-link-for="AnalyserNode">fftSize</a>
-              frames are used for the down-mixing operation.
+              Apply <a>time-domain down-mixing</a>.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the

--- a/index.html
+++ b/index.html
@@ -12661,7 +12661,7 @@ interface AnalyserNode : AudioNode {
             </dt>
             <dd>
               <p>
-                Copies the <a>current time-domain data<a> (waveform data) into
+                Copies the <a>current time-domain data</a> (waveform data) into
                 the passed unsigned byte array. If the array has fewer elements
                 than the value of <a data-link-for=
                 "AnalyserNode"><code>fftSize</code></a>, the excess elements
@@ -12796,7 +12796,7 @@ interface AnalyserNode : AudioNode {
             </dt>
             <dd>
               <p>
-                Copies the <a>current time-domain data<a> (waveform data) into
+                Copies the <a>current time-domain data</a> (waveform data) into
                 the passed floating-point array. If the array has fewer
                 elements than the value of <a data-link-for=
                 "AnalyserNode"><code>fftSize</code></a>, the excess elements
@@ -12912,17 +12912,17 @@ dictionary AnalyserOptions : AudioNodeOptions {
             Time-Domain Down-Mixing
           </h3>
           <p>
-            When the <dfn>current time-domain data</dfn> are computed, the input
-          signal must be <a
-          href="#channel-up-mixing-and-down-mixing">down-mixed</a> to mono as if <a
-              data-link-for="AudioNode">channelCount</a> is 1, <a
-              data-link-for="AudioNode">channelCountMode</a> is "<a
-              data-link-for="ChannelCountMode">max</a>" and <a
-              data-link-for="AudioNode">channelInterpretation</a> is "<a
-              data-link-for="ChannelInterpretation">speakers</a>". This is
-              independent of the settings for the <a>AnalyserNode</a> itself.
-              The most recent <a data-link-for="AnalyserNode">fftSize</a> frames
-              are used for the down-mixing operation.
+            When the <dfn>current time-domain data</dfn> are computed, the
+            input signal must be <a href=
+            "#channel-up-mixing-and-down-mixing">down-mixed</a> to mono as if
+            <a data-link-for="AudioNode">channelCount</a> is 1,
+            <a data-link-for="AudioNode">channelCountMode</a> is
+            "<a data-link-for="ChannelCountMode">max</a>" and <a data-link-for=
+            "AudioNode">channelInterpretation</a> is "<a data-link-for=
+            "ChannelInterpretation">speakers</a>". This is independent of the
+            settings for the <a>AnalyserNode</a> itself. The most recent
+            <a data-link-for="AnalyserNode">fftSize</a> frames are used for the
+            down-mixing operation.
           </p>
         </section>
         <section data-link-for="AnalyserNode">
@@ -12932,8 +12932,7 @@ dictionary AnalyserOptions : AudioNodeOptions {
           data</dfn> are computed, the following operations are to be
           performed:
           <ol>
-            <li>
-              Compute the <a>current time-domain data</a>.
+            <li>Compute the <a>current time-domain data</a>.
             </li>
             <li>
               <a href="#blackman-window">Apply a Blackman window</a> to the


### PR DESCRIPTION
Add section to define precisely how down-mixing must be done when
extracting the time domain signal from the `AnalyserNode`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1394-analyser-time-data-down-mixing.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/697f710...rtoy:0b04d8b.html)