### PR TITLE
Fix #1411: Adjust table styling for node and param tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,7 @@
     div.node-info > table > tbody > tr > td {
       padding: 0.2em 0.6em;
       min-width: 150px;
+      border-top: 1px solid #ddd                      
     }
     div.node-info > table > tbody > tr > th {
       line-height: 2em;
@@ -234,6 +235,7 @@
     div.audioparam-info > table > tbody > tr > td {
       padding: 0.2em 0.6em;
       min-width: 150px;
+      border-top: 1px solid #ddd                      
     }
     div.audioparam-info > table > tbody > tr > th {
       line-height: 2em;


### PR DESCRIPTION
Add a faint line to separate each row of the node properties table and
the AudioParam properties tables.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1411-adjust-table-styles.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:525f99e.html)