### PR TITLE
Fix #1379: AudioParam rates for AudioListener

### DIFF
--- a/index.html
+++ b/index.html
@@ -11960,8 +11960,7 @@ interface AudioListener {
           <p>
             For all of the following <a>AudioParam</a>s, the <a>AudioParam</a>
             rate is specified by the <dfn>listener <a>AudioParam</a> rate</dfn>
-            which is <a>a-rate</a> when the <a data-link-for=
-            "PannerNode">panningModel</a> of any connected <a>PannerNode</a> is
+            which is <a>a-rate</a> when any connected <a>PannerNode</a> is
             <a>a-rate</a> and is <a>k-rate</a> otherwise.
           </p>
           <dl class="attributes" data-dfn-for="AudioListener" data-link-for=

--- a/index.html
+++ b/index.html
@@ -11957,6 +11957,14 @@ interface AudioListener {
           <h3>
             Attributes
           </h3>
+          <p>
+            For all of the following <a>AudioParam</a>s, the <a>AudioParam</a>
+            rate is specified by the <dfn>listener <a>AudioParam</a> rate</dfn>
+            which is <a>a-rate</a> when the <a data-link-for=
+            "PannerNode">panningModel</a> of any connected <a>PannerNode</a> is
+            "<a data-link-for="PanningModelType">equalpower</a>" and
+            <a>k-rate</a> otherwise.
+          </p>
           <dl class="attributes" data-dfn-for="AudioListener" data-link-for=
           "AudioListener">
             <dt>
@@ -12018,10 +12026,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12086,10 +12091,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12154,10 +12156,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12222,10 +12221,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12290,10 +12286,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12358,10 +12351,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12426,10 +12416,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12494,10 +12481,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>
@@ -12562,10 +12546,7 @@ interface AudioListener {
                     </td>
                     <td></td>
                     <td>
-                      <a>a-rate</a> when <a data-link-for=
-                      "PannerNode">panningModel</a> is "<a data-link-for=
-                      "PanningModelType">equalpower</a>" and <a>k-rate</a>
-                      otherwise.
+                      See <a>listener AudioParam rate</a>
                     </td>
                   </tr>
                 </table>

--- a/index.html
+++ b/index.html
@@ -11962,8 +11962,7 @@ interface AudioListener {
             rate is specified by the <dfn>listener <a>AudioParam</a> rate</dfn>
             which is <a>a-rate</a> when the <a data-link-for=
             "PannerNode">panningModel</a> of any connected <a>PannerNode</a> is
-            "<a data-link-for="PanningModelType">equalpower</a>" and
-            <a>k-rate</a> otherwise.
+            <a>a-rate</a> and is <a>k-rate</a> otherwise.
           </p>
           <dl class="attributes" data-dfn-for="AudioListener" data-link-for=
           "AudioListener">


### PR DESCRIPTION
Specify that the AudioParam rate for any AudioParam of the
AudioListener is a-rate if any connected PannerNode is a-rate.
Otherwise it is k-rate.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1379-audioparam-rates-for-listener.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:4908394.html)