### PR TITLE
Fix #1406: Add channel interpretation constraints

### DIFF
--- a/index.html
+++ b/index.html
@@ -3974,13 +3974,25 @@ interface AudioNode : EventTarget {
                 with no inputs.
               </p>
               <p>
+                In addition, some nodes have additional
+                <dfn>channelInterpretation constraints</dfn> on the possible
+                values for the channel interpretation:
+              </p>
+              <dl>
+                <dt>
+                  <a>ChannelSplitterNode</a>
+                </dt>
+                <dd>
+                  The channel intepretation can not be changed from
+                  "<a data-link-for="ChannelInterpretation">discrete</a>" and a
+                  <span class="synchronous"><code>InvalidStateError</code>
+                  exception MUST be thrown for any attempt to change the
+                  value.</span>
+                </dd>
+              </dl>
+              <p>
                 See the <a href="#channel-up-mixing-and-down-mixing"></a>
                 section for more information on this attribute.
-              </p>
-              <p>
-                <span class="synchronous">When attempting to this attribute on
-                a <a>ChannelSplitterNode</a>, an <code>InvalidStateError</code>
-                MUST be thrown.</span>
               </p>
             </dd>
             <dt>
@@ -14317,7 +14329,9 @@ dictionary AnalyserOptions : AudioNodeOptions {
               <td>
                 "<a data-link-for="channelInterpretation">discrete</a>"
               </td>
-              <td></td>
+              <td>
+                Has <a>channelInterpretation constraints</a>
+              </td>
             </tr>
             <tr>
               <td>


### PR DESCRIPTION
Add a definition for channel interpretation constraints and use it in ChannelSplitterNode.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1406-channel-interp-constraint.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:d1ebb73.html)