### PR TITLE
Fix #1404: Fix link to mixing equations

### DIFF
--- a/index.html
+++ b/index.html
@@ -3706,10 +3706,10 @@ enum ChannelInterpretation {
               <dfn>speakers</dfn>
             </td>
             <td>
-              use <a href="#ChannelLayouts">up-down-mix equations for
-              mono/stereo/quad/5.1</a>. In cases where the number of channels
-              do not match any of these basic speaker layouts, revert to
-              "discrete".
+              use <a href="#UpMix-sub">up-mix equations</a> or <a href=
+              "#down-mix">down-mix equations</a>. In cases where the number of
+              channels do not match any of these basic speaker layouts, revert
+              to "<a data-link-for="ChannelInterpretation">discrete</a>".
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
In the description of the ChannelIntepretation "speakers", link to the
individual sections for the up and down mixing equations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1404-fix-link-to-mixing-eqs.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/401a0d8...rtoy:9ac7cfc.html)