### PR TITLE
Fix #1396: Add AudioWorkletNode default properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -9423,6 +9423,75 @@ interface AudioWorkletGlobalScope : WorkletGlobalScope {
             node can be connected with other built-in <a>AudioNode</a>s to form
             an audio graph.
           </p>
+          <div class="node-info">
+            <table>
+              <tr>
+                <th>
+                  Property
+                </th>
+                <th>
+                  Value
+                </th>
+                <th>
+                  Notes
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">numberOfInputs</a>
+                </td>
+                <td>
+                  1
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">numberOfOutputs</a>
+                </td>
+                <td>
+                  1
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">channelCount</a>
+                </td>
+                <td>
+                  2
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">channelCountMode</a>
+                </td>
+                <td>
+                  "<a data-link-for="channelCountMode">max</a>"
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">channelInterpretation</a>
+                </td>
+                <td>
+                  "<a data-link-for="channelInterpretation">speakers</a>"
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a>tail-time</a> reference
+                </td>
+                <td></td>
+                <td>
+                  Any <a>tail-time</a> is handled by the node itself
+                </td>
+              </tr>
+            </table>
+          </div>
           <p>
             Every <a>AudioWorkletNode</a> has an associated <dfn>processor
             reference</dfn>, initially null, which refers to the


### PR DESCRIPTION
Add node properties table specifying the default values for the node.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1396-audioworklet-node-default-properties.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/ac422a9...rtoy:da2e469.html)