### PR TITLE
Fix #1402: Add links to looping section

### DIFF
--- a/index.html
+++ b/index.html
@@ -8000,37 +8000,44 @@ dictionary AudioBufferSourceOptions {
             normative requirements.</em>
           </p>
           <p>
-            Setting the <code>loop</code> attribute to true causes playback of
-            the region of the buffer defined by the endpoints
-            <code>loopStart</code> and <code>loopEnd</code> to continue
-            indefinitely, once any part of the looped region has been played.
-            While <code>loop</code> remains true, looped playback will continue
-            until <code>stop()</code> is called, or the scheduled stop time has
-            been reached.
+            Setting the <a data-link-for="AudioBufferSourceNode">loop</a>
+            attribute to true causes playback of the region of the buffer
+            defined by the endpoints <a data-link-for=
+            "AudioBufferSourceNode">loopStart</a> and <a data-link-for=
+            "AudioBufferSourceNode">loopEnd</a> to continue indefinitely, once
+            any part of the looped region has been played. While
+            <a data-link-for="AudioBufferSourceNode">loop</a> remains true,
+            looped playback will continue until <a data-link-for=
+            "AudioBufferSourceNode">stop</a><code>()</code> is called, or the
+            scheduled stop time has been reached.
           </p>
           <p>
             The body of the loop is considered to occupy a region from
-            <code>loopStart</code> up to, but not including,
-            <code>loopEnd</code>. The direction of playback of the looped
-            region respects the sign of the node's playback rate. For positive
-            playback rates, looping occurs from <code>loopStart</code> to
-            <code>loopEnd</code>; for negative rates, looping occurs from
-            <code>loopEnd</code> to <code>loopStart</code>.
+            <a data-link-for="AudioBufferSourceNode">loopStart</a> up to, but
+            not including, <a data-link-for=
+            "AudioBufferSourceNode">loopEnd</a>. The direction of playback of
+            the looped region respects the sign of the node's playback rate.
+            For positive playback rates, looping occurs from <a data-link-for=
+            "AudioBufferSourceNode">loopStart</a> to <a data-link-for=
+            "AudioBufferSourceNode">loopEnd</a>; for negative rates, looping
+            occurs from <a data-link-for="AudioBufferSourceNode">loopEnd</a> to
+            <a data-link-for="AudioBufferSourceNode">loopStart</a>.
           </p>
           <p>
             Looping does not affect the interpretation of the
             <code>offset</code> argument of <a data-link-for=
-            "AudioScheduledSourceNode"><code>start()</code></a>. Playback
-            always starts at the requested offset, and looping only begins once
-            the body of the loop is encountered during playback.
+            "AudioBufferSourceNode">start</a><code>()</code>. Playback always
+            starts at the requested offset, and looping only begins once the
+            body of the loop is encountered during playback.
           </p>
           <p>
             The effective loop start and end points are required to lie within
             the range of zero and the buffer duration, as specified in the
-            algorithm below. <code>loopEnd</code> is further constrained to be
-            at or after <code>loopStart</code>. If any of these constraints are
-            violated, the loop is considered to include the entire buffer
-            contents.
+            algorithm below. <a data-link-for=
+            "AudioBufferSourceNode">loopEnd</a> is further constrained to be at
+            or after <a data-link-for="AudioBufferSourceNode">loopStart</a>. If
+            any of these constraints are violated, the loop is considered to
+            include the entire buffer contents.
           </p>
           <p>
             Loop endpoints have subsample accuracy. When endpoints do not fall
@@ -8046,18 +8053,19 @@ dictionary AudioBufferSourceOptions {
             which follows.
           </p>
           <p>
-            The default values of the <code>loopStart</code> and
-            <code>loopEnd</code> attributes are both 0. Since a
-            <code>loopEnd</code> value of zero is equivalent to the length of
-            the buffer, the default endpoints cause the entire buffer to be
-            included in the loop.
+            The default values of the <a data-link-for=
+            "AudioBufferSourceNode">loopStart</a> and <a data-link-for=
+            "AudioBufferSourceNode">loopEnd</a> attributes are both 0. Since a
+            <a data-link-for="AudioBufferSourceNode">loopEnd</a> value of zero
+            is equivalent to the length of the buffer, the default endpoints
+            cause the entire buffer to be included in the loop.
           </p>
           <p>
             Note that the values of the loop endpoints are expressed as time
             offsets in terms of the sample rate of the buffer, meaning that
-            these values are independent of the node's
-            <code>playbackRate</code> parameter which can vary dynamically
-            during the course of playback.
+            these values are independent of the node's <a data-link-for=
+            "AudioBufferSourceNode">playbackRate</a> parameter which can vary
+            dynamically during the course of playback.
           </p>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -7820,7 +7820,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               Indicates if the region of audio data designated by
-              <code>loopStart</code> and <code>loopEnd</code> should be played
+              <a>loopStart</a> and <a>loopEnd</a> should be played
               continuously in a loop. The default value is <code>false</code>.
             </dd>
             <dt>
@@ -7829,11 +7829,11 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               An optional <a>playhead position</a> where looping should end if
-              the <code>loop</code> attribute is true. Its value is exclusive
+              the <a>loop</a> attribute is true. Its value is exclusive
               of the content of the loop. Its default <code>value</code> is 0,
               and it may usefully be set to any value between 0 and the
-              duration of the buffer. If <code>loopEnd</code> is less than or
-              equal to 0, or if <code>loopEnd</code> is greater than the
+              duration of the buffer. If <a>loopEnd</a> is less than or
+              equal to 0, or if <a>loopEnd</a> is greater than the
               duration of the buffer, looping will end at the end of the
               buffer.
             </dd>
@@ -7843,11 +7843,11 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               An optional <a>playhead position</a> where looping should begin
-              if the <code>loop</code> attribute is true. Its default
+              if the <a>loop</a> attribute is true. Its default
               <code>value</code> is 0, and it may usefully be set to any value
               between 0 and the duration of the buffer. If
-              <code>loopStart</code> is less than 0, looping will begin at 0.
-              If <code>loopStart</code> is greater than the duration of the
+              <a>loopStart</a> is less than 0, looping will begin at 0.
+              If <a>loopStart</a> is greater than the duration of the
               buffer, looping will begin at the end of the buffer.
             </dd>
             <dt>
@@ -8019,9 +8019,9 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
                     beginning of the buffer. <span class="synchronous">A
                     RangeError exception MUST be thrown if <code>offset</code>
                     is negative.</span> If <code>offset</code> is greater than
-                    <code>loopEnd</code>, playback will begin at
-                    <code>loopEnd</code> (and immediately loop to
-                    <code>loopStart</code>). <code>offset</code> is silently
+                    <a>loopEnd</a>, playback will begin at
+                    <a>loopEnd</a> (and immediately loop to
+                    <a>loopStart</a>). <code>offset</code> is silently
                     clamped to [0, <code>duration</code>], when
                     <code>startTime</code> is reached, where
                     <code>duration</code> is the value of the

--- a/index.html
+++ b/index.html
@@ -7820,8 +7820,8 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               Indicates if the region of audio data designated by
-              <a>loopStart</a> and <a>loopEnd</a> should be played
-              continuously in a loop. The default value is <code>false</code>.
+              <a>loopStart</a> and <a>loopEnd</a> should be played continuously
+              in a loop. The default value is <code>false</code>.
             </dd>
             <dt>
               <code><dfn>loopEnd</dfn></code> of type <span class=
@@ -7829,13 +7829,12 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               An optional <a>playhead position</a> where looping should end if
-              the <a>loop</a> attribute is true. Its value is exclusive
-              of the content of the loop. Its default <code>value</code> is 0,
-              and it may usefully be set to any value between 0 and the
-              duration of the buffer. If <a>loopEnd</a> is less than or
-              equal to 0, or if <a>loopEnd</a> is greater than the
-              duration of the buffer, looping will end at the end of the
-              buffer.
+              the <a>loop</a> attribute is true. Its value is exclusive of the
+              content of the loop. Its default <code>value</code> is 0, and it
+              may usefully be set to any value between 0 and the duration of
+              the buffer. If <a>loopEnd</a> is less than or equal to 0, or if
+              <a>loopEnd</a> is greater than the duration of the buffer,
+              looping will end at the end of the buffer.
             </dd>
             <dt>
               <code><dfn>loopStart</dfn></code> of type <span class=
@@ -7845,10 +7844,10 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
               An optional <a>playhead position</a> where looping should begin
               if the <a>loop</a> attribute is true. Its default
               <code>value</code> is 0, and it may usefully be set to any value
-              between 0 and the duration of the buffer. If
-              <a>loopStart</a> is less than 0, looping will begin at 0.
-              If <a>loopStart</a> is greater than the duration of the
-              buffer, looping will begin at the end of the buffer.
+              between 0 and the duration of the buffer. If <a>loopStart</a> is
+              less than 0, looping will begin at 0. If <a>loopStart</a> is
+              greater than the duration of the buffer, looping will begin at
+              the end of the buffer.
             </dd>
             <dt>
               <code><dfn>playbackRate</dfn></code> of type <span class=
@@ -8019,10 +8018,9 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
                     beginning of the buffer. <span class="synchronous">A
                     RangeError exception MUST be thrown if <code>offset</code>
                     is negative.</span> If <code>offset</code> is greater than
-                    <a>loopEnd</a>, playback will begin at
-                    <a>loopEnd</a> (and immediately loop to
-                    <a>loopStart</a>). <code>offset</code> is silently
-                    clamped to [0, <code>duration</code>], when
+                    <a>loopEnd</a>, playback will begin at <a>loopEnd</a> (and
+                    immediately loop to <a>loopStart</a>). <code>offset</code>
+                    is silently clamped to [0, <code>duration</code>], when
                     <code>startTime</code> is reached, where
                     <code>duration</code> is the value of the
                     <code>duration</code> attribute of the


### PR DESCRIPTION
Add links to `loop`, `loopStart`, and `loopEnd` to clarify what is actually being discussed here.  The preceding section is the `AudioBufferSourceOptions` dictionary, which also as members with the same name.  Adding links makes it clear that we're referring to the attributes of the `AudioBufferSourceNode` and not the dictionary.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1402-linkify-looping-section.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:b9047c4.html)