### PR TITLE
Fetch MathJax from cdnjs

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,22 +9,22 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class=
     'remove'></script>
     <link rel="preload" href=
-    "https://www.w3.org/scripts/MathJax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
     as="script">
     <link rel="preload" href=
-    "https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/jax.js?rev=2.6.1"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/jax/output/HTML-CSS/jax.js?rev=2.6.1"
     as="script">
     <link rel="preload" href=
-    "https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/fonts/STIX/fontdata.js?rev=2.6.1"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/jax/output/HTML-CSS/fonts/STIX/fontdata.js?rev=2.6.1"
     as="script">
     <link rel="preload" href=
-    "https://www.w3.org/scripts/MathJax/2.6.1/config/TeX-AMS-MML_HTMLorMML.js?rev=2.6.1"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/config/TeX-AMS-MML_HTMLorMML.js?rev=2.6.1"
     as="script">
     <link rel="preload" href=
-    "https://www.w3.org/scripts/MathJax/2.6.1/jax/element/mml/optable/BasicLatin.js?rev=2.6.1"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/jax/element/mml/optable/BasicLatin.js?rev=2.6.1"
     as="script">
     <link rel="preload" href=
-    "https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/autoload/mtable.js?rev=2.6.1"
+    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/jax/output/HTML-CSS/autoload/mtable.js?rev=2.6.1"
     as="script">
     <script class='remove'>
     var respecConfig = {
@@ -122,7 +122,7 @@
       }
       new Promise(function (resolve, reject) {
         var mathjax = document.createElement('script');
-        var url = "https://www.w3.org/scripts/MathJax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+        var url = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
         // Safari doesn't (yet) support load event on scripts so we have to poll. So 😢.
         var id = setInterval(function () {
           if (window.MathJax) {


### PR DESCRIPTION
Looking for some improvements to make the page loads faster. 

I found that fetching assets from W3.org is really slow (from Singapore at least):
![image](https://user-images.githubusercontent.com/3654180/31582657-6e2f3fd0-b1bc-11e7-8f3c-d7820f012e4d.png)

If we use cdnjs instead:

![image](https://user-images.githubusercontent.com/3654180/31582664-94729390-b1bc-11e7-8e9b-1742515c4556.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/pioug/web-audio-api/gh-pages.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/5cd4fbf...pioug:870598b.html)