### PR TITLE
Fix #1363: Add links to Oscillator computed frequency

### DIFF
--- a/index.html
+++ b/index.html
@@ -15895,14 +15895,14 @@ dictionary WaveShaperOptions : AudioNodeOptions {
         <p>
           Both <code>frequency</code> and <code>detune</code> are <a>a-rate</a>
           parameters, and form a <a>compound parameter</a>. They are used
-          together to determine a <em>computedFrequency</em> value:
+          together to determine a <dfn>computedOscFrequency</dfn> value:
         </p>
         <pre>
-  computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
+  computedOscFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
 </pre>
         <p>
           The OscillatorNode's instantaneous phase at each time is the definite
-          time integral of <em>computedFrequency</em>, assuming a phase angle
+          time integral of <a>computedOscFrequency</a>, assuming a phase angle
           of zero at the node's exact start time. Its <a>nominal range</a> is
           [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
         </p>
@@ -16102,8 +16102,9 @@ interface OscillatorNode : AudioScheduledSourceNode {
               A detuning value (in cents) which will offset the
               <a><code>frequency</code></a> by the given amount. Its default
               <code>value</code> is 0. This parameter is <a>a-rate</a>. It
-              forms a <a>compound parameter</a> with <code>frequency</code>.
-              Its <a>nominal range</a> is \((-\infty, \infty)\).
+              forms a <a>compound parameter</a> with <code>frequency</code> to
+              form the <a>computedOscFrequency</a>. Its <a>nominal range</a> is
+              \((-\infty, \infty)\).
             </dd>
             <dt>
               <code><dfn>frequency</dfn></code> of type <span class=
@@ -16112,9 +16113,9 @@ interface OscillatorNode : AudioScheduledSourceNode {
             <dd>
               The frequency (in Hertz) of the periodic waveform. Its default
               <code>value</code> is 440. This parameter is <a>a-rate</a>. It
-              forms a <a>compound parameter</a> with <code>detune</code>. Its
-              <a>nominal range</a> is [-<a>Nyquist frequency</a>, <a>Nyquist
-              frequency</a>].
+              forms a <a>compound parameter</a> with <code>detune</code> to
+              form the <a>computedOscFrequency</a>. Its <a>nominal range</a> is
+              [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
             </dd>
             <dt>
               <code><dfn>type</dfn></code> of type <span class=

--- a/index.html
+++ b/index.html
@@ -17776,11 +17776,11 @@ interface OscillatorNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               <p>
-              A detuning value (in cents) which will offset the
-              <a><code>frequency</code></a> by the given amount. Its default
-              <code>value</code> is 0. This parameter is <a>a-rate</a>. It
-              forms a <a>compound parameter</a> with <code>frequency</code> to
-              form the <a>computedOscFrequency</a>.
+                A detuning value (in cents) which will offset the
+                <a><code>frequency</code></a> by the given amount. Its default
+                <code>value</code> is 0. This parameter is <a>a-rate</a>. It
+                forms a <a>compound parameter</a> with <code>frequency</code>
+                to form the <a>computedOscFrequency</a>.
               </p>
               <div class="audioparam-info">
                 <table>
@@ -17844,11 +17844,11 @@ interface OscillatorNode : AudioScheduledSourceNode {
             </dt>
             <dd>
               <p>
-              The frequency (in Hertz) of the periodic waveform. Its default
-              <code>value</code> is 440. This parameter is <a>a-rate</a>. It
-              forms a <a>compound parameter</a> with <code>detune</code> to
-              form the <a>computedOscFrequency</a>. Its <a>nominal range</a> is
-              [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
+                The frequency (in Hertz) of the periodic waveform. Its default
+                <code>value</code> is 440. This parameter is <a>a-rate</a>. It
+                forms a <a>compound parameter</a> with <code>detune</code> to
+                form the <a>computedOscFrequency</a>. Its <a>nominal range</a>
+                is [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
               </p>
               <div class="audioparam-info">
                 <table>


### PR DESCRIPTION
In the definitions for Oscillator frequency and detune, add a link to computedOscFrequency to make it easy to find how these compound parameters behave together.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1363-osc-link-to-computed-freq.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:4126851.html)