### PR TITLE
Fix #1416: Fix typos in PeriodicWave Constructor

### DIFF
--- a/index.html
+++ b/index.html
@@ -18250,7 +18250,7 @@ interface PeriodicWave {
                 <li>If <var>options</var> has not been passed in, let
                 <var>[[\real]]</var> and <var>[[\imag]]</var> be two internal
                 slots of type <code>Float32Array</code> and length 2. Set the
-                second element of the <var>[[\imag]]</var> array be 1.
+                second element of the <var>[[\imag]]</var> array to 1.
                   <div class="note">
                     When setting this <a>PeriodicWave</a> on an
                     <a>OscillatorNode</a>, this is equivalent to using the
@@ -18259,15 +18259,15 @@ interface PeriodicWave {
                 </li>
                 <li>Otherwise, let <var>[[\real]]</var> and
                 <var>[[\imag]]</var> be two internal slots of type
-                <code>Float32Array</code>, of length both equal to the maximum
-                length of the <var>real</var> and <var>imag</var> of the
-                attributes of the <a>PeriodicWaveOptions</a> passed in.
-                  <a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">
+                <code>Float32Array</code>, both of length equal to the maximum
+                length of the <var>real</var> and <var>imag</var> attributes of
+                the <a>PeriodicWaveOptions</a> passed in. <a href=
+                "https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">
                   Make a copy</a> of those arrays into their respective
                   internal slots.
                 </li>
                 <li>Let [[\normalize]] be an internal slot of the
-                <a>PeriodicWave</a> the is initialized to the inverse of the
+                <a>PeriodicWave</a> that is initialized to the inverse of the
                 <var>disableNormalization</var> attribute of the
                 <a>PeriodicWaveConstraints</a> on the
                 <a>PeriodicWaveOptions</a>.


### PR DESCRIPTION
Minor typo and phrasing fixes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1416-fix-typos-periodic-wave-maker.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/50e15e1...rtoy:f9099cd.html)