### PR TITLE
Fix #1419: Fix up #dom links introduced in #1287

### DIFF
--- a/index.html
+++ b/index.html
@@ -11719,20 +11719,19 @@ interface PannerNode : AudioNode {
             <dd>
               <p>
                 This method is DEPRECATED. It is equivalent to setting
-                <code>orientationX.value</code>,
-                <code>orientationY.value</code>, and
-                <code>orientationZ.value</code> attribute directly, with the
-                <code>x</code>, <code>y</code> and <code>z</code> parameters,
-                respectively.
+                <a>orientationX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>orientationY</a>.<a data-link-for="AudioParam">value</a>,
+                and <a>orientationZ</a>.<a data-link-for="AudioParam">value</a>
+                attribute directly, with the <code>x</code>, <code>y</code> and
+                <code>z</code> parameters, respectively.
               </p>
               <p>
-                Consequently, if any of the <a data-link-for=
-                "AudioPanner">orientationX</a>, <a data-link-for=
-                "AudioPanner">orientationY</a>, and <a data-link-for=
-                "AudioPanner">orientationZ</a> <a>AudioParam</a>s have an
-                automation curve set using <a data-link-for=
-                "AudioParam">setValueCurveAtTime</a>() at the time this method
-                is called, a <code>NotSupportedError</code> MUST be thrown.
+                Consequently, if any of the <a>orientationX</a>,
+                <a>orientationY</a>, and <a>orientationZ</a> <a>AudioParam</a>s
+                have an automation curve set using <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
+                this method is called, a <code>NotSupportedError</code> MUST be
+                thrown.
               </p>
               <p>
                 Describes which direction the audio source is pointing in the
@@ -11821,19 +11820,20 @@ interface PannerNode : AudioNode {
             </dt>
             <dd>
               <p>
-                This method is DEPRECATED. It is equivalent to setting <a href=
-                "#dom-pannernode-positionx">positionX.value</a>, <a href=
-                "#dom-pannernode-positiony">positionY.value</a>, and <a href=
-                "#dom-pannernode-positionz">positionZ.value</a> attribute
-                directly with the <a>x</a>, <a>y</a> and <a>z</a> parameters,
-                respectively.
+                This method is DEPRECATED. It is equivalent to setting
+                <a>positionX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>positionY</a>.<a data-link-for="AudioParam">value</a>, and
+                <a>positionZ</a>.<a data-link-for="AudioParam">value</a>
+                attribute directly with the <code>x</code>, <code>y</code> and
+                <code>z</code> parameters, respectively.
               </p>
               <p>
                 Consequently, if any of the <a>positionX</a>, <a>positionY</a>,
                 and <a>positionZ</a> <a>AudioParam</a>s have an automation
                 curve set using <a data-link-for=
-                "AudioParam">setValueCurveAtTime</a>() at the time this method
-                is called, a <code>NotSupportedError</code> MUST be thrown.
+                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
+                this method is called, a <code>NotSupportedError</code> MUST be
+                thrown.
               </p>
               <p>
                 Sets the position of the audio source relative to the
@@ -12758,25 +12758,25 @@ interface AudioListener {
             </dt>
             <dd>
               <p>
-                This method is DEPRECATED. It is equivalent to setting <a href=
-                "#dom-audiolistener-forwardx">forwardX.value</a>, <a href=
-                "#dom-audiolistener-forwardy">forwardY.value</a>, <a href=
-                "#dom-audiolistener-forwardz">forwardZ.value</a>, <a href=
-                "#dom-audiolistener-upx">upX.value</a>, <a href=
-                "#dom-audiolistener-upx">upY.value</a>, and <a href=
-                "#dom-audiolistener-upz">upZ.value</a> directly with the given
-                <code>x</code>, <code>y</code>, <code>z</code>,
+                This method is DEPRECATED. It is equivalent to setting
+                <a>forwardX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>forwardY</a>.<a data-link-for="AudioParam">value</a>,
+                <a>forwardZ</a>.<a data-link-for="AudioParam">value</a>,
+                <a>upX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>upY</a>.<a data-link-for="AudioParam">value</a>, and
+                <a>upZ</a>.<a data-link-for="AudioParam">value</a> directly
+                with the given <code>x</code>, <code>y</code>, <code>z</code>,
                 <code>xUp</code>, <code>yUp</code>, and <code>zUp</code>
                 values, respectively.
               </p>
               <p>
-                Consequently, if any of the <a>orientationX</a>,
-                <a>orientationY</a>, <a>orientationZ</a>, <a>upX</a>,
-                <a>upY</a> and <a>upZ</a> <a>AudioParam</a>s have an automation
-                curve set using <a href=
-                "#dom-audioparam-setvaluecurveattime">setValueCurveAtTime()</a>
-                at the time this method is called, a
-                <code>NotSupportedError</code> MUST be thrown.
+                Consequently, if any of the <a>forwardX</a>, <a>forwardY</a>,
+                <a>forwardZ</a>, <a>upX</a>, <a>upY</a> and <a>upZ</a>
+                <a>AudioParam</a>s have an automation curve set using
+                <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
+                this method is called, a <code>NotSupportedError</code> MUST be
+                thrown.
               </p>
               <p>
                 Describes which direction the listener is pointing in the 3D
@@ -12917,10 +12917,10 @@ interface AudioListener {
             </dt>
             <dd>
               <p>
-                This method is DEPRECATED. It is equivalent to setting <a href=
-                "#dom-AudioListener-positionx">positionX.value</a>, <a href=
-                "#dom-AudioListener-positiony">positionY.value</a>, and
-                <a href="#dom-AudioListener-positionz">positionZ.value</a>
+                This method is DEPRECATED. It is equivalent to setting
+                <a>positionX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>positionY</a>.<a data-link-for="AudioParam">value</a>, and
+                <a>positionZ</a>.<a data-link-for="AudioParam">value</a>
                 directly with the given <code>x</code>, <code>y</code>, and
                 <code>z</code> values, respectively.
               </p>
@@ -12928,9 +12928,10 @@ interface AudioListener {
                 Consequently, any of the <a>positionX</a>, <a>positionY</a>,
                 and <a>positionZ</a> <a>AudioParam</a>s for this
                 <a>AudioListenerNode</a> have an automation curve set using
-                <a data-link-for="AudioParam">setValueCurveAtTime</a>() at the
-                time this method is called, a <code>NotSupportedError</code>
-                MUST be thrown.
+                <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
+                this method is called, a <code>NotSupportedError</code> MUST be
+                thrown.
               </p>
               <p>
                 Sets the position of the listener in a 3D cartesian coordinate


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1419-fix-dom-links.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/51e6ec3...rtoy:f9a4666.html)