### PR TITLE
Fix #973: Reorder sections alphabetically, mostly

### DIFF
--- a/index.html
+++ b/index.html
@@ -9820,1221 +9820,6 @@ dictionary AudioProcessingEventInit : EventInit {
         </section>
       </section>
       <section>
-        <h2 id="AudioWorklet">
-          The <dfn>AudioWorklet</dfn> Interface
-        </h2>
-        <section>
-          <h2 id="AudioWorklet-concepts">
-            Concepts
-          </h2>
-          <p>
-            The <a>AudioWorklet</a> object allows developers to supply scripts
-            (such as JavaScript or WebAssembly code) to process audio on the
-            <a>rendering thread</a>, supporting custom <a>AudioNode</a>s. This
-            processing mechanism ensures the synchronous execution of the
-            script code with other built-in <a>AudioNode</a>s in the audio
-            graph.
-          </p>
-          <p>
-            An associated pair of objects MUST be defined in order to realize
-            this mechanism: <a>AudioWorkletNode</a> and
-            <a>AudioWorkletProcessor</a>. The former represents the interface
-            for the main global scope similar to other <a>AudioNode</a>
-            objects, and the latter implements the internal audio processing
-            within a special scope named <a>AudioWorkletGlobalScope</a>.
-          </p>
-          <figure>
-            <img alt="AudioWorklet concept" src=
-            "images/audioworklet-concept.png" width="756" height="144">
-            <figcaption>
-              <a><code>AudioWorkletNode</code></a> and
-              <a><code>AudioWorkletProcessor</code></a>
-            </figcaption>
-          </figure>
-          <p>
-            Importing a script via the <a href=
-            "https://drafts.css-houdini.org/worklets/#dom-worklet-import">import(moduleUrl)</a>
-            method registers class definitions of <a>AudioWorkletProcessor</a>
-            under the <a>AudioWorkletGlobalScope</a>. There are two internal
-            storage areas for the imported class definitions and the active
-            instances created from the definition.
-          </p>
-          <dl>
-            <dt>
-              <dfn>node name to processor definition map</dfn>
-            </dt>
-            <dd>
-              Belongs to <a>AudioWorkletGlobalScope</a>. This map associates a
-              string key to the corresponding <a>AudioWorkletProcessor</a>
-              definition. Initially this map is empty and becomes populated
-              when <a data-link-for=
-              "AudioWorkletGlobalScope">registerProcessor</a> method is called.
-            </dd>
-            <dt>
-              <dfn>node name to parameter descriptor map</dfn>
-            </dt>
-            <dd>
-              Belongs to <a>BaseAudioContext</a>. This map contains an
-              identical set of string keys from <a>node name to processor
-              definition map</a> that are associated with the matching
-              <a>parameterDescriptors</a> values. This internal storage is
-              populated when a promise from <a href=
-              "https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule">addModule()</a>
-              on <a data-link-for="Window">audioWorklet</a> gets resolved.
-            </dd>
-          </dl>
-          <pre class="example" title=
-          "Registering an AudioWorkletProcessor class definition">
-// bypass.js script file, AudioWorkletGlobalScope
-registerProcessor("Bypass", class extends AudioWorkletProcessor {
-  process (inputs, outputs) {
-    // Single input, single channel.
-    var input = inputs[0], output = outputs[0];
-    output[0].set(input[0]);
-  }
-});
-</pre>
-          <pre class="example" title=
-          "Importing a script and creating AudioWorkletNode">
-// The main global scope
-window.audioWorklet.addModule("bypass.js").then(function () {
-  var context = new AudioContext();
-  var bypass = new AudioWorkletNode(context, "Bypass");
-});
-</pre>
-          <p>
-            At the instantiation of <a>AudioWorkletNode</a> in the main global
-            scope, the counterpart <a>AudioWorkletProcessor</a> will also be
-            created in <a>AudioWorkletGlobalScope</a>. These two objects
-            communicate via the asynchronous message passing described in the
-            <a href="#processing-model">processing model</a> section.
-          </p>
-        </section>
-        <pre class="idl">
-partial interface Window {
-    [SameObject]
-    readonly        attribute Worklet audioWorklet;
-};
-        </pre>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="Window" data-link-for="Window">
-            <dt>
-              <code><dfn>audioWorklet</dfn></code> of type <span class=
-              "idlAttrType"><a><code>Worklet</code></a></span> readonly
-            </dt>
-            <dd>
-              The <code>audioWorklet</code> attributes allows access to the
-              <code>Worklet</code> object that can import a script containing
-              <a><code>AudioWorkletProcessor</code></a> class definitions via
-              the algorithm defined by [[!worklets-1]].
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2 id="AudioWorkletGlobalScope">
-            The <dfn>AudioWorkletGlobalScope</dfn> Interface
-          </h2>
-          <p>
-            This special execution context is designed to enable the
-            generation, processing, and analysis of audio data directly using a
-            script in the audio <a>rendering thread</a>. The user-supplied
-            script code is evaluated in this scope to define one or more
-            <a>AudioWorkletProcessor</a> subclasses, which in turn are used to
-            instantiate <a>AudioWorkletProcessor</a>s, in a 1:1 association
-            with <a>AudioWorkletNode</a>s in the main scope.
-          </p>
-          <p>
-            At least one <a>AudioWorkletGlobalScope</a> exists for each
-            <a>AudioContext</a> that contains one or more
-            <a>AudioWorkletNode</a>s. The running of imported scripts is
-            performed by the UA as defined in [[!worklets-1]], in such a way
-            that all scripts are applied consistently to every global scope,
-            and all scopes thus exhibit identical behavior. Beyond these
-            guarantees, the creation of global scopes is transparent to the
-            author and cannot be observed from the main window scope.
-          </p>
-          <p>
-            <a>AudioWorkletGlobalScope</a> has a <a>node name to processor
-            definition map</a>. This map stores definitions of
-            <a>AudioWorkletProcessor</a> with the associated string key.
-            Initially it is empty and populated when
-            <code>registerProcessor</code> method is called, but this storage
-            is internal and is not directly exposed to the user.
-          </p>
-          <div class="note">
-            The <a>AudioWorkletGlobalScope</a> may also contain any other data
-            and code to be shared by these instances. As an example, multiple
-            processors might share an ArrayBuffer defining a wavetable or an
-            impulse response.
-          </div>
-          <div class="note">
-            Every <a>AudioWorkletGlobalScope</a> is associated with a single
-            <a>BaseAudioContext</a>, and with a single audio rendering thread
-            for that context. This prevents data races from occurring in global
-            scope code running within concurrent threads.
-          </div>
-          <pre class="idl">
-[Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
-interface AudioWorkletGlobalScope : WorkletGlobalScope {
-    void registerProcessor (DOMString name, VoidFunction processorCtor);
-    readonly attribute double currentTime;
-    readonly attribute float  sampleRate;
-};
-          </pre>
-          <section>
-            <h3>
-              Attributes
-            </h3>
-            <dl class="attributes" data-dfn-for="AudioWorkletGlobalScope"
-            data-link-for="AudioWorkletGlobalScope">
-              <dt>
-                <code><dfn>currentTime</dfn></code> of type <span class=
-                "idlAttrType"><code>double</code></span>, readonly
-              </dt>
-              <dd>
-                The context time of the block of audio being processed. By
-                definition this will be equal to the value of
-                <a>BaseAudioContext</a>'s <a data-link-for=
-                "BaseAudioContext">currentTime</a> attribute that was most
-                recently observable in the <a>control thread</a>.
-              </dd>
-              <dt>
-                <code><dfn>sampleRate</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, readonly
-              </dt>
-              <dd>
-                The sample rate of the associated <a>BaseAudioContext</a>.
-              </dd>
-            </dl>
-          </section>
-          <section>
-            <h3>
-              Methods
-            </h3>
-            <dl class="methods" data-dfn-for="AudioWorkletGlobalScope"
-            data-link-for="AudioWorkletGlobalScope">
-              <dt>
-                <code><dfn>registerProcessor</dfn></code>
-              </dt>
-              <dd>
-                <p>
-                  Registers a class definition derived from
-                  <a>AudioWorkletProcessor</a>.
-                </p>
-                <p>
-                  When the <a><code>registerProcessor(<em>name</em>,
-                  <em>processorConstructor</em>)</code></a> method is called,
-                  the user agent MUST run the following steps:
-                </p>
-                <ol>
-                  <li>If the <code><em>name</em></code> is the empty string,
-                  <span class="synchronous">throw a
-                  <code>NotSupportedError</code> exception and abort these
-                  steps because the empty string is not a valid key</span>.
-                  </li>
-                  <li>If the <code><em>name</em></code> exists as a key in the
-                  <a>node name to processor definition map</a>, <span class=
-                  "synchronous">throw a <code>NotSupportedError</code>
-                  exception and abort these steps</span> because registering a
-                  definition with a duplicated key is not allowed.
-                  </li>
-                  <li>If the result of <code><a href=
-                  "http://www.ecma-international.org/ecma-262/6.0/#sec-isconstructor">
-                    IsConstructor</a>(argument=<em>processorConstructor</em>)</code>
-                    is false, <span class="synchronous">throw a
-                    <code>TypeError</code> and abort these steps</span>.
-                  </li>
-                  <li>Let <code><em>prototype</em></code> be the result of
-                  <code><a href=
-                  "http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
-                    Get</a>(O=<em>processorConstructor</em>,
-                    P="prototype")</code>.
-                  </li>
-                  <li>If the result of <code><a href=
-                  "http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">
-                    Type</a>(argument=<em>prototype</em>)</code> is not
-                    <code>Object</code>, <span class="synchronous">throw a
-                    <code>TypeError</code> and abort all these steps</span>.
-                  </li>
-                  <li>If the result of <code><a href=
-                  "http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
-                    IsCallable</a>(argument=Get(O=<em>prototype</em>,
-                    P="process"))</code> is false, <span class=
-                    "synchronous">throw a <code>TypeError</code> and abort
-                    these steps</span>.
-                  </li>
-                  <li>If the result of <code><a href=
-                  "http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
-                    Get</a>(O=<em>processorConstructor</em>,
-                    P="parameterDescriptors")</code> is not an array or
-                    <code>undefined</code>, <span class="synchronous">throw a
-                    <code>TypeError</code> and abort these steps</span>.
-                  </li>
-                  <li>Let <em>definition</em> be a new
-                  <a>AudioWorkletProcessor</a> definition with:
-                    <ul>
-                      <li>node name being <em>name</em>
-                      </li>
-                      <li>processor class constructor being
-                      <em>processorConstructor</em>
-                      </li>
-                    </ul>
-                  </li>
-                  <li>d the key-value pair (<em>name</em> -
-                  <em>definition</em>) to the <a>node name to processor
-                  definition map</a> of the associated
-                  <a>AudioWorkletGlobalScope</a>.
-                  </li>
-                </ol>
-                <p class="note">
-                  The class constructor should only be looked up once, thus it
-                  does not have the opportunity to dynamically change its
-                  definition.
-                </p>
-                <table class="parameters">
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Type
-                    </th>
-                    <th>
-                      Nullable
-                    </th>
-                    <th>
-                      Optional
-                    </th>
-                    <th>
-                      Description
-                    </th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">
-                      name
-                    </td>
-                    <td class="prmType">
-                      <a><code>DOMString</code></a>
-                    </td>
-                    <td class="prmNullFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmOptFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmDesc">
-                      A string key that represents a class definition to be
-                      registered. This key is used to look up the constructor
-                      of <a>AudioWorkletProcessor</a> during construction of an
-                      <a>AudioWorkletNode</a>.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">
-                      processorCtr
-                    </td>
-                    <td class="prmType">
-                      <a><code>VoidFunction</code></a>
-                    </td>
-                    <td class="prmNullFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmOptFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmDesc">
-                      A class definition extended from
-                      <a>AudioWorkletProcessor</a>.
-                    </td>
-                  </tr>
-                </table>
-                <div>
-                  <em>Return type:</em> <code>void</code>
-                </div>
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h2 id="AudioWorkletNode-section">
-            The AudioWorkletNode Interface
-          </h2>
-          <p>
-            This interface represents a user-defined <a>AudioNode</a> which
-            lives on the <a>control thread</a>. The user can create an
-            <a>AudioWorkletNode</a> from an <a>BaseAudioContext</a>, and such a
-            node can be connected with other built-in <a>AudioNode</a>s to form
-            an audio graph.
-          </p>
-          <div class="node-info">
-            <table>
-              <tr>
-                <th>
-                  Property
-                </th>
-                <th>
-                  Value
-                </th>
-                <th>
-                  Notes
-                </th>
-              </tr>
-              <tr>
-                <td>
-                  <a data-link-for="AudioNode">numberOfInputs</a>
-                </td>
-                <td>
-                  1
-                </td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>
-                  <a data-link-for="AudioNode">numberOfOutputs</a>
-                </td>
-                <td>
-                  1
-                </td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>
-                  <a data-link-for="AudioNode">channelCount</a>
-                </td>
-                <td>
-                  2
-                </td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>
-                  <a data-link-for="AudioNode">channelCountMode</a>
-                </td>
-                <td>
-                  "<a data-link-for="channelCountMode">max</a>"
-                </td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>
-                  <a data-link-for="AudioNode">channelInterpretation</a>
-                </td>
-                <td>
-                  "<a data-link-for="channelInterpretation">speakers</a>"
-                </td>
-                <td></td>
-              </tr>
-              <tr>
-                <td>
-                  <a>tail-time</a> reference
-                </td>
-                <td></td>
-                <td>
-                  Any <a>tail-time</a> is handled by the node itself
-                </td>
-              </tr>
-            </table>
-          </div>
-          <p>
-            Every <a>AudioWorkletNode</a> has an associated <dfn>processor
-            reference</dfn>, initially null, which refers to the
-            <a>AudioWorkletProcessor</a> handling the processing for this node.
-          </p>
-          <p>
-            Every <a>AudioWorkletProcessor</a> has an associated <dfn>active
-            source</dfn> flag, initially <code>true</code>. This flag causes
-            the node to be retained in memory and perform audio processing in
-            the absence of any connected inputs.
-          </p>
-          <pre class="idl">
-[Exposed=Window]
-interface AudioParamMap {
-    readonly maplike&lt;DOMString, AudioParam&gt;;
-};
-          </pre>
-          <p>
-            This interface has "entries", "forEach", "get", "has", "keys",
-            "values", @@iterator methods and a "size" getter brought by
-            <code>readonly maplike</code>.
-          </p>
-          <pre class="idl">
-enum AudioWorkletProcessorState {
-    "pending",
-    "running",
-    "stopped",
-    "error"
-};
-          </pre>
-          <table class="simple" data-dfn-for="AudioWorkletProcessorState"
-          data-link-for="AudioWorkletProcessorState">
-            <tr>
-              <th colspan="2">
-                Enumeration description
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <dfn>pending</dfn>
-              </td>
-              <td>
-                The construction of associated processor has not been
-                completed. In this state, no audio processing can happen and
-                all messages to the processor will be queued.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <dfn>running</dfn>
-              </td>
-              <td>
-                Indicates that the <a>active source</a> flag on the
-                corresponding processor is <code>true</code>.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <dfn>stopped</dfn>
-              </td>
-              <td>
-                Indicates that the <a>active source</a> flag on the
-                corresponding processor is <code>false</code>.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <dfn>error</dfn>
-              </td>
-              <td>
-                When an exception is thrown from the processor's
-                <code>constructor</code>, <code>process</code> method, or any
-                user-defined class method throws an exception. Note that once
-                an <a>AudioWorkletNode</a> reaches to this state, the processor
-                will output silence throughout its lifetime.
-              </td>
-            </tr>
-          </table>
-          <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional AudioWorkletOptions options)]
-interface AudioWorkletNode : AudioNode {
-    readonly        attribute AudioParamMap              parameters;
-    readonly        attribute MessagePort                port;
-    readonly        attribute AudioWorkletProcessorState processorState;
-                    attribute EventHandler               onprocessorstatechange;
-};
-          </pre>
-          <section>
-            <h3>
-              Constructors
-            </h3>
-            <dl class="methods" data-dfn-for="AudioWorkletNode" data-link-for=
-            "AudioWorkletNode">
-              <dt>
-                <code><dfn>AudioWorkletNode</dfn></code>
-              </dt>
-              <dd>
-                <p>
-                  Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
-                  <a href="#audionode-constructor-init">Initialize</a>
-                  <var>node</var>. Perform the <a href=
-                  "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">
-                  construction procedure</a> of an
-                  <a><code>AudioWorkletNode</code></a> and the corresponding
-                  <a><code>AudioWorkletProcessor</code></a> object. Return
-                  <var>node</var>.
-                </p>
-                <table class="parameters">
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Type
-                    </th>
-                    <th>
-                      Nullable
-                    </th>
-                    <th>
-                      Optional
-                    </th>
-                    <th>
-                      Description
-                    </th>
-                  </tr>
-                  <tr>
-                    <td class="prmName">
-                      context
-                    </td>
-                    <td class="prmType">
-                      <a><code>BaseAudioContext</code></a>
-                    </td>
-                    <td class="prmNullFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmOptFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmDesc">
-                      The <a>BaseAudioContext</a> this new
-                      <a>AudioWorkletNode</a> will be <a href=
-                      "#associated">associated</a> with.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="prmName">
-                      options
-                    </td>
-                    <td class="prmType">
-                      <a><code>AudioWorkletOptions</code></a>
-                    </td>
-                    <td class="prmNullFalse">
-                      <span role="img" aria-label="False">✘</span>
-                    </td>
-                    <td class="prmOptTrue">
-                      <span role="img" aria-label="True">✔</span>
-                    </td>
-                    <td class="prmDesc">
-                      Optional initial parameters value for this
-                      <a>AudioWorkletNode</a>.
-                    </td>
-                  </tr>
-                </table>
-              </dd>
-            </dl>
-          </section>
-          <section>
-            <h3>
-              Attributes
-            </h3>
-            <dl class="attributes" data-dfn-for="AudioWorkletNode"
-            data-link-for="AudioWorkletNode">
-              <dt>
-                <code><dfn>onprocessorstatechange</dfn></code> of type
-                <span class=
-                "idlAttrType"><a><code>EventHandler</code></a></span>
-              </dt>
-              <dd>
-                Any state change on the processor will queue a task on the
-                control thread to fire <a>onprocessorstatechange</a> event to
-                the node.
-              </dd>
-              <dt>
-                <code><dfn>parameters</dfn></code> of type <span class=
-                "idlAttrType"><a><code>AudioParamMap</code></a></span>,
-                readonly
-              </dt>
-              <dd>
-                The <code>parameters</code> attribute is a collection of
-                <a>AudioParam</a> objects with associated names. This maplike
-                object is populated from a list of <a>AudioParamDescriptor</a>s
-                in the <a>AudioWorkletProcessor</a> class definition at the
-                instantiation.
-              </dd>
-              <dt>
-                <code><dfn>port</dfn></code> of type <span class=
-                "idlAttrType"><a><code>MessagePort</code></a></span>, readonly
-              </dt>
-              <dd>
-                Every <a>AudioWorkletNode</a> has an associated
-                <code>port</code> which is a <a href=
-                "https://html.spec.whatwg.org/multipage/comms.html#message-ports">
-                MessagePort</a>. It is connected to the port on the
-                corresponding <a>AudioWorkletProcessor</a> object allowing
-                bidirectional communication between a pair of
-                <a>AudioWorkletNode</a> and <a>AudioWorkletProcessor</a>.
-              </dd>
-              <dt>
-                <code><dfn>processorState</dfn></code> of type <span class=
-                "idlAttrType"><a><code>AudioWorkletProcessorState</code></a></span>,
-                readonly
-              </dt>
-              <dd>
-                Indicates the state of the associated processor. The
-                propagation from the actual processor's <a>active source</a>
-                flag to this property is done by queueing a task.
-              </dd>
-            </dl>
-          </section>
-          <section>
-            <h2 id="AudioWorkletNodeOptions">
-              <dfn>AudioWorkletNodeOptions</dfn>
-            </h2>
-            <p>
-              The <code>AudioWorkletNodeOptions</code> dictionary can be used
-              for the custom initialization of <a><code>AudioNode</code></a>
-              attributes in the <a><code>AudioWorkletNode</code></a>
-              constructor. Entries in this dictionary whose names correspond to
-              <a><code>AudioParam</code></a>s in the class definition of an
-              <a><code>AudioWorkletProcessor</code></a> are used to initialize
-              the parameter values upon the creation of a node.
-            </p>
-            <pre class="idl">
-dictionary AudioWorkletNodeOptions : AudioNodeOptions {
-             unsigned long             numberOfInputs = 1;
-             unsigned long             numberOfOutputs = 1;
-             sequence&lt;unsigned long&gt;    outputChannelCount;
-             record&lt;DOMString, double&gt;  parameterData;
-};
-            </pre>
-            <section>
-              <h3>
-                Dictionary <a>AudioWorkletNodeOptions</a> Members
-              </h3>
-              <dl class="attributes" data-dfn-for="AudioWorkletNodeOptions"
-              data-link-for="AudioWorkletNodeOptions">
-                <dt>
-                  <code><dfn>numberOfInputs</dfn></code> of type <span class=
-                  "idlAttrType"><code>unsigned long</code></span>, defaulting
-                  to 1
-                </dt>
-                <dd>
-                  This is used to initialize the value of <a>AudioNode</a>
-                  <a data-link-for="AudioNode">numberOfInputs</a> attribute.
-                </dd>
-                <dt>
-                  <code><dfn>numberOfOutputs</dfn></code> of type <span class=
-                  "idlAttrType"><code>unsigned long</code></span>, defaulting
-                  to 1
-                </dt>
-                <dd>
-                  This is used to initialize the value of <a>AudioNode</a>
-                  <a data-link-for="AudioNode">numberOfOutputs</a> attribute.
-                </dd>
-                <dt>
-                  <code><dfn>outputChannelCount</dfn></code> of type
-                  <span class="idlAttrType"><code>sequence&lt;unsigned
-                  long&gt;</code></span>
-                </dt>
-                <dd>
-                  This array is used to configure the number of channels in
-                  each output. For example, <code>outputChannelCount: [n,
-                  m]</code> specifies the number of channels in the first
-                  output to <code>n</code> and the second output to
-                  <code>m</code> respectively. <code>IndexSizeError</code> MUST
-                  be thrown if the length of sequence does not match
-                  <a data-link-for=
-                  "AudioWorkletNodeOptions">numberOfOutputs</a>. A
-                  <code>NotSupportedError</code> exception MUST be thrown if a
-                  channel count is not in the valid range of AudioNode's
-                  <a data-link-for="AudioNode">channelCount</a>.
-                </dd>
-                <dt>
-                  <code><dfn>parameterData</dfn></code> of type <span class=
-                  "idlAttrType"><code>record&lt;DOMString,
-                  double&gt;</code></span>
-                </dt>
-                <dd>
-                  This is a list of user-defined key-value pairs that are used
-                  to initialize <a>AudioParam</a> values in
-                  <a>AudioWorkletNode</a>. If the string key of an entry in the
-                  list does not match any name of <a>AudioParam</a> objects in
-                  the node, it is ignored.
-                </dd>
-              </dl>
-            </section>
-            <section>
-              <h3>
-                Configuring Channels with <a>AudioWorkletNodeOptions</a>
-              </h3>
-              <p>
-                With a combination of <a data-link-for=
-                "AudioWorkletNodeOptions">numberOfInputs</a>, <a data-link-for=
-                "AudioWorkletNodeOptions">numberOfOutputs</a> and
-                <a data-link-for=
-                "AudioWorkletNodeOptions">outputChannelCount</a>, various
-                channel configurations can be achieved.
-              </p>
-              <ol>
-                <li>
-                  <a data-link-for="AudioWorkletNodeOptions">numberOfInputs</a>
-                  = 0, <a data-link-for=
-                  "AudioWorkletNodeOptions">numberOfOutputs</a> = 0
-                  <ul>
-                    <li>
-                      <code>NotSupportedError</code> MUST be thrown by the
-                      constructor.
-                    </li>
-                  </ul>
-                </li>
-                <li>
-                  <a data-link-for="AudioWorkletNodeOptions">numberOfInputs</a>
-                  = 1, <a data-link-for=
-                  "AudioWorkletNodeOptions">numberOfOutputs</a> = 1
-                  <ul>
-                    <li>If <a data-link-for=
-                    "AudioWorkletNodeOptions">outputChannelCount</a> is
-                    unspecified, the output channel count will match
-                    <a>computedNumberOfChannels</a> from the input.
-                    </li>
-                  </ul>
-                </li>
-                <li>All other cases
-                  <ul>
-                    <li>If <a data-link-for=
-                    "AudioWorkletNodeOptions">outputChannelCount</a> is
-                    unspecified, it will be mono for all outputs.
-                    </li>
-                  </ul>
-                </li>
-              </ol>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h2 id="instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">
-            The instantiation of <a>AudioWorkletNode</a> and
-            <a>AudioWorkletProcessor</a>
-          </h2>
-          <p>
-            When the constructor of <a>AudioWorkletNode</a> is invoked in the
-            main global scope, the corresponding <a>AudioWorkletProcessor</a>
-            instance is automatically created in
-            <a>AudioWorkletGlobalScope</a>. After the construction, they
-            maintain the internal reference to each other until the
-            <a>AudioWorkletNode</a> instance is destroyed.
-          </p>
-          <p>
-            Note that the instantiation of these two objects spans the control
-            thread and the rendering thread.
-          </p>
-          <p>
-            When <a>AudioWorkletNode</a>(<var>context</var>,
-            <var>nodeName</var>, <var>options</var>) constructor is invoked,
-            the user agent MUST perform the following steps on the control
-            thread, where the constructor was called.
-          </p>
-          <ol>
-            <li>Let <var>this</var> be the instance being created by
-            constructor of <a>AudioWorkletNode</a> or its subclass.
-            </li>
-            <li>If <var>nodeName</var> does not exists as a key in the
-            <a>BaseAudioContext</a>’s <a>node name to parameter descriptor
-            map</a>, throw a <code>NotSupportedError</code> exception and abort
-            these steps.
-            </li>
-            <li>Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
-            </li>
-            <li>Let <var>messageChannel</var> be a new <a href=
-            "https://html.spec.whatwg.org/multipage/#message-channels">MessageChannel</a>.
-            </li>
-            <li>Let <var>nodePort</var> be the value of
-            <var>messageChannel</var>'s <code>port1</code> attribute.
-            </li>
-            <li>Let <var>processorPortOnThisSide</var> be the value of
-            <var>messageChannel</var>'s <code>port2</code> attribute.
-            </li>
-            <li>Let <var>processorPortSerialization</var> be <a href=
-            "https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserializewithtransfer">
-              StructuredSerializeWithTransfer</a>(<var>processorPortOnThisSide</var>,
-              « <var>processorPortOnThisSide</var> »).
-            </li>
-            <li>Set <var>node</var>'s <a data-link-for=
-            "AudioWorkletNode">port</a> to <var>nodePort</var>.
-            </li>
-            <li>Let <var>parameterDescriptors</var> be the result of retrieval
-            of <var>nodeName</var> from <a>node name to parameter descriptor
-            map</a>:
-              <ol>
-                <li>Let <var>audioParamMap</var> be a new <a>AudioParamMap</a>
-                object.
-                </li>
-                <li>For each <var>descriptor</var> of
-                <var>parameterDescriptors</var>:
-                  <ol>
-                    <li>Let <var>paramName</var> be the value of
-                    <var>descriptor</var>'s <a data-link-for=
-                    "AudioParamDescriptor">name</a>.
-                    </li>
-                    <li>Let <var>audioParam</var> be a new <a>AudioParam</a>
-                    instance.
-                    </li>
-                    <li>Append (<var>paramName</var>, <var>audioParam</var>) to
-                    <var>audioParamMap</var>'s entries.
-                    </li>
-                  </ol>
-                </li>
-                <li>For each <var>paramNameInOption</var> → <var>value</var> of
-                <var>options</var>:
-                  <ol>
-                    <li>If there exists an entry with name member equal to
-                    <var>paramNameInOption</var> inside
-                    <var>audioParamMap</var>, set that <a>AudioParam</a>'s
-                    value to <var>value</var>.
-                    </li>
-                    <li>
-                      <var>paramNameInOption</var> will be ignored when:
-                      <ul>
-                        <li>
-                          <var>audioParamMap</var> does not have any entry with
-                          the same name member.
-                        </li>
-                        <li>
-                          <var>value</var> is not a type of <code>Number</code>
-                          or out of the range specified in
-                          <a>AudioParamDescriptor</a>.
-                        </li>
-                      </ul>
-                    </li>
-                  </ol>
-                </li>
-                <li>Set <var>node</var>'s <a data-link-for="AudioWorkletNode">
-                  parameters</a> to <var>audioParamMap</var>.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <a href="#queuing">Queue a control message</a> to create an
-              <a>AudioWorkletProcessor</a>, given <var>nodeName</var>,
-              <var>processorPortSerialization</var>, and <var>node</var>.
-            </li>
-            <li>Return <var>node</var>.
-            </li>
-          </ol>
-          <p>
-            In order to process a control message for the construction of an
-            <a>AudioWorkletProcessor</a>, given a string <var>nodeName</var>, a
-            serialization record <var>processorPortSerialization</var>, and an
-            <a>AudioWorkletNode</a> <var>node</var>, perform the following
-            steps on the <a>rendering thread</a>. If any of these steps throws
-            an exception (either explicitly or implicitly), abort the rest of
-            steps and queue a task on the <a>control thread</a> to fire
-            <a data-link-for=
-            "AudioWorkletNode"><code>onprocessorstatechange</code></a> event to
-            <var>node</var> with <code>error</code> state.
-          </p>
-          <ol>
-            <li>Let <var>processorPort</var> be <a href=
-            "https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
-              StructuredDeserializeWithTransfer</a>(<var>processorPortSerialization</var>,
-              the current Realm).
-            </li>
-            <li>Let <var>processorConstructor</var> be the result of looking up
-            <var>nodeName</var> on the <a>AudioWorkletGlobalScope</a>'s <a>node
-            name to processor definition map</a>.
-            </li>
-            <li>If <var>processorConstructor</var> is <code>undefined</code>,
-            throw a <code>NotSupportedError</code> DOMException.
-            </li>
-            <li>Let <var>processor</var> be the result of
-            Construct(<var>processorConstructor</var>).
-            </li>
-            <li>If <var>processor</var> does not implement the
-            <a>AudioWorkletProcessor</a> interface, throw an
-            <code>"InvalidStateError"</code> DOMException.
-            </li>
-            <li>Set <var>processor</var>'s <a data-link-for=
-            "AudioWorkletProcessor">port</a> to <var>processorPort</var>.
-            </li>
-            <li>Set <var>processor</var>'s <a>node reference</a> to
-            <var>node</var>.
-            </li>
-            <li>Set <var>node</var>'s <a>processor reference</a> to
-            <var>processor</var>.
-            </li>
-            <li>Queue a task the <a>control thread</a> to set the associated
-            <a>AudioWorkletNode</a>'s state to <code>running</code>, then fire
-            a <code>statechange</code> event.
-            </li>
-          </ol>
-        </section>
-        <section class="informative">
-          <h2 id="AudioWorklet-Sequence">
-            AudioWorklet Sequence of Events
-          </h2>
-          <p>
-            The following figure illustrates an idealized sequence of events
-            occurring relative to an <a>AudioWorklet</a>:
-          </p>
-          <figure>
-            <img alt="AudioWorklet sequence" src=
-            "images/audioworklet-instantiation-sequence.png" width="784"
-            height="427">
-            <figcaption>
-              <a>AudioWorklet</a> sequence
-            </figcaption>
-          </figure>
-          <p>
-            The steps depicted in the diagram are one possible sequence of
-            events involving the creation of an <a>AudioContext</a> and an
-            associated <a>AudioWorkletGlobalScope</a>, followed by the creation
-            of an <a>AudioWorkletNode</a> and its associated
-            <a>AudioWorkletProcessor</a>.
-          </p>
-          <ol>
-            <li>In the main scope, <code>window.audioWorklet</code> is
-            requested to import a script. No <a>AudioWorkletGlobalScope</a>s
-            exist yet, so the script is fetched and added to the Worklet module
-            responses map.
-            </li>
-            <li>An <a>AudioContext</a> is created.
-            </li>
-            <li>An <a>AudioWorkletGlobalScope</a> is created in association
-            with the context's audio rendering thread. This is the global scope
-            in which <a>AudioWorkletProcessor</a> class definitions will be
-            evaluated.
-            </li>
-            <li>As part of the global scope's initialization, the set of
-            imported scripts is run, including the one that was previously
-            imported.
-            </li>
-            <li>As part of running the imported script, an
-            <a>AudioWorkletProcessor</a> is registered under the key
-            <code>"Custom1"</code> within the <a>AudioWorkletGlobalScope</a>.
-            </li>
-            <li>In the main scope, an <a>AudioWorkletNode</a> is created using
-            the key <code>"Custom1"</code> along with an <code>opts</code>
-            dictionary of options.
-            </li>
-            <li>As part of the node's creation, this key is used to look up the
-            correct <a>AudioWorkletProcessor</a> subclass for instantiation.
-            </li>
-            <li>An instance of the <a>AudioWorkletProcessor</a> subclass is
-            instantiated with a structured clone of the same <code>opts</code>
-            dictionary. This instance is paired with the previously created <a>
-              AudioWorkletNode</a>.
-            </li>
-          </ol>
-        </section>
-        <section class="informative">
-          <h2 id="AudioWorklet-Examples">
-            AudioWorklet Examples
-          </h2>
-          <section>
-            <h3>
-              The BitCrusher Node
-            </h3>
-            <p>
-              Bitcrushing is a mechanism by which the quality of an audio
-              stream is reduced both by quantizing the sample value (simulating
-              a lower bit-depth), and by quantizing in time resolution
-              (simulating a lower sample rate). This example shows how to use
-              <a><code>AudioParam</code></a>s (in this case, treated as
-              <a>a-rate</a>) inside an
-              <a><code>AudioWorkletProcessor</code></a>.
-            </p>
-            <pre class="example" title="BitCrusher - Global Scope">
-window.audioWorklet.addModule('bitcrusher.js').then(function () {
-  let context = new AudioContext();
-  let osc = new OscillatorNode(context);
-  let amp = new GainNode(context);
-
-  // Create a worklet node. 'BitCrusher' identifies the
-  // AudioWorkletProcessor previously registered when
-  // bitcrusher.js was imported. The options automatically
-  // initialize the correspondingly named AudioParams.
-  let bitcrusher = new AudioWorkletNode(context, 'BitCrusher', {
-    bitDepth: 8,
-    frequencyReduction: 0.5
-  });
-
-  osc.connect(bitcrusher).connect(amp).connect(context.destination);
-  osc.start();
-});
-</pre>
-            <pre class="example" title=
-            "BitCrusher - AudioWorkletGlobalScope (bitcrusher.js)">
-registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
-
-  static get parameterDescriptors () {
-    return [{
-      name: 'bitDepth',
-      defaultValue: 12,
-      minValue: 1,
-      maxValue: 16
-    }, {
-      name: 'frequencyReduction',
-      defaultValue: 0.5,
-      minValue: 0,
-      maxValue: 1
-    }];
-  }
-
-  constructor (options) {
-    // We don't need to look at options: only AudioParams are initialized,
-    // which were taken care of by the node.
-    super(options);
-    this._phase = 0;
-    this._lastSampleValue = 0;
-  }
-
-  process (inputs, outputs, parameters) {
-    let input = inputs[0];
-    let output = outputs[0];
-    let bitDepth = parameters.bitDepth;
-    let frequencyReduction = parameters.frequencyReduction;
-
-    for (let channel = 0; channel &lt; output.length; ++channel) {
-      for (let i = 0; i &lt; output[channel].length; ++i) {
-        let step = Math.pow(0.5, bitDepth[i]);
-        this._phase += frequencyReduction[i];
-        if (this._phase &gt;= 1.0) {
-          this._phase -= 1.0;
-          this._lastSampleValue =
-            step * Math.floor(input[channel][i] / step + 0.5);
-        }
-        output[channel][i] = this._lastSampleValue;
-      }
-    }
-
-    // No need to return a value; this node's lifetime is dependent only on its
-    // input connections.
-  }
-
-});
-</pre>
-            <div class="note">
-              <p>
-                In the definition of <a>AudioWorkletProcessor</a> class, an
-                <code>InvalidStateError</code> will be thrown if the
-                author-supplied constructor uses JavaScript's return-override
-                feature, or does not properly call <code>super()</code>.
-              </p>
-            </div>
-          </section>
-          <section>
-            <h3>
-              VU Meter Node
-            </h3>
-            <p>
-              This example of a simple sound level meter further illustrates
-              how to create an <a><code>AudioWorkletNode</code></a> subclass
-              that acts like a native <a><code>AudioNode</code></a>, accepting
-              constructor options and encapsulating the inter-thread
-              communication (asynchronous) between
-              <a><code>AudioWorkletNode</code></a> and
-              <a><code>AudioWorkletProcessor</code></a> in clean method calls
-              and attribute accesses. This node does not use any output.
-            </p>
-            <pre class="example" title=
-            "VUMeterNode - Global Scope (vumeternode.js)">
-class VUMeterNode extends AudioWorkletNode {
-
-  constructor (context, options) {
-    // Setting default values for the input, the output and the channel count.
-    options.numberOfInputs = 1;
-    options.numberOfOutputs = 0;
-    options.channelCount = 1;
-    options.updatingInterval = options.hasOwnProperty('updatingInterval')
-      ? options.updatingInterval
-      : 100;
-
-    super(context, 'VUMeter', options);
-
-    // States in AudioWorkletNode
-    this._updatingInterval = options.updatingInterval;
-    this._volume = 0;
-
-    // Handles updated values from AudioWorkletProcessor
-    this.port.onmessage = event =&gt; {
-      if (event.data.volume)
-        this._volume = event.data.volume;
-    }
-    this.port.start();
-  }
-
-  get updatingInterval() {
-    return this._updatingInterval;
-  }
-
-  set updatingInterval (intervalValue) {
-    this._updatingInterval = intervalValue;
-    this.port.postMessage({ updatingInterval: intervalValue });
-  }
-
-  draw () {
-    /* Draw the meter based on the volume value. */
-  }
-
-}
-
-// The application can use the node when this promise resolves.
-let importAudioWorkletNode = window.audioWorklet.addModule('vumeterprocessor.js');
-</pre>
-            <pre class="example" title=
-            "VUMeterNode - AudioWorkletGlobalScope (vumeterprocessor.js)">
-registerProcessor('VUMeter', class extends AudioWorkletProcessor {
-
-  static meterSmoothingFactor = 0.9;
-  static meterMinimum = 0.00001;
-
-  constructor (options) {
-    super(options);
-    this._volume = 0;
-    this._updatingInterval = options.updatingInterval;
-    this._nextUpdateFrames = this.interval;
-
-    this.port.onmessage = event =&gt; {
-      if (event.data.updatingInterval)
-        this._updatingInterval = event.data.updatingInterval;
-    }
-    this.port.start();
-  }
-
-  get interval () {
-    return this._updatingInterval / 1000 * sampleRate;
-  }
-
-  process (inputs, outputs, parameters) {
-    // Note that the input will be down-mixed to mono; however, if no inputs are
-    // connected then zero channels will be passed in.
-    if (inputs[0].length &gt; 0) {
-      let buffer = inputs[0][0];
-      let bufferLength = buffer.length;
-      let sum = 0, x = 0, rms = 0;
-
-      // Calculated the squared-sum.
-      for (let i = 0; i &lt; bufferLength; ++i) {
-        x = buffer[i];
-        sum += x * x;
-      }
-
-      // Calculate the RMS level and update the volume.
-      rms =  Math.sqrt(sum / bufferLength);
-      this.volume = Math.max(rms, this._volume * meterSmoothingFactor);
-
-      // Update and sync the volume property with the main thread.
-      this._nextUpdateFrame -= bufferLength;
-      if (this._nextUpdateFrame &lt; 0) {
-        this._nextUpdateFrame += this.interval;
-        this.port.postMessage({ volume: this._volume });
-      }
-    }
-
-    // Keep on processing if the volume is above a threshold, so that
-    // disconnecting inputs does not immediately cause the meter to stop
-    // computing its smoothed value.
-    return this._volume &gt;= meterMinimum;
-  }
-
-});
-</pre>
-            <pre class="example" title=
-            "VUMeterNode - Global Scope (main HTML file)">
-&lt;script src="vumeternode.js"&gt;&lt;/script&gt;
-&lt;script&gt;
-  importAudioWorkletNode.then(function () {
-    let context = new AudioContext();
-    let oscillator = new Oscillator(context);
-    let vuMeterNode = new VUMeterNode(context, { updatingInterval: 50 });
-
-    oscillator.connect(vuMeterNode);
-
-    function drawMeter () {
-      vuMeterNode.draw();
-      requestAnimationFrame(drawMeter);
-    }
-
-    drawMeter();
-  });
-&lt;/script&gt;
-</pre>
-          </section>
-        </section>
-      </section>
-      <section>
         <h2>
           The BiquadFilterNode Interface
         </h2>
@@ -18981,6 +17766,1221 @@ dictionary WaveShaperOptions : AudioNodeOptions {
                 The type of oversampling to use for the shaping curve.
               </dd>
             </dl>
+          </section>
+        </section>
+      </section>
+      <section>
+        <h2 id="AudioWorklet">
+          The <dfn>AudioWorklet</dfn> Interface
+        </h2>
+        <section>
+          <h2 id="AudioWorklet-concepts">
+            Concepts
+          </h2>
+          <p>
+            The <a>AudioWorklet</a> object allows developers to supply scripts
+            (such as JavaScript or WebAssembly code) to process audio on the
+            <a>rendering thread</a>, supporting custom <a>AudioNode</a>s. This
+            processing mechanism ensures the synchronous execution of the
+            script code with other built-in <a>AudioNode</a>s in the audio
+            graph.
+          </p>
+          <p>
+            An associated pair of objects MUST be defined in order to realize
+            this mechanism: <a>AudioWorkletNode</a> and
+            <a>AudioWorkletProcessor</a>. The former represents the interface
+            for the main global scope similar to other <a>AudioNode</a>
+            objects, and the latter implements the internal audio processing
+            within a special scope named <a>AudioWorkletGlobalScope</a>.
+          </p>
+          <figure>
+            <img alt="AudioWorklet concept" src=
+            "images/audioworklet-concept.png" width="756" height="144">
+            <figcaption>
+              <a><code>AudioWorkletNode</code></a> and
+              <a><code>AudioWorkletProcessor</code></a>
+            </figcaption>
+          </figure>
+          <p>
+            Importing a script via the <a href=
+            "https://drafts.css-houdini.org/worklets/#dom-worklet-import">import(moduleUrl)</a>
+            method registers class definitions of <a>AudioWorkletProcessor</a>
+            under the <a>AudioWorkletGlobalScope</a>. There are two internal
+            storage areas for the imported class definitions and the active
+            instances created from the definition.
+          </p>
+          <dl>
+            <dt>
+              <dfn>node name to processor definition map</dfn>
+            </dt>
+            <dd>
+              Belongs to <a>AudioWorkletGlobalScope</a>. This map associates a
+              string key to the corresponding <a>AudioWorkletProcessor</a>
+              definition. Initially this map is empty and becomes populated
+              when <a data-link-for=
+              "AudioWorkletGlobalScope">registerProcessor</a> method is called.
+            </dd>
+            <dt>
+              <dfn>node name to parameter descriptor map</dfn>
+            </dt>
+            <dd>
+              Belongs to <a>BaseAudioContext</a>. This map contains an
+              identical set of string keys from <a>node name to processor
+              definition map</a> that are associated with the matching
+              <a>parameterDescriptors</a> values. This internal storage is
+              populated when a promise from <a href=
+              "https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule">addModule()</a>
+              on <a data-link-for="Window">audioWorklet</a> gets resolved.
+            </dd>
+          </dl>
+          <pre class="example" title=
+          "Registering an AudioWorkletProcessor class definition">
+// bypass.js script file, AudioWorkletGlobalScope
+registerProcessor("Bypass", class extends AudioWorkletProcessor {
+  process (inputs, outputs) {
+    // Single input, single channel.
+    var input = inputs[0], output = outputs[0];
+    output[0].set(input[0]);
+  }
+});
+</pre>
+          <pre class="example" title=
+          "Importing a script and creating AudioWorkletNode">
+// The main global scope
+window.audioWorklet.addModule("bypass.js").then(function () {
+  var context = new AudioContext();
+  var bypass = new AudioWorkletNode(context, "Bypass");
+});
+</pre>
+          <p>
+            At the instantiation of <a>AudioWorkletNode</a> in the main global
+            scope, the counterpart <a>AudioWorkletProcessor</a> will also be
+            created in <a>AudioWorkletGlobalScope</a>. These two objects
+            communicate via the asynchronous message passing described in the
+            <a href="#processing-model">processing model</a> section.
+          </p>
+        </section>
+        <pre class="idl">
+partial interface Window {
+    [SameObject]
+    readonly        attribute Worklet audioWorklet;
+};
+        </pre>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="Window" data-link-for="Window">
+            <dt>
+              <code><dfn>audioWorklet</dfn></code> of type <span class=
+              "idlAttrType"><a><code>Worklet</code></a></span> readonly
+            </dt>
+            <dd>
+              The <code>audioWorklet</code> attributes allows access to the
+              <code>Worklet</code> object that can import a script containing
+              <a><code>AudioWorkletProcessor</code></a> class definitions via
+              the algorithm defined by [[!worklets-1]].
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2 id="AudioWorkletGlobalScope">
+            The <dfn>AudioWorkletGlobalScope</dfn> Interface
+          </h2>
+          <p>
+            This special execution context is designed to enable the
+            generation, processing, and analysis of audio data directly using a
+            script in the audio <a>rendering thread</a>. The user-supplied
+            script code is evaluated in this scope to define one or more
+            <a>AudioWorkletProcessor</a> subclasses, which in turn are used to
+            instantiate <a>AudioWorkletProcessor</a>s, in a 1:1 association
+            with <a>AudioWorkletNode</a>s in the main scope.
+          </p>
+          <p>
+            At least one <a>AudioWorkletGlobalScope</a> exists for each
+            <a>AudioContext</a> that contains one or more
+            <a>AudioWorkletNode</a>s. The running of imported scripts is
+            performed by the UA as defined in [[!worklets-1]], in such a way
+            that all scripts are applied consistently to every global scope,
+            and all scopes thus exhibit identical behavior. Beyond these
+            guarantees, the creation of global scopes is transparent to the
+            author and cannot be observed from the main window scope.
+          </p>
+          <p>
+            <a>AudioWorkletGlobalScope</a> has a <a>node name to processor
+            definition map</a>. This map stores definitions of
+            <a>AudioWorkletProcessor</a> with the associated string key.
+            Initially it is empty and populated when
+            <code>registerProcessor</code> method is called, but this storage
+            is internal and is not directly exposed to the user.
+          </p>
+          <div class="note">
+            The <a>AudioWorkletGlobalScope</a> may also contain any other data
+            and code to be shared by these instances. As an example, multiple
+            processors might share an ArrayBuffer defining a wavetable or an
+            impulse response.
+          </div>
+          <div class="note">
+            Every <a>AudioWorkletGlobalScope</a> is associated with a single
+            <a>BaseAudioContext</a>, and with a single audio rendering thread
+            for that context. This prevents data races from occurring in global
+            scope code running within concurrent threads.
+          </div>
+          <pre class="idl">
+[Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
+interface AudioWorkletGlobalScope : WorkletGlobalScope {
+    void registerProcessor (DOMString name, VoidFunction processorCtor);
+    readonly attribute double currentTime;
+    readonly attribute float  sampleRate;
+};
+          </pre>
+          <section>
+            <h3>
+              Attributes
+            </h3>
+            <dl class="attributes" data-dfn-for="AudioWorkletGlobalScope"
+            data-link-for="AudioWorkletGlobalScope">
+              <dt>
+                <code><dfn>currentTime</dfn></code> of type <span class=
+                "idlAttrType"><code>double</code></span>, readonly
+              </dt>
+              <dd>
+                The context time of the block of audio being processed. By
+                definition this will be equal to the value of
+                <a>BaseAudioContext</a>'s <a data-link-for=
+                "BaseAudioContext">currentTime</a> attribute that was most
+                recently observable in the <a>control thread</a>.
+              </dd>
+              <dt>
+                <code><dfn>sampleRate</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, readonly
+              </dt>
+              <dd>
+                The sample rate of the associated <a>BaseAudioContext</a>.
+              </dd>
+            </dl>
+          </section>
+          <section>
+            <h3>
+              Methods
+            </h3>
+            <dl class="methods" data-dfn-for="AudioWorkletGlobalScope"
+            data-link-for="AudioWorkletGlobalScope">
+              <dt>
+                <code><dfn>registerProcessor</dfn></code>
+              </dt>
+              <dd>
+                <p>
+                  Registers a class definition derived from
+                  <a>AudioWorkletProcessor</a>.
+                </p>
+                <p>
+                  When the <a><code>registerProcessor(<em>name</em>,
+                  <em>processorConstructor</em>)</code></a> method is called,
+                  the user agent MUST run the following steps:
+                </p>
+                <ol>
+                  <li>If the <code><em>name</em></code> is the empty string,
+                  <span class="synchronous">throw a
+                  <code>NotSupportedError</code> exception and abort these
+                  steps because the empty string is not a valid key</span>.
+                  </li>
+                  <li>If the <code><em>name</em></code> exists as a key in the
+                  <a>node name to processor definition map</a>, <span class=
+                  "synchronous">throw a <code>NotSupportedError</code>
+                  exception and abort these steps</span> because registering a
+                  definition with a duplicated key is not allowed.
+                  </li>
+                  <li>If the result of <code><a href=
+                  "http://www.ecma-international.org/ecma-262/6.0/#sec-isconstructor">
+                    IsConstructor</a>(argument=<em>processorConstructor</em>)</code>
+                    is false, <span class="synchronous">throw a
+                    <code>TypeError</code> and abort these steps</span>.
+                  </li>
+                  <li>Let <code><em>prototype</em></code> be the result of
+                  <code><a href=
+                  "http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+                    Get</a>(O=<em>processorConstructor</em>,
+                    P="prototype")</code>.
+                  </li>
+                  <li>If the result of <code><a href=
+                  "http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">
+                    Type</a>(argument=<em>prototype</em>)</code> is not
+                    <code>Object</code>, <span class="synchronous">throw a
+                    <code>TypeError</code> and abort all these steps</span>.
+                  </li>
+                  <li>If the result of <code><a href=
+                  "http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
+                    IsCallable</a>(argument=Get(O=<em>prototype</em>,
+                    P="process"))</code> is false, <span class=
+                    "synchronous">throw a <code>TypeError</code> and abort
+                    these steps</span>.
+                  </li>
+                  <li>If the result of <code><a href=
+                  "http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+                    Get</a>(O=<em>processorConstructor</em>,
+                    P="parameterDescriptors")</code> is not an array or
+                    <code>undefined</code>, <span class="synchronous">throw a
+                    <code>TypeError</code> and abort these steps</span>.
+                  </li>
+                  <li>Let <em>definition</em> be a new
+                  <a>AudioWorkletProcessor</a> definition with:
+                    <ul>
+                      <li>node name being <em>name</em>
+                      </li>
+                      <li>processor class constructor being
+                      <em>processorConstructor</em>
+                      </li>
+                    </ul>
+                  </li>
+                  <li>d the key-value pair (<em>name</em> -
+                  <em>definition</em>) to the <a>node name to processor
+                  definition map</a> of the associated
+                  <a>AudioWorkletGlobalScope</a>.
+                  </li>
+                </ol>
+                <p class="note">
+                  The class constructor should only be looked up once, thus it
+                  does not have the opportunity to dynamically change its
+                  definition.
+                </p>
+                <table class="parameters">
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Type
+                    </th>
+                    <th>
+                      Nullable
+                    </th>
+                    <th>
+                      Optional
+                    </th>
+                    <th>
+                      Description
+                    </th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">
+                      name
+                    </td>
+                    <td class="prmType">
+                      <a><code>DOMString</code></a>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc">
+                      A string key that represents a class definition to be
+                      registered. This key is used to look up the constructor
+                      of <a>AudioWorkletProcessor</a> during construction of an
+                      <a>AudioWorkletNode</a>.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">
+                      processorCtr
+                    </td>
+                    <td class="prmType">
+                      <a><code>VoidFunction</code></a>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc">
+                      A class definition extended from
+                      <a>AudioWorkletProcessor</a>.
+                    </td>
+                  </tr>
+                </table>
+                <div>
+                  <em>Return type:</em> <code>void</code>
+                </div>
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h2 id="AudioWorkletNode-section">
+            The AudioWorkletNode Interface
+          </h2>
+          <p>
+            This interface represents a user-defined <a>AudioNode</a> which
+            lives on the <a>control thread</a>. The user can create an
+            <a>AudioWorkletNode</a> from an <a>BaseAudioContext</a>, and such a
+            node can be connected with other built-in <a>AudioNode</a>s to form
+            an audio graph.
+          </p>
+          <div class="node-info">
+            <table>
+              <tr>
+                <th>
+                  Property
+                </th>
+                <th>
+                  Value
+                </th>
+                <th>
+                  Notes
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">numberOfInputs</a>
+                </td>
+                <td>
+                  1
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">numberOfOutputs</a>
+                </td>
+                <td>
+                  1
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">channelCount</a>
+                </td>
+                <td>
+                  2
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">channelCountMode</a>
+                </td>
+                <td>
+                  "<a data-link-for="channelCountMode">max</a>"
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a data-link-for="AudioNode">channelInterpretation</a>
+                </td>
+                <td>
+                  "<a data-link-for="channelInterpretation">speakers</a>"
+                </td>
+                <td></td>
+              </tr>
+              <tr>
+                <td>
+                  <a>tail-time</a> reference
+                </td>
+                <td></td>
+                <td>
+                  Any <a>tail-time</a> is handled by the node itself
+                </td>
+              </tr>
+            </table>
+          </div>
+          <p>
+            Every <a>AudioWorkletNode</a> has an associated <dfn>processor
+            reference</dfn>, initially null, which refers to the
+            <a>AudioWorkletProcessor</a> handling the processing for this node.
+          </p>
+          <p>
+            Every <a>AudioWorkletProcessor</a> has an associated <dfn>active
+            source</dfn> flag, initially <code>true</code>. This flag causes
+            the node to be retained in memory and perform audio processing in
+            the absence of any connected inputs.
+          </p>
+          <pre class="idl">
+[Exposed=Window]
+interface AudioParamMap {
+    readonly maplike&lt;DOMString, AudioParam&gt;;
+};
+          </pre>
+          <p>
+            This interface has "entries", "forEach", "get", "has", "keys",
+            "values", @@iterator methods and a "size" getter brought by
+            <code>readonly maplike</code>.
+          </p>
+          <pre class="idl">
+enum AudioWorkletProcessorState {
+    "pending",
+    "running",
+    "stopped",
+    "error"
+};
+          </pre>
+          <table class="simple" data-dfn-for="AudioWorkletProcessorState"
+          data-link-for="AudioWorkletProcessorState">
+            <tr>
+              <th colspan="2">
+                Enumeration description
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <dfn>pending</dfn>
+              </td>
+              <td>
+                The construction of associated processor has not been
+                completed. In this state, no audio processing can happen and
+                all messages to the processor will be queued.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>running</dfn>
+              </td>
+              <td>
+                Indicates that the <a>active source</a> flag on the
+                corresponding processor is <code>true</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>stopped</dfn>
+              </td>
+              <td>
+                Indicates that the <a>active source</a> flag on the
+                corresponding processor is <code>false</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <dfn>error</dfn>
+              </td>
+              <td>
+                When an exception is thrown from the processor's
+                <code>constructor</code>, <code>process</code> method, or any
+                user-defined class method throws an exception. Note that once
+                an <a>AudioWorkletNode</a> reaches to this state, the processor
+                will output silence throughout its lifetime.
+              </td>
+            </tr>
+          </table>
+          <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional AudioWorkletOptions options)]
+interface AudioWorkletNode : AudioNode {
+    readonly        attribute AudioParamMap              parameters;
+    readonly        attribute MessagePort                port;
+    readonly        attribute AudioWorkletProcessorState processorState;
+                    attribute EventHandler               onprocessorstatechange;
+};
+          </pre>
+          <section>
+            <h3>
+              Constructors
+            </h3>
+            <dl class="methods" data-dfn-for="AudioWorkletNode" data-link-for=
+            "AudioWorkletNode">
+              <dt>
+                <code><dfn>AudioWorkletNode</dfn></code>
+              </dt>
+              <dd>
+                <p>
+                  Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
+                  <a href="#audionode-constructor-init">Initialize</a>
+                  <var>node</var>. Perform the <a href=
+                  "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">
+                  construction procedure</a> of an
+                  <a><code>AudioWorkletNode</code></a> and the corresponding
+                  <a><code>AudioWorkletProcessor</code></a> object. Return
+                  <var>node</var>.
+                </p>
+                <table class="parameters">
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Type
+                    </th>
+                    <th>
+                      Nullable
+                    </th>
+                    <th>
+                      Optional
+                    </th>
+                    <th>
+                      Description
+                    </th>
+                  </tr>
+                  <tr>
+                    <td class="prmName">
+                      context
+                    </td>
+                    <td class="prmType">
+                      <a><code>BaseAudioContext</code></a>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc">
+                      The <a>BaseAudioContext</a> this new
+                      <a>AudioWorkletNode</a> will be <a href=
+                      "#associated">associated</a> with.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">
+                      options
+                    </td>
+                    <td class="prmType">
+                      <a><code>AudioWorkletOptions</code></a>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptTrue">
+                      <span role="img" aria-label="True">✔</span>
+                    </td>
+                    <td class="prmDesc">
+                      Optional initial parameters value for this
+                      <a>AudioWorkletNode</a>.
+                    </td>
+                  </tr>
+                </table>
+              </dd>
+            </dl>
+          </section>
+          <section>
+            <h3>
+              Attributes
+            </h3>
+            <dl class="attributes" data-dfn-for="AudioWorkletNode"
+            data-link-for="AudioWorkletNode">
+              <dt>
+                <code><dfn>onprocessorstatechange</dfn></code> of type
+                <span class=
+                "idlAttrType"><a><code>EventHandler</code></a></span>
+              </dt>
+              <dd>
+                Any state change on the processor will queue a task on the
+                control thread to fire <a>onprocessorstatechange</a> event to
+                the node.
+              </dd>
+              <dt>
+                <code><dfn>parameters</dfn></code> of type <span class=
+                "idlAttrType"><a><code>AudioParamMap</code></a></span>,
+                readonly
+              </dt>
+              <dd>
+                The <code>parameters</code> attribute is a collection of
+                <a>AudioParam</a> objects with associated names. This maplike
+                object is populated from a list of <a>AudioParamDescriptor</a>s
+                in the <a>AudioWorkletProcessor</a> class definition at the
+                instantiation.
+              </dd>
+              <dt>
+                <code><dfn>port</dfn></code> of type <span class=
+                "idlAttrType"><a><code>MessagePort</code></a></span>, readonly
+              </dt>
+              <dd>
+                Every <a>AudioWorkletNode</a> has an associated
+                <code>port</code> which is a <a href=
+                "https://html.spec.whatwg.org/multipage/comms.html#message-ports">
+                MessagePort</a>. It is connected to the port on the
+                corresponding <a>AudioWorkletProcessor</a> object allowing
+                bidirectional communication between a pair of
+                <a>AudioWorkletNode</a> and <a>AudioWorkletProcessor</a>.
+              </dd>
+              <dt>
+                <code><dfn>processorState</dfn></code> of type <span class=
+                "idlAttrType"><a><code>AudioWorkletProcessorState</code></a></span>,
+                readonly
+              </dt>
+              <dd>
+                Indicates the state of the associated processor. The
+                propagation from the actual processor's <a>active source</a>
+                flag to this property is done by queueing a task.
+              </dd>
+            </dl>
+          </section>
+          <section>
+            <h2 id="AudioWorkletNodeOptions">
+              <dfn>AudioWorkletNodeOptions</dfn>
+            </h2>
+            <p>
+              The <code>AudioWorkletNodeOptions</code> dictionary can be used
+              for the custom initialization of <a><code>AudioNode</code></a>
+              attributes in the <a><code>AudioWorkletNode</code></a>
+              constructor. Entries in this dictionary whose names correspond to
+              <a><code>AudioParam</code></a>s in the class definition of an
+              <a><code>AudioWorkletProcessor</code></a> are used to initialize
+              the parameter values upon the creation of a node.
+            </p>
+            <pre class="idl">
+dictionary AudioWorkletNodeOptions : AudioNodeOptions {
+             unsigned long             numberOfInputs = 1;
+             unsigned long             numberOfOutputs = 1;
+             sequence&lt;unsigned long&gt;    outputChannelCount;
+             record&lt;DOMString, double&gt;  parameterData;
+};
+            </pre>
+            <section>
+              <h3>
+                Dictionary <a>AudioWorkletNodeOptions</a> Members
+              </h3>
+              <dl class="attributes" data-dfn-for="AudioWorkletNodeOptions"
+              data-link-for="AudioWorkletNodeOptions">
+                <dt>
+                  <code><dfn>numberOfInputs</dfn></code> of type <span class=
+                  "idlAttrType"><code>unsigned long</code></span>, defaulting
+                  to 1
+                </dt>
+                <dd>
+                  This is used to initialize the value of <a>AudioNode</a>
+                  <a data-link-for="AudioNode">numberOfInputs</a> attribute.
+                </dd>
+                <dt>
+                  <code><dfn>numberOfOutputs</dfn></code> of type <span class=
+                  "idlAttrType"><code>unsigned long</code></span>, defaulting
+                  to 1
+                </dt>
+                <dd>
+                  This is used to initialize the value of <a>AudioNode</a>
+                  <a data-link-for="AudioNode">numberOfOutputs</a> attribute.
+                </dd>
+                <dt>
+                  <code><dfn>outputChannelCount</dfn></code> of type
+                  <span class="idlAttrType"><code>sequence&lt;unsigned
+                  long&gt;</code></span>
+                </dt>
+                <dd>
+                  This array is used to configure the number of channels in
+                  each output. For example, <code>outputChannelCount: [n,
+                  m]</code> specifies the number of channels in the first
+                  output to <code>n</code> and the second output to
+                  <code>m</code> respectively. <code>IndexSizeError</code> MUST
+                  be thrown if the length of sequence does not match
+                  <a data-link-for=
+                  "AudioWorkletNodeOptions">numberOfOutputs</a>. A
+                  <code>NotSupportedError</code> exception MUST be thrown if a
+                  channel count is not in the valid range of AudioNode's
+                  <a data-link-for="AudioNode">channelCount</a>.
+                </dd>
+                <dt>
+                  <code><dfn>parameterData</dfn></code> of type <span class=
+                  "idlAttrType"><code>record&lt;DOMString,
+                  double&gt;</code></span>
+                </dt>
+                <dd>
+                  This is a list of user-defined key-value pairs that are used
+                  to initialize <a>AudioParam</a> values in
+                  <a>AudioWorkletNode</a>. If the string key of an entry in the
+                  list does not match any name of <a>AudioParam</a> objects in
+                  the node, it is ignored.
+                </dd>
+              </dl>
+            </section>
+            <section>
+              <h3>
+                Configuring Channels with <a>AudioWorkletNodeOptions</a>
+              </h3>
+              <p>
+                With a combination of <a data-link-for=
+                "AudioWorkletNodeOptions">numberOfInputs</a>, <a data-link-for=
+                "AudioWorkletNodeOptions">numberOfOutputs</a> and
+                <a data-link-for=
+                "AudioWorkletNodeOptions">outputChannelCount</a>, various
+                channel configurations can be achieved.
+              </p>
+              <ol>
+                <li>
+                  <a data-link-for="AudioWorkletNodeOptions">numberOfInputs</a>
+                  = 0, <a data-link-for=
+                  "AudioWorkletNodeOptions">numberOfOutputs</a> = 0
+                  <ul>
+                    <li>
+                      <code>NotSupportedError</code> MUST be thrown by the
+                      constructor.
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a data-link-for="AudioWorkletNodeOptions">numberOfInputs</a>
+                  = 1, <a data-link-for=
+                  "AudioWorkletNodeOptions">numberOfOutputs</a> = 1
+                  <ul>
+                    <li>If <a data-link-for=
+                    "AudioWorkletNodeOptions">outputChannelCount</a> is
+                    unspecified, the output channel count will match
+                    <a>computedNumberOfChannels</a> from the input.
+                    </li>
+                  </ul>
+                </li>
+                <li>All other cases
+                  <ul>
+                    <li>If <a data-link-for=
+                    "AudioWorkletNodeOptions">outputChannelCount</a> is
+                    unspecified, it will be mono for all outputs.
+                    </li>
+                  </ul>
+                </li>
+              </ol>
+            </section>
+          </section>
+        </section>
+        <section>
+          <h2 id="instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">
+            The instantiation of <a>AudioWorkletNode</a> and
+            <a>AudioWorkletProcessor</a>
+          </h2>
+          <p>
+            When the constructor of <a>AudioWorkletNode</a> is invoked in the
+            main global scope, the corresponding <a>AudioWorkletProcessor</a>
+            instance is automatically created in
+            <a>AudioWorkletGlobalScope</a>. After the construction, they
+            maintain the internal reference to each other until the
+            <a>AudioWorkletNode</a> instance is destroyed.
+          </p>
+          <p>
+            Note that the instantiation of these two objects spans the control
+            thread and the rendering thread.
+          </p>
+          <p>
+            When <a>AudioWorkletNode</a>(<var>context</var>,
+            <var>nodeName</var>, <var>options</var>) constructor is invoked,
+            the user agent MUST perform the following steps on the control
+            thread, where the constructor was called.
+          </p>
+          <ol>
+            <li>Let <var>this</var> be the instance being created by
+            constructor of <a>AudioWorkletNode</a> or its subclass.
+            </li>
+            <li>If <var>nodeName</var> does not exists as a key in the
+            <a>BaseAudioContext</a>’s <a>node name to parameter descriptor
+            map</a>, throw a <code>NotSupportedError</code> exception and abort
+            these steps.
+            </li>
+            <li>Let <var>node</var> be a new <a>AudioWorkletNode</a> object.
+            </li>
+            <li>Let <var>messageChannel</var> be a new <a href=
+            "https://html.spec.whatwg.org/multipage/#message-channels">MessageChannel</a>.
+            </li>
+            <li>Let <var>nodePort</var> be the value of
+            <var>messageChannel</var>'s <code>port1</code> attribute.
+            </li>
+            <li>Let <var>processorPortOnThisSide</var> be the value of
+            <var>messageChannel</var>'s <code>port2</code> attribute.
+            </li>
+            <li>Let <var>processorPortSerialization</var> be <a href=
+            "https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserializewithtransfer">
+              StructuredSerializeWithTransfer</a>(<var>processorPortOnThisSide</var>,
+              « <var>processorPortOnThisSide</var> »).
+            </li>
+            <li>Set <var>node</var>'s <a data-link-for=
+            "AudioWorkletNode">port</a> to <var>nodePort</var>.
+            </li>
+            <li>Let <var>parameterDescriptors</var> be the result of retrieval
+            of <var>nodeName</var> from <a>node name to parameter descriptor
+            map</a>:
+              <ol>
+                <li>Let <var>audioParamMap</var> be a new <a>AudioParamMap</a>
+                object.
+                </li>
+                <li>For each <var>descriptor</var> of
+                <var>parameterDescriptors</var>:
+                  <ol>
+                    <li>Let <var>paramName</var> be the value of
+                    <var>descriptor</var>'s <a data-link-for=
+                    "AudioParamDescriptor">name</a>.
+                    </li>
+                    <li>Let <var>audioParam</var> be a new <a>AudioParam</a>
+                    instance.
+                    </li>
+                    <li>Append (<var>paramName</var>, <var>audioParam</var>) to
+                    <var>audioParamMap</var>'s entries.
+                    </li>
+                  </ol>
+                </li>
+                <li>For each <var>paramNameInOption</var> → <var>value</var> of
+                <var>options</var>:
+                  <ol>
+                    <li>If there exists an entry with name member equal to
+                    <var>paramNameInOption</var> inside
+                    <var>audioParamMap</var>, set that <a>AudioParam</a>'s
+                    value to <var>value</var>.
+                    </li>
+                    <li>
+                      <var>paramNameInOption</var> will be ignored when:
+                      <ul>
+                        <li>
+                          <var>audioParamMap</var> does not have any entry with
+                          the same name member.
+                        </li>
+                        <li>
+                          <var>value</var> is not a type of <code>Number</code>
+                          or out of the range specified in
+                          <a>AudioParamDescriptor</a>.
+                        </li>
+                      </ul>
+                    </li>
+                  </ol>
+                </li>
+                <li>Set <var>node</var>'s <a data-link-for="AudioWorkletNode">
+                  parameters</a> to <var>audioParamMap</var>.
+                </li>
+              </ol>
+            </li>
+            <li>
+              <a href="#queuing">Queue a control message</a> to create an
+              <a>AudioWorkletProcessor</a>, given <var>nodeName</var>,
+              <var>processorPortSerialization</var>, and <var>node</var>.
+            </li>
+            <li>Return <var>node</var>.
+            </li>
+          </ol>
+          <p>
+            In order to process a control message for the construction of an
+            <a>AudioWorkletProcessor</a>, given a string <var>nodeName</var>, a
+            serialization record <var>processorPortSerialization</var>, and an
+            <a>AudioWorkletNode</a> <var>node</var>, perform the following
+            steps on the <a>rendering thread</a>. If any of these steps throws
+            an exception (either explicitly or implicitly), abort the rest of
+            steps and queue a task on the <a>control thread</a> to fire
+            <a data-link-for=
+            "AudioWorkletNode"><code>onprocessorstatechange</code></a> event to
+            <var>node</var> with <code>error</code> state.
+          </p>
+          <ol>
+            <li>Let <var>processorPort</var> be <a href=
+            "https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
+              StructuredDeserializeWithTransfer</a>(<var>processorPortSerialization</var>,
+              the current Realm).
+            </li>
+            <li>Let <var>processorConstructor</var> be the result of looking up
+            <var>nodeName</var> on the <a>AudioWorkletGlobalScope</a>'s <a>node
+            name to processor definition map</a>.
+            </li>
+            <li>If <var>processorConstructor</var> is <code>undefined</code>,
+            throw a <code>NotSupportedError</code> DOMException.
+            </li>
+            <li>Let <var>processor</var> be the result of
+            Construct(<var>processorConstructor</var>).
+            </li>
+            <li>If <var>processor</var> does not implement the
+            <a>AudioWorkletProcessor</a> interface, throw an
+            <code>"InvalidStateError"</code> DOMException.
+            </li>
+            <li>Set <var>processor</var>'s <a data-link-for=
+            "AudioWorkletProcessor">port</a> to <var>processorPort</var>.
+            </li>
+            <li>Set <var>processor</var>'s <a>node reference</a> to
+            <var>node</var>.
+            </li>
+            <li>Set <var>node</var>'s <a>processor reference</a> to
+            <var>processor</var>.
+            </li>
+            <li>Queue a task the <a>control thread</a> to set the associated
+            <a>AudioWorkletNode</a>'s state to <code>running</code>, then fire
+            a <code>statechange</code> event.
+            </li>
+          </ol>
+        </section>
+        <section class="informative">
+          <h2 id="AudioWorklet-Sequence">
+            AudioWorklet Sequence of Events
+          </h2>
+          <p>
+            The following figure illustrates an idealized sequence of events
+            occurring relative to an <a>AudioWorklet</a>:
+          </p>
+          <figure>
+            <img alt="AudioWorklet sequence" src=
+            "images/audioworklet-instantiation-sequence.png" width="784"
+            height="427">
+            <figcaption>
+              <a>AudioWorklet</a> sequence
+            </figcaption>
+          </figure>
+          <p>
+            The steps depicted in the diagram are one possible sequence of
+            events involving the creation of an <a>AudioContext</a> and an
+            associated <a>AudioWorkletGlobalScope</a>, followed by the creation
+            of an <a>AudioWorkletNode</a> and its associated
+            <a>AudioWorkletProcessor</a>.
+          </p>
+          <ol>
+            <li>In the main scope, <code>window.audioWorklet</code> is
+            requested to import a script. No <a>AudioWorkletGlobalScope</a>s
+            exist yet, so the script is fetched and added to the Worklet module
+            responses map.
+            </li>
+            <li>An <a>AudioContext</a> is created.
+            </li>
+            <li>An <a>AudioWorkletGlobalScope</a> is created in association
+            with the context's audio rendering thread. This is the global scope
+            in which <a>AudioWorkletProcessor</a> class definitions will be
+            evaluated.
+            </li>
+            <li>As part of the global scope's initialization, the set of
+            imported scripts is run, including the one that was previously
+            imported.
+            </li>
+            <li>As part of running the imported script, an
+            <a>AudioWorkletProcessor</a> is registered under the key
+            <code>"Custom1"</code> within the <a>AudioWorkletGlobalScope</a>.
+            </li>
+            <li>In the main scope, an <a>AudioWorkletNode</a> is created using
+            the key <code>"Custom1"</code> along with an <code>opts</code>
+            dictionary of options.
+            </li>
+            <li>As part of the node's creation, this key is used to look up the
+            correct <a>AudioWorkletProcessor</a> subclass for instantiation.
+            </li>
+            <li>An instance of the <a>AudioWorkletProcessor</a> subclass is
+            instantiated with a structured clone of the same <code>opts</code>
+            dictionary. This instance is paired with the previously created <a>
+              AudioWorkletNode</a>.
+            </li>
+          </ol>
+        </section>
+        <section class="informative">
+          <h2 id="AudioWorklet-Examples">
+            AudioWorklet Examples
+          </h2>
+          <section>
+            <h3>
+              The BitCrusher Node
+            </h3>
+            <p>
+              Bitcrushing is a mechanism by which the quality of an audio
+              stream is reduced both by quantizing the sample value (simulating
+              a lower bit-depth), and by quantizing in time resolution
+              (simulating a lower sample rate). This example shows how to use
+              <a><code>AudioParam</code></a>s (in this case, treated as
+              <a>a-rate</a>) inside an
+              <a><code>AudioWorkletProcessor</code></a>.
+            </p>
+            <pre class="example" title="BitCrusher - Global Scope">
+window.audioWorklet.addModule('bitcrusher.js').then(function () {
+  let context = new AudioContext();
+  let osc = new OscillatorNode(context);
+  let amp = new GainNode(context);
+
+  // Create a worklet node. 'BitCrusher' identifies the
+  // AudioWorkletProcessor previously registered when
+  // bitcrusher.js was imported. The options automatically
+  // initialize the correspondingly named AudioParams.
+  let bitcrusher = new AudioWorkletNode(context, 'BitCrusher', {
+    bitDepth: 8,
+    frequencyReduction: 0.5
+  });
+
+  osc.connect(bitcrusher).connect(amp).connect(context.destination);
+  osc.start();
+});
+</pre>
+            <pre class="example" title=
+            "BitCrusher - AudioWorkletGlobalScope (bitcrusher.js)">
+registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
+
+  static get parameterDescriptors () {
+    return [{
+      name: 'bitDepth',
+      defaultValue: 12,
+      minValue: 1,
+      maxValue: 16
+    }, {
+      name: 'frequencyReduction',
+      defaultValue: 0.5,
+      minValue: 0,
+      maxValue: 1
+    }];
+  }
+
+  constructor (options) {
+    // We don't need to look at options: only AudioParams are initialized,
+    // which were taken care of by the node.
+    super(options);
+    this._phase = 0;
+    this._lastSampleValue = 0;
+  }
+
+  process (inputs, outputs, parameters) {
+    let input = inputs[0];
+    let output = outputs[0];
+    let bitDepth = parameters.bitDepth;
+    let frequencyReduction = parameters.frequencyReduction;
+
+    for (let channel = 0; channel &lt; output.length; ++channel) {
+      for (let i = 0; i &lt; output[channel].length; ++i) {
+        let step = Math.pow(0.5, bitDepth[i]);
+        this._phase += frequencyReduction[i];
+        if (this._phase &gt;= 1.0) {
+          this._phase -= 1.0;
+          this._lastSampleValue =
+            step * Math.floor(input[channel][i] / step + 0.5);
+        }
+        output[channel][i] = this._lastSampleValue;
+      }
+    }
+
+    // No need to return a value; this node's lifetime is dependent only on its
+    // input connections.
+  }
+
+});
+</pre>
+            <div class="note">
+              <p>
+                In the definition of <a>AudioWorkletProcessor</a> class, an
+                <code>InvalidStateError</code> will be thrown if the
+                author-supplied constructor uses JavaScript's return-override
+                feature, or does not properly call <code>super()</code>.
+              </p>
+            </div>
+          </section>
+          <section>
+            <h3>
+              VU Meter Node
+            </h3>
+            <p>
+              This example of a simple sound level meter further illustrates
+              how to create an <a><code>AudioWorkletNode</code></a> subclass
+              that acts like a native <a><code>AudioNode</code></a>, accepting
+              constructor options and encapsulating the inter-thread
+              communication (asynchronous) between
+              <a><code>AudioWorkletNode</code></a> and
+              <a><code>AudioWorkletProcessor</code></a> in clean method calls
+              and attribute accesses. This node does not use any output.
+            </p>
+            <pre class="example" title=
+            "VUMeterNode - Global Scope (vumeternode.js)">
+class VUMeterNode extends AudioWorkletNode {
+
+  constructor (context, options) {
+    // Setting default values for the input, the output and the channel count.
+    options.numberOfInputs = 1;
+    options.numberOfOutputs = 0;
+    options.channelCount = 1;
+    options.updatingInterval = options.hasOwnProperty('updatingInterval')
+      ? options.updatingInterval
+      : 100;
+
+    super(context, 'VUMeter', options);
+
+    // States in AudioWorkletNode
+    this._updatingInterval = options.updatingInterval;
+    this._volume = 0;
+
+    // Handles updated values from AudioWorkletProcessor
+    this.port.onmessage = event =&gt; {
+      if (event.data.volume)
+        this._volume = event.data.volume;
+    }
+    this.port.start();
+  }
+
+  get updatingInterval() {
+    return this._updatingInterval;
+  }
+
+  set updatingInterval (intervalValue) {
+    this._updatingInterval = intervalValue;
+    this.port.postMessage({ updatingInterval: intervalValue });
+  }
+
+  draw () {
+    /* Draw the meter based on the volume value. */
+  }
+
+}
+
+// The application can use the node when this promise resolves.
+let importAudioWorkletNode = window.audioWorklet.addModule('vumeterprocessor.js');
+</pre>
+            <pre class="example" title=
+            "VUMeterNode - AudioWorkletGlobalScope (vumeterprocessor.js)">
+registerProcessor('VUMeter', class extends AudioWorkletProcessor {
+
+  static meterSmoothingFactor = 0.9;
+  static meterMinimum = 0.00001;
+
+  constructor (options) {
+    super(options);
+    this._volume = 0;
+    this._updatingInterval = options.updatingInterval;
+    this._nextUpdateFrames = this.interval;
+
+    this.port.onmessage = event =&gt; {
+      if (event.data.updatingInterval)
+        this._updatingInterval = event.data.updatingInterval;
+    }
+    this.port.start();
+  }
+
+  get interval () {
+    return this._updatingInterval / 1000 * sampleRate;
+  }
+
+  process (inputs, outputs, parameters) {
+    // Note that the input will be down-mixed to mono; however, if no inputs are
+    // connected then zero channels will be passed in.
+    if (inputs[0].length &gt; 0) {
+      let buffer = inputs[0][0];
+      let bufferLength = buffer.length;
+      let sum = 0, x = 0, rms = 0;
+
+      // Calculated the squared-sum.
+      for (let i = 0; i &lt; bufferLength; ++i) {
+        x = buffer[i];
+        sum += x * x;
+      }
+
+      // Calculate the RMS level and update the volume.
+      rms =  Math.sqrt(sum / bufferLength);
+      this.volume = Math.max(rms, this._volume * meterSmoothingFactor);
+
+      // Update and sync the volume property with the main thread.
+      this._nextUpdateFrame -= bufferLength;
+      if (this._nextUpdateFrame &lt; 0) {
+        this._nextUpdateFrame += this.interval;
+        this.port.postMessage({ volume: this._volume });
+      }
+    }
+
+    // Keep on processing if the volume is above a threshold, so that
+    // disconnecting inputs does not immediately cause the meter to stop
+    // computing its smoothed value.
+    return this._volume &gt;= meterMinimum;
+  }
+
+});
+</pre>
+            <pre class="example" title=
+            "VUMeterNode - Global Scope (main HTML file)">
+&lt;script src="vumeternode.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+  importAudioWorkletNode.then(function () {
+    let context = new AudioContext();
+    let oscillator = new Oscillator(context);
+    let vuMeterNode = new VUMeterNode(context, { updatingInterval: 50 });
+
+    oscillator.connect(vuMeterNode);
+
+    function drawMeter () {
+      vuMeterNode.draw();
+      requestAnimationFrame(drawMeter);
+    }
+
+    drawMeter();
+  });
+&lt;/script&gt;
+</pre>
           </section>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -3454,6 +3454,580 @@ dictionary OfflineAudioCompletionEventInit : EventInit {
         </section>
       </section>
       <section>
+        <h2 id="AudioBuffer">
+          The AudioBuffer Interface
+        </h2>
+        <p>
+          This interface represents a memory-resident audio asset (for one-shot
+          sounds and other short audio clips). Its format is non-interleaved
+          32-bit linear floating-point PCM values with a normal range of \([-1,
+          1]\), but values are not limited to this range. It can contain one or
+          more channels. Typically, it would be expected that the length of the
+          PCM data would be fairly short (usually somewhat less than a minute).
+          For longer sounds, such as music soundtracks, streaming should be
+          used with the <code>audio</code> element and
+          <code>MediaElementAudioSourceNode</code>.
+        </p>
+        <p>
+          An <a>AudioBuffer</a> may be used by one or more
+          <a><code>AudioContext</code></a>s, and can be shared between an
+          <a><code>OfflineAudioContext</code></a> and an
+          <a><code>AudioContext</code></a>.
+        </p>
+        <p>
+          <a>AudioBuffer</a> has four internal slots:
+        </p>
+        <dl>
+          <dt>
+            <var>[[number of channels]]</var>
+          </dt>
+          <dd>
+            The number of audio channels for this <a>AudioBuffer</a>, which is
+            an unsigned long.
+          </dd>
+          <dt>
+            <var>[[\length]]</var>
+          </dt>
+          <dd>
+            The length of each channel of this <a>AudioBuffer</a>, which is an
+            unsigned long.
+          </dd>
+          <dt>
+            [[sample rate]]
+          </dt>
+          <dd>
+            The sample-rate, in Hz, of this <a>AudioBuffer</a>, a float
+          </dd>
+          <dt>
+            [[internal data]]
+          </dt>
+          <dd>
+            A <a href="https://tc39.github.io/ecma262/#sec-data-blocks">data
+            block</a> holding the audio sample data.
+          </dd>
+        </dl>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (AudioBufferOptions options)]
+interface AudioBuffer {
+    readonly        attribute float         sampleRate;
+    readonly        attribute unsigned long length;
+    readonly        attribute double        duration;
+    readonly        attribute unsigned long numberOfChannels;
+    Float32Array getChannelData (unsigned long channel);
+    void         copyFromChannel (Float32Array destination, unsigned long channelNumber, optional unsigned long startInChannel = 0);
+    void         copyToChannel (Float32Array source, unsigned long channelNumber, optional unsigned long startInChannel = 0);
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="AudioBuffer" data-link-for=
+          "AudioBuffer">
+            <dt>
+              <code><dfn>AudioBuffer</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>b</var> be a new <a>AudioBuffer</a> object.
+                Respectively assign the values of the attributes
+                <var>numberOfChannels</var>, <var>length</var>,
+                <var>sampleRate</var> of the <a>AudioBufferOptions</a> passed
+                in the constructor to the internal slots <var>[[number of
+                channels]]</var>, <var>[[\length]]</var>, <var>[[sample
+                rate]]</var>.
+              </p>
+              <p>
+                Set the internal slot <var>[[internal data]]</var> of this
+                <a>AudioBuffer</a> to the result of calling <a href=
+                "https://tc39.github.io/ecma262/#sec-createbytedatablock"><code>
+                CreateByteDataBlock([[\length]] * [[number of
+                channels]])</code></a>.
+              </p>
+              <p class="note">
+                This initializes the underlying storage to zero.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>AudioBufferOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="AudioBuffer" data-link-for=
+          "AudioBuffer">
+            <dt>
+              <code><dfn>duration</dfn></code> of type <span class=
+              "idlAttrType"><code>double</code></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Duration of the PCM audio data in seconds.
+              </p>
+              <p>
+                This is computed from the <var>[[sample rate]]</var> and the
+                <var>[[\length]]</var> of the <a>AudioBuffer</a> by performing
+                a division between the <var>[[\length]]</var> and the
+                <var>[[sample rate]]</var>.
+              </p>
+            </dd>
+            <dt>
+              <code><dfn>length</dfn></code> of type <span class=
+              "idlAttrType"><code>unsigned long</code></span>, readonly
+            </dt>
+            <dd>
+              Length of the PCM audio data in sample-frames. This MUST return
+              the value of <var>[[\length]]</var>.
+            </dd>
+            <dt>
+              <code><dfn>numberOfChannels</dfn></code> of type <span class=
+              "idlAttrType"><code>unsigned long</code></span>, readonly
+            </dt>
+            <dd>
+              The number of discrete audio channels. This MUST return the value
+              of <var>[[number of channels]]</var>.
+            </dd>
+            <dt>
+              <code><dfn>sampleRate</dfn></code> of type <span class=
+              "idlAttrType"><code>float</code></span>, readonly
+            </dt>
+            <dd>
+              The sample-rate for the PCM audio data in samples per second.
+              This MUST return the value of <var>[[sample rate]]</var>.
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Methods
+          </h3>
+          <dl class="methods" data-dfn-for="AudioBuffer" data-link-for=
+          "AudioBuffer">
+            <dt>
+              <code><dfn>copyFromChannel</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                The <code>copyFromChannel</code> method copies the samples from
+                the specified channel of the <a>AudioBuffer</a> to the
+                <code>destination</code> array.
+              </p>
+              <p>
+                Let <code>buffer</code> be the <a>AudioBuffer</a> buffer with
+                \(N_b\) frames, let \(N_f\) be the number of elements in the
+                <code>destination</code> array, and \(k\) be the value of
+                <code>startInChannel</code>. Then the number of frames copied
+                from <code>buffer</code> to <code>destination</code> is
+                \(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
+                remaining elements of <code>destination</code> are not
+                modified.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    destination
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The array the channel data will be copied to.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    channelNumber
+                  </td>
+                  <td class="prmType">
+                    <a><code>unsigned long</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The index of the channel to copy the data from. If
+                    <code>channelNumber</code> is greater or equal than the
+                    number of channel of the <a>AudioBuffer</a>, <span class=
+                    "synchronous">an <code>IndexSizeError</code> MUST be
+                    thrown</span>.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    startInChannel
+                  </td>
+                  <td class="prmType">
+                    <a><code>unsigned long = 0</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    An optional offset to copy the data from. If
+                    <code>startInChannel</code> is greater than the
+                    <code>length</code> of the <a>AudioBuffer</a>, <span class=
+                    "synchronous">an <code>IndexSizeError</code> MUST be
+                    thrown</span>.
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>copyToChannel</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                The <code>copyFromChannel</code> method copies the samples from
+                the specified channel of the <a>AudioBuffer</a> to the
+                <code>destination</code> array.
+              </p>
+              <p>
+                Let <code>buffer</code> be the <a>AudioBuffer</a> buffer with
+                \(N_b\) frames, let \(N_f\) be the number of elements in the
+                <code>destination</code> array, and \(k\) be the value of
+                <code>startInChannel</code>. Then the number of frames copied
+                from <code>buffer</code> to <code>destination</code> is
+                \(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
+                remaining elements of <code>destination</code> are not
+                modified.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    source
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The array the channel data will be copied from.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    channelNumber
+                  </td>
+                  <td class="prmType">
+                    <a><code>unsigned long</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The index of the channel to copy the data to. If
+                    <code>channelNumber</code> is greater or equal than the
+                    number of channel of the <a>AudioBuffer</a>, <span class=
+                    "synchronous">an <code>IndexSizeError</code> MUST be
+                    thrown</span>.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    startInChannel
+                  </td>
+                  <td class="prmType">
+                    <a><code>unsigned long = 0</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    An optional offset to copy the data to. If
+                    <code>startInChannel</code> is greater than the
+                    <code>length</code> of the <a>AudioBuffer</a>, <span class=
+                    "synchronous">an <code>IndexSizeError</code> MUST be
+                    thrown</span>.
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>getChannelData</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                According to the rules described in <a href=
+                "#acquire-the-content">acquire the content</a> either <a href=
+                "https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+                get a reference to</a> or <a href=
+                "https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get
+                a copy of</a> the bytes stored in [[internal data]] in a new
+                <code>Float32Array</code>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    channel
+                  </td>
+                  <td class="prmType">
+                    <a><code>unsigned long</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    This parameter is an index representing the particular
+                    channel to get data for. An index value of 0 represents the
+                    first channel. <span class="synchronous">This index value
+                    MUST be less than <code>numberOfChannels</code> or an
+                    <code>IndexSizeError</code> exception MUST be
+                    thrown.</span>
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>Float32Array</code>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <p class="note">
+          The methods <code>copyToChannel</code> and
+          <code>copyFromChannel</code> can be used to fill part of an array by
+          passing in a <code>Float32Array</code> that's a view onto the larger
+          array. When reading data from an <a>AudioBuffer</a>'s channels, and
+          the data can be processed in chunks, <code>copyFromChannel</code>
+          should be preferred to calling <code>getChannelData</code> and
+          accessing the resulting array, because it may avoid unnecessary
+          memory allocation and copying.
+        </p>
+        <p>
+          An internal operation <a href="#acquire-the-content">acquire the
+          contents of an <code>AudioBuffer</code></a> is invoked when the
+          contents of an <a>AudioBuffer</a> are needed by some API
+          implementation. This operation returns immutable channel data to the
+          invoker.
+        </p>
+        <p>
+          When an <dfn id="acquire-the-content">acquire the content</dfn>
+          operation occurs on an <a>AudioBuffer</a>, run the following steps:
+        </p>
+        <ol>
+          <li>If the operation <a href=
+          "https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
+          on any of the <a>AudioBuffer</a>'s <code>ArrayBuffer</code>s return
+          <code>true</code>, abort these steps, and return a zero-length
+          channel data buffer to the invoker.
+          </li>
+          <li>
+            <a href=
+            "https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
+            all <code>ArrayBuffer</code>s for arrays previously returned by
+            <code>getChannelData</code> on this <a>AudioBuffer</a>.
+          </li>
+          <li>Retain the underlying <var>[[internal data]]</var> from those
+          <code>ArrayBuffer</code>s and return references to them to the
+          invoker.
+          </li>
+          <li>Attach <code>ArrayBuffer</code>s containing copies of the data to
+          the <a>AudioBuffer</a>, to be returned by the next call to
+          <code>getChannelData</code>.
+          </li>
+        </ol>The <a href="#acquire-the-content">acquire the contents of an
+        AudioBuffer</a> operation is invoked in the following cases:
+        <ul>
+          <li>When <code>AudioBufferSourceNode.start</code> is called, it
+          <a href="#acquire-the-content">acquires the contents</a> of the
+          node's <code>buffer</code>. If the operation fails, nothing is
+          played.
+          </li>
+          <li>When the <code>buffer</code> of an <a>AudioBufferSourceNode</a>
+          is set and <code>AudioBufferSourceNode.start</code> has been
+          previously called, the setter <a href="#acquire-the-content">acquires
+          the content</a> of the <a>AudioBuffer</a>. If the operation fails,
+          nothing is played.
+          </li>
+          <li>When a <a>ConvolverNode</a>'s <code>buffer</code> is set to an
+          <a>AudioBuffer</a> while the node is connected to an output node, or
+          a <a>ConvolverNode</a> is connected to an output node while the
+          <a>ConvolverNode</a>'s <code>buffer</code> is set to an
+          <a>AudioBuffer</a>, it <a href="#acquire-the-content">acquires the
+          content</a> of the <a>AudioBuffer</a>.
+          </li>
+          <li>When the dispatch of an <a>AudioProcessingEvent</a> completes, it
+          <a href="#acquire-the-content">acquires the contents</a> of its
+          <code>outputBuffer</code>.
+          </li>
+        </ul>
+        <p class="note">
+          This means that <code>copyToChannel</code> cannot be used to change
+          the content of an <a>AudioBuffer</a> currently in use by an
+          <code>AudioNode</code> that has <a href=
+          "#acquire-the-content">acquired the content of an AudioBuffer</a>,
+          since the <a>AudioNode</a> will continue to use the data previously
+          acquired.
+        </p>
+        <section>
+          <h2>
+            <dfn>AudioBufferOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options to use in constructing an
+            <a><code>AudioBuffer</code></a>. The <a data-link-for=
+            "AudioBufferOptions"><code>length</code></a> and <a data-link-for=
+            "AudioBufferOptions"><code>sampleRate</code></a> members are
+            required. A <code>NotFoundError</code> exception MUST be thrown if
+            any of the required members are not specified.
+          </p>
+          <pre class="idl">
+dictionary AudioBufferOptions {
+             unsigned long numberOfChannels = 1;
+    required unsigned long length;
+    required float         sampleRate;
+};
+          </pre>
+          <section>
+            <h3>
+              Dictionary <a>AudioBufferOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="AudioBufferOptions"
+            data-link-for="AudioBufferOptions">
+              <dt>
+                <code><dfn>length</dfn></code> of type <span class=
+                "idlAttrType"><code>unsigned long</code></span>, required
+              </dt>
+              <dd>
+                The length in sample frames of the buffer.
+              </dd>
+              <dt>
+                <code><dfn>numberOfChannels</dfn></code> of type <span class=
+                "idlAttrType"><code>unsigned long</code></span>, defaulting to
+                1
+              </dt>
+              <dd>
+                The number of channels for the buffer.
+              </dd>
+              <dt>
+                <code><dfn>sampleRate</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, required
+              </dt>
+              <dd>
+                The sample rate in Hz for the buffer.
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </section>
+      <section>
         <h2>
           The <dfn>AudioNode</dfn> Interface
         </h2>
@@ -4863,100 +5437,6 @@ dictionary AudioNodeOptions {
             the <a><code>AudioNode</code></a> will be deleted when its
             <a><code>AudioContext</code></a> is deleted.
           </p>
-        </section>
-      </section>
-      <section>
-        <h2 id="AudioDestinationNode">
-          The <dfn>AudioDestinationNode</dfn> Interface
-        </h2>
-        <p>
-          This is an <a><code>AudioNode</code></a> representing the final audio
-          destination and is what the user will ultimately hear. It can often
-          be considered as an audio output device which is connected to
-          speakers. All rendered audio to be heard will be routed to this node,
-          a "terminal" node in the <a><code>AudioContext</code></a>'s routing
-          graph. There is only a single AudioDestinationNode per
-          <a><code>AudioContext</code></a>, provided through the
-          <code>destination</code> attribute of
-          <a><code>AudioContext</code></a>.
-        </p>
-        <p>
-          The output of a <a><code>AudioDestinationNode</code></a> is produced
-          by <a href="#SummingJunction">summing its input</a>, allowing to
-          capture the output of an <a><code>AudioContext</code></a> into, for
-          example, a <a><code>MediaStreamAudioDestinationNode</code></a>, or a
-          <code>MediaRecorder</code> (described in [[mediastream-recording]]).
-        </p>
-        <pre>
-      numberOfInputs  : 1
-      numberOfOutputs : 1
-
-</pre>
-        <p>
-          The <a>AudioDestinationNode</a> can be either the destination of an
-          <a>AudioContext</a> or <a>OfflineAudioContext</a>, and the channel
-          properties depend on what the context is.
-        </p>
-        <p>
-          For an <a>AudioContext</a>, the defaults are
-        </p>
-        <pre>
-      channelCount = 2
-      channelCountMode = "explicit"
-      channelInterpretation = "speakers"
-</pre>
-        <p>
-          The <a data-link-for="AudioNode">channelCount</a> can be set to any
-          value less than or equal to <a data-link-for=
-          "AudioDestinationNode">maxChannelCount</a>. <span class=
-          "synchronous">An <code>IndexSizeError</code> exception MUST be thrown
-          if this value is not within the valid range.</span> Giving a concrete
-          example, if the audio hardware supports 8-channel output, then we may
-          set <a data-link-for="AudioNode">channelCount</a> to 8, and render 8
-          channels of output.
-        </p>
-        <p>
-          For an <a>OfflineAudioContext</a>, the defaults are
-        </p>
-        <pre>
-      channelCount = numberOfChannels
-      channelCountMode = "explicit"
-      channelInterpretation = "speakers"
-</pre>
-        <p>
-          where <code>numberOfChannels</code> is the number of channels
-          specified when constructing the <a>OfflineAudioContext</a>. This
-          value may not be changed; <span class="synchronous">a
-          <code>NotSupportedError</code> exception MUST be thrown if
-          <a data-link-for="AudioNode">channelCount</a> is changed to a
-          different value</span>.
-        </p>
-        <pre class="idl">
-[Exposed=Window]
-interface AudioDestinationNode : AudioNode {
-    readonly        attribute unsigned long maxChannelCount;
-};
-        </pre>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="AudioDestinationNode"
-          data-link-for="AudioDestinationNode">
-            <dt>
-              <code><dfn>maxChannelCount</dfn></code> of type <span class=
-              "idlAttrType"><code>unsigned long</code></span>, readonly
-            </dt>
-            <dd>
-              The maximum number of channels that the <a data-link-for=
-              "AudioNode"><code>channelCount</code></a> attribute can be set
-              to. An <a><code>AudioDestinationNode</code></a> representing the
-              audio hardware end-point (the normal case) can potentially output
-              more than 2 channels of audio if the audio hardware is
-              multi-channel. <code>maxChannelCount</code> is the maximum number
-              of channels that this hardware is capable of supporting.
-            </dd>
-          </dl>
         </section>
       </section>
       <section>
@@ -6400,15 +6880,13 @@ interface AudioScheduledSourceNode : AudioNode {
         </section>
       </section>
       <section>
-        <h2 id="GainNode">
-          The GainNode Interface
+        <h2>
+          The AnalyserNode Interface
         </h2>
         <p>
-          Changing the gain of an audio signal is a fundamental operation in
-          audio applications. The <code>GainNode</code> is one of the building
-          blocks for creating <a href="#mixer-gain-structure">mixers</a>. This
-          interface is an <a><code>AudioNode</code></a> with a single input and
-          single output:
+          This interface represents a node which is able to provide real-time
+          frequency and time-domain analysis information. The audio stream will
+          be passed un-processed from input to output.
         </p>
         <div class="node-info">
           <table>
@@ -6439,7 +6917,9 @@ interface AudioScheduledSourceNode : AudioNode {
               <td>
                 1
               </td>
-              <td></td>
+              <td>
+                This output may be left unconnected.
+              </td>
             </tr>
             <tr>
               <td>
@@ -6479,33 +6959,31 @@ interface AudioScheduledSourceNode : AudioNode {
             </tr>
           </table>
         </div>
-        <p>
-          Each sample of each channel of the input data of the
-          <a><code>GainNode</code></a> MUST be multiplied by the
-          <a>computedValue</a> of the <a data-link-for=
-          "GainNode"><code>gain</code></a> <a><code>AudioParam</code></a>.
-        </p>
         <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional GainOptions options)]
-interface GainNode : AudioNode {
-    readonly        attribute AudioParam gain;
+ Constructor (BaseAudioContext context, optional AnalyserOptions options)]
+interface AnalyserNode : AudioNode {
+    void getFloatFrequencyData (Float32Array array);
+    void getByteFrequencyData (Uint8Array array);
+    void getFloatTimeDomainData (Float32Array array);
+    void getByteTimeDomainData (Uint8Array array);
+                    attribute unsigned long fftSize;
+    readonly        attribute unsigned long frequencyBinCount;
+                    attribute double        minDecibels;
+                    attribute double        maxDecibels;
+                    attribute double        smoothingTimeConstant;
 };
         </pre>
         <section>
           <h3>
             Constructors
           </h3>
-          <dl class="methods" data-dfn-for="GainNode" data-link-for="GainNode">
+          <dl class="methods" data-dfn-for="AnalyserNode" data-link-for=
+          "AnalyserNode">
             <dt>
-              <code><dfn>GainNode</dfn></code>
+              <code><dfn>AnalyserNode</dfn></code>
             </dt>
             <dd>
-              <p>
-                Let <var>gain</var> be a new <a>GainNode</a> object. <a href=
-                "#audionode-constructor-init">Initialize</a> <var>gain</var>,
-                and return <var>gain</var>.
-              </p>
               <table class="parameters">
                 <tr>
                   <th>
@@ -6538,8 +7016,8 @@ interface GainNode : AudioNode {
                     <span role="img" aria-label="False">✘</span>
                   </td>
                   <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>GainNode</a> will
-                    be <a href="#associated">associated</a> with.
+                    The <a>BaseAudioContext</a> this new <a>AnalyserNode</a>
+                    will be <a href="#associated">associated</a> with.
                   </td>
                 </tr>
                 <tr>
@@ -6547,7 +7025,7 @@ interface GainNode : AudioNode {
                     options
                   </td>
                   <td class="prmType">
-                    <a><code>GainOptions</code></a>
+                    <a><code>AnalyserOptions</code></a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -6556,7 +7034,8 @@ interface GainNode : AudioNode {
                     <span role="img" aria-label="True">✔</span>
                   </td>
                   <td class="prmDesc">
-                    Optional initial parameter values for this <a>GainNode</a>.
+                    Optional initial parameter value for this
+                    <a>AnalyserNode</a>.
                   </td>
                 </tr>
               </table>
@@ -6567,585 +7046,73 @@ interface GainNode : AudioNode {
           <h3>
             Attributes
           </h3>
-          <dl class="attributes" data-dfn-for="GainNode" data-link-for=
-          "GainNode">
+          <dl class="attributes" data-dfn-for="AnalyserNode" data-link-for=
+          "AnalyserNode">
             <dt>
-              <code><dfn>gain</dfn></code> of type <span class=
-              "idlAttrType"><code>AudioParam</code></span>, readonly
+              <code><dfn>fftSize</dfn></code> of type <span class=
+              "idlAttrType"><a><code>unsigned long</code></a></span>
             </dt>
             <dd>
               <p>
-                Represents the amount of gain to apply.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>GainOptions</dfn>
-          </h2>
-          <p>
-            This specifies options to use in constructing a
-            <a><code>GainNode</code></a>. All members are optional; if not
-            specified, the normal defaults are used in constructing the node.
-          </p>
-          <pre class="idl">
-dictionary GainOptions : AudioNodeOptions {
-             float gain = 1.0;
-};
-          </pre>
-          <section>
-            <h3>
-              Dictionary <a>GainOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="GainOptions" data-link-for=
-            "GainOptions">
-              <dt>
-                <code><dfn>gain</dfn></code> of type <span class=
-                "idlAttrType"><a>float</a></span>, defaulting to 1.0
-              </dt>
-              <dd>
-                The initial gain value for the <a data-link-for=
-                "GainNode"><code>gain</code></a> AudioParam.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2 id="DelayNode">
-          The DelayNode Interface
-        </h2>
-        <p>
-          A delay-line is a fundamental building block in audio applications.
-          This interface is an <a><code>AudioNode</code></a> with a single
-          input and single output.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">max</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                Yes
-              </td>
-              <td>
-                Continues to output non-silent audio with zero input up to the
-                <a>maxDelayTime</a> of the node.
-              </td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The number of channels of the output always equals the number of
-          channels of the input.
-        </p>
-        <p>
-          It delays the incoming audio signal by a certain amount.
-          Specifically, at each time <em>t</em>, input signal
-          <em>input(t)</em>, delay time <em>delayTime(t)</em> and output signal
-          <em>output(t)</em>, the output will be <em>output(t) = input(t -
-          delayTime(t))</em>. The default <code>delayTime</code> is 0 seconds
-          (no delay).
-        </p>
-        <p>
-          When the number of channels in a <a>DelayNode</a>'s input changes
-          (thus changing the output channel count also), there may be delayed
-          audio samples which have not yet been output by the node and are part
-          of its internal state. If these samples were received earlier with a
-          different channel count, they MUST be upmixed or downmixed before
-          being combined with newly received input so that all internal
-          delay-line mixing takes place using the single prevailing channel
-          layout.
-        </p>
-        <p class="note">
-          By definition, a <a>DelayNode</a> introduces an audio processing
-          latency equal to the amount of the delay.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional DelayOptions options)]
-interface DelayNode : AudioNode {
-    readonly        attribute AudioParam delayTime;
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="DelayNode" data-link-for=
-          "DelayNode">
-            <dt>
-              <code><dfn>DelayNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>DelayNode</a> object. <a href=
-                "#audionode-constructor-init">Initialize</a> <var>node</var>,
-                and return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>DelayNode</a> will
-                    be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>DelayOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this <a>DelayNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="DelayNode" data-link-for=
-          "DelayNode">
-            <dt>
-              <code><dfn>delayTime</dfn></code> of type <span class=
-              "idlAttrType"><code>AudioParam</code></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                An <a><code>AudioParam</code></a> object representing the
-                amount of delay (in seconds) to apply. Its default
-                <code>value</code> is 0 (no delay). The minimum value is 0 and
-                the maximum value is determined by the
-                <code>maxDelayTime</code> argument to the
-                <code>AudioContext</code> method <code>createDelay</code>.
+                The size of the FFT used for frequency-domain analysis.
+                <span class="synchronous">This MUST be a power of two in the
+                range 32 to 32768, otherwise an <code>IndexSizeError</code>
+                exception MUST be thrown</span>. The default value is 2048.
+                Note that large FFT sizes can be costly to compute.
               </p>
               <p>
-                If <a><code>DelayNode</code></a> is part of a <a>cycle</a>,
-                then the value of the <a><code>delayTime</code></a> attribute
-                is clamped to a minimum of one <a>render quantum</a>.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a data-link-for="AudioNode">maxDelayTime</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>DelayOptions</dfn>
-          </h2>
-          <p>
-            This specifies options for constructing a
-            <a><code>DelayNode</code></a>. All members are optional; if not
-            given, the node is constructed using the normal defaults.
-          </p>
-          <pre class="idl">
-dictionary DelayOptions : AudioNodeOptions {
-             double maxDelayTime = 1;
-             double delayTime = 0;
-};
-          </pre>
-          <section>
-            <h3>
-              Dictionary <a>DelayOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="DelayOptions" data-link-for=
-            "DelayOptions">
-              <dt>
-                <code><dfn>delayTime</dfn></code> of type <span class=
-                "idlAttrType"><a>double</a></span>, defaulting to 0
-              </dt>
-              <dd>
-                The maximum delay time for the node.
-              </dd>
-              <dt>
-                <code><dfn>maxDelayTime</dfn></code> of type <span class=
-                "idlAttrType"><a>double</a></span>, defaulting to 1
-              </dt>
-              <dd>
-                The initial delay time for the node.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2 id="AudioBuffer">
-          The AudioBuffer Interface
-        </h2>
-        <p>
-          This interface represents a memory-resident audio asset (for one-shot
-          sounds and other short audio clips). Its format is non-interleaved
-          32-bit linear floating-point PCM values with a normal range of \([-1,
-          1]\), but values are not limited to this range. It can contain one or
-          more channels. Typically, it would be expected that the length of the
-          PCM data would be fairly short (usually somewhat less than a minute).
-          For longer sounds, such as music soundtracks, streaming should be
-          used with the <code>audio</code> element and
-          <code>MediaElementAudioSourceNode</code>.
-        </p>
-        <p>
-          An <a>AudioBuffer</a> may be used by one or more
-          <a><code>AudioContext</code></a>s, and can be shared between an
-          <a><code>OfflineAudioContext</code></a> and an
-          <a><code>AudioContext</code></a>.
-        </p>
-        <p>
-          <a>AudioBuffer</a> has four internal slots:
-        </p>
-        <dl>
-          <dt>
-            <var>[[number of channels]]</var>
-          </dt>
-          <dd>
-            The number of audio channels for this <a>AudioBuffer</a>, which is
-            an unsigned long.
-          </dd>
-          <dt>
-            <var>[[\length]]</var>
-          </dt>
-          <dd>
-            The length of each channel of this <a>AudioBuffer</a>, which is an
-            unsigned long.
-          </dd>
-          <dt>
-            [[sample rate]]
-          </dt>
-          <dd>
-            The sample-rate, in Hz, of this <a>AudioBuffer</a>, a float
-          </dd>
-          <dt>
-            [[internal data]]
-          </dt>
-          <dd>
-            A <a href="https://tc39.github.io/ecma262/#sec-data-blocks">data
-            block</a> holding the audio sample data.
-          </dd>
-        </dl>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (AudioBufferOptions options)]
-interface AudioBuffer {
-    readonly        attribute float         sampleRate;
-    readonly        attribute unsigned long length;
-    readonly        attribute double        duration;
-    readonly        attribute unsigned long numberOfChannels;
-    Float32Array getChannelData (unsigned long channel);
-    void         copyFromChannel (Float32Array destination, unsigned long channelNumber, optional unsigned long startInChannel = 0);
-    void         copyToChannel (Float32Array source, unsigned long channelNumber, optional unsigned long startInChannel = 0);
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="AudioBuffer" data-link-for=
-          "AudioBuffer">
-            <dt>
-              <code><dfn>AudioBuffer</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>b</var> be a new <a>AudioBuffer</a> object.
-                Respectively assign the values of the attributes
-                <var>numberOfChannels</var>, <var>length</var>,
-                <var>sampleRate</var> of the <a>AudioBufferOptions</a> passed
-                in the constructor to the internal slots <var>[[number of
-                channels]]</var>, <var>[[\length]]</var>, <var>[[sample
-                rate]]</var>.
-              </p>
-              <p>
-                Set the internal slot <var>[[internal data]]</var> of this
-                <a>AudioBuffer</a> to the result of calling <a href=
-                "https://tc39.github.io/ecma262/#sec-createbytedatablock"><code>
-                CreateByteDataBlock([[\length]] * [[number of
-                channels]])</code></a>.
-              </p>
-              <p class="note">
-                This initializes the underlying storage to zero.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>AudioBufferOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="AudioBuffer" data-link-for=
-          "AudioBuffer">
-            <dt>
-              <code><dfn>duration</dfn></code> of type <span class=
-              "idlAttrType"><code>double</code></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Duration of the PCM audio data in seconds.
-              </p>
-              <p>
-                This is computed from the <var>[[sample rate]]</var> and the
-                <var>[[\length]]</var> of the <a>AudioBuffer</a> by performing
-                a division between the <var>[[\length]]</var> and the
-                <var>[[sample rate]]</var>.
+                If the <code>fftSize</code> is changed to a different value,
+                then all state associated with smoothing of the frequency data
+                (for <a data-link-for=
+                "AnalyserNode"><code>getByteFrequencyData</code></a> and
+                <a data-link-for=
+                "AnalyserNode"><code>getFloatFrequencyData</code></a>) is
+                reset. That is the <a>previous block</a>, \(\hat{X}_{-1}[k]\),
+                used for <a href="#smoothing-over-time">smoothing over time</a>
+                is set to 0 for all \(k\).
               </p>
             </dd>
             <dt>
-              <code><dfn>length</dfn></code> of type <span class=
-              "idlAttrType"><code>unsigned long</code></span>, readonly
+              <code><dfn>frequencyBinCount</dfn></code> of type <span class=
+              "idlAttrType"><a><code>unsigned long</code></a></span>, readonly
             </dt>
             <dd>
-              Length of the PCM audio data in sample-frames. This MUST return
-              the value of <var>[[\length]]</var>.
+              Half the FFT size.
             </dd>
             <dt>
-              <code><dfn>numberOfChannels</dfn></code> of type <span class=
-              "idlAttrType"><code>unsigned long</code></span>, readonly
+              <code><dfn>maxDecibels</dfn></code> of type <span class=
+              "idlAttrType"><a><code>double</code></a></span>
             </dt>
             <dd>
-              The number of discrete audio channels. This MUST return the value
-              of <var>[[number of channels]]</var>.
+              <a>maxDecibels</a> is the maximum power value in the scaling
+              range for the FFT analysis data for conversion to unsigned byte
+              values. The default value is -30. <span class="synchronous">If
+              the value of this attribute is set to a value less than or equal
+              to <code><a>minDecibels</a></code>, an
+              <code>IndexSizeError</code> exception MUST be thrown.</span>
             </dd>
             <dt>
-              <code><dfn>sampleRate</dfn></code> of type <span class=
-              "idlAttrType"><code>float</code></span>, readonly
+              <code><dfn>minDecibels</dfn></code> of type <span class=
+              "idlAttrType"><a><code>double</code></a></span>
             </dt>
             <dd>
-              The sample-rate for the PCM audio data in samples per second.
-              This MUST return the value of <var>[[sample rate]]</var>.
+              <a>minDecibels</a> is the minimum power value in the scaling
+              range for the FFT analysis data for conversion to unsigned byte
+              values. The default value is -100. <span class="synchronous">If
+              the value of this attribute is set to a value more than or equal
+              to <code><a>maxDecibels</a></code>, an
+              <code>IndexSizeError</code> exception MUST be thrown.</span>
+            </dd>
+            <dt>
+              <code><dfn>smoothingTimeConstant</dfn></code> of type
+              <span class="idlAttrType"><a><code>double</code></a></span>
+            </dt>
+            <dd>
+              A value from 0 -&gt; 1 where 0 represents no time averaging with
+              the last analysis frame. The default value is 0.8. <span class=
+              "synchronous">If the value of this attribute is set to a value
+              less than 0 or more than 1, an <code>IndexSizeError</code>
+              exception MUST be thrown.</span>
             </dd>
           </dl>
         </section>
@@ -7153,26 +7120,49 @@ interface AudioBuffer {
           <h3>
             Methods
           </h3>
-          <dl class="methods" data-dfn-for="AudioBuffer" data-link-for=
-          "AudioBuffer">
+          <dl class="methods" data-dfn-for="AnalyserNode" data-link-for=
+          "AnalyserNode">
             <dt>
-              <code><dfn>copyFromChannel</dfn></code>
+              <code><dfn>getByteFrequencyData</dfn></code>
             </dt>
             <dd>
               <p>
-                The <code>copyFromChannel</code> method copies the samples from
-                the specified channel of the <a>AudioBuffer</a> to the
-                <code>destination</code> array.
+                Copies the <a>current frequency data</a> into the passed
+                unsigned byte array. If the array has fewer elements than the
+                <a><code>frequencyBinCount</code></a>, the excess elements will
+                be dropped. If the array has more elements than the
+                <a><code>frequencyBinCount</code></a>, the excess elements will
+                be ignored. The most recent <a data-link-for=
+                "AnalyserNode"><code>fftSize</code></a> frames are used in
+                computing the frequency data.
               </p>
               <p>
-                Let <code>buffer</code> be the <a>AudioBuffer</a> buffer with
-                \(N_b\) frames, let \(N_f\) be the number of elements in the
-                <code>destination</code> array, and \(k\) be the value of
-                <code>startInChannel</code>. Then the number of frames copied
-                from <code>buffer</code> to <code>destination</code> is
-                \(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
-                remaining elements of <code>destination</code> are not
-                modified.
+                If another call to <code>getByteFreqencyData</code> or
+                <code>getFloatFrequencyData</code> occurs within the same
+                <a>render quantum</a> as a previous call, the <a>current
+                frequency data</a> is not updated with the same data. Instead,
+                the previously computed data is returned.
+              </p>
+              <p>
+                The values stored in the unsigned byte array are computed in
+                the following way. Let \(Y[k]\) be the <a>current frequency
+                data</a> as described in <a href=
+                "#fft-windowing-and-smoothing-over-time">FFT windowing and
+                smoothing</a>. Then the byte value, \(b[k]\), is
+              </p>
+              <pre class="nohighlight">
+                  $$
+                    b[k] = \left\lfloor
+                        \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
+                        \left(Y[k] - \mbox{dB}_{min}\right)
+                      \right\rfloor
+                  $$
+</pre>
+              <p>
+                where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code>
+                and \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If
+                \(b[k]\) lies outside the range of 0 to 255, \(b[k]\) is
+                clipped to lie in that range.
               </p>
               <table class="parameters">
                 <tr>
@@ -7194,7 +7184,142 @@ interface AudioBuffer {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    destination
+                    array
+                  </td>
+                  <td class="prmType">
+                    <a><code>Uint8Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    This parameter is where the frequency-domain analysis data
+                    will be copied.
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>getByteTimeDomainData</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Copies the <a>current time-domain data</a> (waveform data) into
+                the passed unsigned byte array. If the array has fewer elements
+                than the value of <a data-link-for=
+                "AnalyserNode"><code>fftSize</code></a>, the excess elements
+                will be dropped. If the array has more elements than
+                <a data-link-for="AnalyserNode"><code>fftSize</code></a>, the
+                excess elements will be ignored. The most recent
+                <a data-link-for="AnalyserNode"><code>fftSize</code></a> frames
+                are used in computing the byte data.
+              </p>
+              <p>
+                The values stored in the unsigned byte array are computed in
+                the following way. Let \(x[k]\) be the time-domain data. Then
+                the byte value, \(b[k]\), is
+              </p>
+              <pre class="nohighlight">
+              $$
+                b[k] = \left\lfloor 128(1 + x[k]) \right\rfloor.
+              $$
+</pre>
+              <p>
+                If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is
+                clipped to lie in that range.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    array
+                  </td>
+                  <td class="prmType">
+                    <a><code>Uint8Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    This parameter is where the time-domain sample data will be
+                    copied.
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>getFloatFrequencyData</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Copies the <a>current frequency data</a> into the passed
+                floating-point array. If the array has fewer elements than the
+                <a><code>frequencyBinCount</code></a>, the excess elements will
+                be dropped. If the array has more elements than the
+                <a><code>frequencyBinCount</code></a>, the excess elements will
+                be ignored. The most recent <a data-link-for=
+                "AnalyserNode"><code>fftSize</code></a> frames are used in
+                computing the frequency data.
+              </p>
+              <p>
+                If another call to <code>getFloatFrequencyData</code> or
+                <code>getByteFrequencyData</code> occurs within the same
+                <a>render quantum</a> as a previous call, the <a>current
+                frequency data</a> is not updated with the same data. Instead,
+                the previously computed data is returned.
+              </p>
+              <p>
+                The frequency data are in dB units.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    array
                   </td>
                   <td class="prmType">
                     <a><code>Float32Array</code></a>
@@ -7206,49 +7331,8 @@ interface AudioBuffer {
                     <span role="img" aria-label="False">✘</span>
                   </td>
                   <td class="prmDesc">
-                    The array the channel data will be copied to.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    channelNumber
-                  </td>
-                  <td class="prmType">
-                    <a><code>unsigned long</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The index of the channel to copy the data from. If
-                    <code>channelNumber</code> is greater or equal than the
-                    number of channel of the <a>AudioBuffer</a>, <span class=
-                    "synchronous">an <code>IndexSizeError</code> MUST be
-                    thrown</span>.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    startInChannel
-                  </td>
-                  <td class="prmType">
-                    <a><code>unsigned long = 0</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    An optional offset to copy the data from. If
-                    <code>startInChannel</code> is greater than the
-                    <code>length</code> of the <a>AudioBuffer</a>, <span class=
-                    "synchronous">an <code>IndexSizeError</code> MUST be
-                    thrown</span>.
+                    This parameter is where the frequency-domain analysis data
+                    will be copied.
                   </td>
                 </tr>
               </table>
@@ -7257,23 +7341,19 @@ interface AudioBuffer {
               </div>
             </dd>
             <dt>
-              <code><dfn>copyToChannel</dfn></code>
+              <code><dfn>getFloatTimeDomainData</dfn></code>
             </dt>
             <dd>
               <p>
-                The <code>copyFromChannel</code> method copies the samples from
-                the specified channel of the <a>AudioBuffer</a> to the
-                <code>destination</code> array.
-              </p>
-              <p>
-                Let <code>buffer</code> be the <a>AudioBuffer</a> buffer with
-                \(N_b\) frames, let \(N_f\) be the number of elements in the
-                <code>destination</code> array, and \(k\) be the value of
-                <code>startInChannel</code>. Then the number of frames copied
-                from <code>buffer</code> to <code>destination</code> is
-                \(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
-                remaining elements of <code>destination</code> are not
-                modified.
+                Copies the <a>current time-domain data</a> (waveform data) into
+                the passed floating-point array. If the array has fewer
+                elements than the value of <a data-link-for=
+                "AnalyserNode"><code>fftSize</code></a>, the excess elements
+                will be dropped. If the array has more elements than
+                <a data-link-for="AnalyserNode"><code>fftSize</code></a>, the
+                excess elements will be ignored. The most recent
+                <a data-link-for="AnalyserNode"><code>fftSize</code></a> frames
+                are returned (after downmixing).
               </p>
               <table class="parameters">
                 <tr>
@@ -7295,7 +7375,7 @@ interface AudioBuffer {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    source
+                    array
                   </td>
                   <td class="prmType">
                     <a><code>Float32Array</code></a>
@@ -7307,241 +7387,221 @@ interface AudioBuffer {
                     <span role="img" aria-label="False">✘</span>
                   </td>
                   <td class="prmDesc">
-                    The array the channel data will be copied from.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    channelNumber
-                  </td>
-                  <td class="prmType">
-                    <a><code>unsigned long</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The index of the channel to copy the data to. If
-                    <code>channelNumber</code> is greater or equal than the
-                    number of channel of the <a>AudioBuffer</a>, <span class=
-                    "synchronous">an <code>IndexSizeError</code> MUST be
-                    thrown</span>.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    startInChannel
-                  </td>
-                  <td class="prmType">
-                    <a><code>unsigned long = 0</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    An optional offset to copy the data to. If
-                    <code>startInChannel</code> is greater than the
-                    <code>length</code> of the <a>AudioBuffer</a>, <span class=
-                    "synchronous">an <code>IndexSizeError</code> MUST be
-                    thrown</span>.
+                    This parameter is where the time-domain sample data will be
+                    copied.
                   </td>
                 </tr>
               </table>
               <div>
                 <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>getChannelData</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                According to the rules described in <a href=
-                "#acquire-the-content">acquire the content</a> either <a href=
-                "https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-                get a reference to</a> or <a href=
-                "https://heycam.github.io/webidl/#dfn-get-buffer-source-copy">get
-                a copy of</a> the bytes stored in [[internal data]] in a new
-                <code>Float32Array</code>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    channel
-                  </td>
-                  <td class="prmType">
-                    <a><code>unsigned long</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter is an index representing the particular
-                    channel to get data for. An index value of 0 represents the
-                    first channel. <span class="synchronous">This index value
-                    MUST be less than <code>numberOfChannels</code> or an
-                    <code>IndexSizeError</code> exception MUST be
-                    thrown.</span>
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>Float32Array</code>
               </div>
             </dd>
           </dl>
         </section>
-        <p class="note">
-          The methods <code>copyToChannel</code> and
-          <code>copyFromChannel</code> can be used to fill part of an array by
-          passing in a <code>Float32Array</code> that's a view onto the larger
-          array. When reading data from an <a>AudioBuffer</a>'s channels, and
-          the data can be processed in chunks, <code>copyFromChannel</code>
-          should be preferred to calling <code>getChannelData</code> and
-          accessing the resulting array, because it may avoid unnecessary
-          memory allocation and copying.
-        </p>
-        <p>
-          An internal operation <a href="#acquire-the-content">acquire the
-          contents of an <code>AudioBuffer</code></a> is invoked when the
-          contents of an <a>AudioBuffer</a> are needed by some API
-          implementation. This operation returns immutable channel data to the
-          invoker.
-        </p>
-        <p>
-          When an <dfn id="acquire-the-content">acquire the content</dfn>
-          operation occurs on an <a>AudioBuffer</a>, run the following steps:
-        </p>
-        <ol>
-          <li>If the operation <a href=
-          "https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
-          on any of the <a>AudioBuffer</a>'s <code>ArrayBuffer</code>s return
-          <code>true</code>, abort these steps, and return a zero-length
-          channel data buffer to the invoker.
-          </li>
-          <li>
-            <a href=
-            "https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
-            all <code>ArrayBuffer</code>s for arrays previously returned by
-            <code>getChannelData</code> on this <a>AudioBuffer</a>.
-          </li>
-          <li>Retain the underlying <var>[[internal data]]</var> from those
-          <code>ArrayBuffer</code>s and return references to them to the
-          invoker.
-          </li>
-          <li>Attach <code>ArrayBuffer</code>s containing copies of the data to
-          the <a>AudioBuffer</a>, to be returned by the next call to
-          <code>getChannelData</code>.
-          </li>
-        </ol>The <a href="#acquire-the-content">acquire the contents of an
-        AudioBuffer</a> operation is invoked in the following cases:
-        <ul>
-          <li>When <code>AudioBufferSourceNode.start</code> is called, it
-          <a href="#acquire-the-content">acquires the contents</a> of the
-          node's <code>buffer</code>. If the operation fails, nothing is
-          played.
-          </li>
-          <li>When the <code>buffer</code> of an <a>AudioBufferSourceNode</a>
-          is set and <code>AudioBufferSourceNode.start</code> has been
-          previously called, the setter <a href="#acquire-the-content">acquires
-          the content</a> of the <a>AudioBuffer</a>. If the operation fails,
-          nothing is played.
-          </li>
-          <li>When a <a>ConvolverNode</a>'s <code>buffer</code> is set to an
-          <a>AudioBuffer</a> while the node is connected to an output node, or
-          a <a>ConvolverNode</a> is connected to an output node while the
-          <a>ConvolverNode</a>'s <code>buffer</code> is set to an
-          <a>AudioBuffer</a>, it <a href="#acquire-the-content">acquires the
-          content</a> of the <a>AudioBuffer</a>.
-          </li>
-          <li>When the dispatch of an <a>AudioProcessingEvent</a> completes, it
-          <a href="#acquire-the-content">acquires the contents</a> of its
-          <code>outputBuffer</code>.
-          </li>
-        </ul>
-        <p class="note">
-          This means that <code>copyToChannel</code> cannot be used to change
-          the content of an <a>AudioBuffer</a> currently in use by an
-          <code>AudioNode</code> that has <a href=
-          "#acquire-the-content">acquired the content of an AudioBuffer</a>,
-          since the <a>AudioNode</a> will continue to use the data previously
-          acquired.
-        </p>
         <section>
           <h2>
-            <dfn>AudioBufferOptions</dfn>
+            <dfn>AnalyserOptions</dfn>
           </h2>
           <p>
-            This specifies the options to use in constructing an
-            <a><code>AudioBuffer</code></a>. The <a data-link-for=
-            "AudioBufferOptions"><code>length</code></a> and <a data-link-for=
-            "AudioBufferOptions"><code>sampleRate</code></a> members are
-            required. A <code>NotFoundError</code> exception MUST be thrown if
-            any of the required members are not specified.
+            This specifies the options to be used when constructing an
+            <a><code>AnalyserNode</code></a>. All members are optional; if not
+            specified, the normal default values are used to construct the
+            node.
           </p>
           <pre class="idl">
-dictionary AudioBufferOptions {
-             unsigned long numberOfChannels = 1;
-    required unsigned long length;
-    required float         sampleRate;
+dictionary AnalyserOptions : AudioNodeOptions {
+             unsigned long fftSize = 2048;
+             double        maxDecibels = -30;
+             double        minDecibels = -100;
+             double        smoothingTimeConstant = 0.8;
 };
-          </pre>
+        </pre>
           <section>
             <h3>
-              Dictionary <a>AudioBufferOptions</a> Members
+              Dictionary <a>AnalyserOptions</a> Members
             </h3>
-            <dl class="attributes" data-dfn-for="AudioBufferOptions"
-            data-link-for="AudioBufferOptions">
+            <dl class="attributes" data-dfn-for="AnalyserOptions"
+            data-link-for="AnalyserOptions">
               <dt>
-                <code><dfn>length</dfn></code> of type <span class=
-                "idlAttrType"><code>unsigned long</code></span>, required
-              </dt>
-              <dd>
-                The length in sample frames of the buffer.
-              </dd>
-              <dt>
-                <code><dfn>numberOfChannels</dfn></code> of type <span class=
+                <code><dfn>fftSize</dfn></code> of type <span class=
                 "idlAttrType"><code>unsigned long</code></span>, defaulting to
-                1
+                2048
               </dt>
               <dd>
-                The number of channels for the buffer.
+                The desired initial size of the FFT for frequency-domain
+                analysis.
               </dd>
               <dt>
-                <code><dfn>sampleRate</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, required
+                <code><dfn>maxDecibels</dfn></code> of type <span class=
+                "idlAttrType"><code>double</code></span>, defaulting to -30
               </dt>
               <dd>
-                The sample rate in Hz for the buffer.
+                The desired initial maximum power in dB for FFT analysis.
+              </dd>
+              <dt>
+                <code><dfn>minDecibels</dfn></code> of type <span class=
+                "idlAttrType"><code>double</code></span>, defaulting to -100
+              </dt>
+              <dd>
+                The desired initial minimum power in dB for FFT analysis.
+              </dd>
+              <dt>
+                <code><dfn>smoothingTimeConstant</dfn></code> of type
+                <span class="idlAttrType"><code>unsigned long</code></span>,
+                defaulting to 0.8
+              </dt>
+              <dd>
+                The desired initial smoothing constant for the FFT analysis.
               </dd>
             </dl>
           </section>
+        </section>
+        <section>
+          <h3>
+            Time-Domain Down-Mixing
+          </h3>
+          <p>
+            When the <dfn>current time-domain data</dfn> are computed, the
+            input signal must be <a href=
+            "#channel-up-mixing-and-down-mixing">down-mixed</a> to mono as if
+            <a data-link-for="AudioNode">channelCount</a> is 1,
+            <a data-link-for="AudioNode">channelCountMode</a> is
+            "<a data-link-for="ChannelCountMode">max</a>" and <a data-link-for=
+            "AudioNode">channelInterpretation</a> is "<a data-link-for=
+            "ChannelInterpretation">speakers</a>". This is independent of the
+            settings for the <a>AnalyserNode</a> itself. The most recent
+            <a data-link-for="AnalyserNode">fftSize</a> frames are used for the
+            down-mixing operation.
+          </p>
+        </section>
+        <section data-link-for="AnalyserNode">
+          <h3>
+            FFT Windowing and smoothing over time
+          </h3>When the <dfn id="current-frequency-data">current frequency
+          data</dfn> are computed, the following operations are to be
+          performed:
+          <ol>
+            <li>Compute the <a>current time-domain data</a>.
+            </li>
+            <li>
+              <a href="#blackman-window">Apply a Blackman window</a> to the
+              time domain input data.
+            </li>
+            <li>
+              <a href="#fourier-transform">Apply a Fourier transform</a> to the
+              windowed time domain input data to get imaginary and real
+              frequency data.
+            </li>
+            <li>
+              <a href="#smoothing-over-time">Smooth over time</a> the frequency
+              domain data.
+            </li>
+            <li>
+              <a href="#conversion-to-db">Conversion to dB</a>.
+            </li>
+          </ol>
+          <p>
+            In the following, let \(N\) be the value of the
+            <code>.fftSize</code> attribute of this <code>AnalyserNode</code>.
+          </p>
+          <p>
+            <dfn id="blackman-window">Applying a Blackman window</dfn> consists
+            in the following operation on the input time domain data. Let
+            \(x[n]\) for \(n = 0, \ldots, N - 1\) be the time domain data. The
+            Blackman window is defined by
+          </p>
+          <pre class="nohighlight">
+          $$
+          \begin{align*}
+            \alpha &amp;= \mbox{0.16} \\ a_0 &amp;= \frac{1-\alpha}{2} \\
+             a_1   &amp;= \frac{1}{2} \\
+             a_2   &amp;= \frac{\alpha}{2} \\
+             w[n] &amp;= a_0 - a_1 \cos\frac{2\pi n}{N} + a_2 \cos\frac{4\pi n}{N}, \mbox{ for } n = 0, \ldots, N - 1
+           \end{align*}
+           $$
+
+</pre>
+          <p>
+            The windowed signal \(\hat{x}[n]\) is
+          </p>
+          <pre class="nohighlight">
+            $$
+              \hat{x}[n] = x[n] w[n], \mbox{ for } n = 0, \ldots, N - 1
+            $$
+
+</pre>
+          <p>
+            <dfn id="fourier-transform">Applying a Fourier transform</dfn>
+            consists of computing the Fourier transform in the following way.
+            Let \(X[k]\) be the complex frequency domain data and
+            \(\hat{x}[n]\) be the windowed time domain data computed above.
+            Then
+          </p>
+          <pre class="nohighlight">
+            $$
+              X[k] = \frac{1}{N} \sum_{n = 0}^{N - 1} \hat{x}[n]\, e^{\frac{-2\pi i k n}{N}}
+            $$
+</pre>
+          <p>
+            for \(k = 0, \dots, N/2-1\).
+          </p>
+          <p>
+            <dfn id="smoothing-over-time">Smoothing over time</dfn> frequency
+            data consists in the following operation:
+          </p>
+          <ul>
+            <li>Let \(\hat{X}_{-1}[k]\) be the result of this operation on the
+            <a>previous block</a>. The <dfn>previous block</dfn> is defined as
+            being the buffer computed by the previous <a href=
+            "#smoothing-over-time">smoothing over time</a> operation, or an
+            array of \(N\) zeros if this is the first time we are <a href=
+            "#smoothing-over-time">smoothing over time</a>.
+            </li>
+            <li>Let \(\tau\) be the value of the <a data-link-for=
+            "AnalyserNode"><code>smoothingTimeConstant</code></a> attribute for
+            this <a><code>AnalyserNode</code></a>.
+            </li>
+            <li>Let \(X[k]\) be the result of <a href=
+            "#fourier-transform">applying a Fourier transform</a> of the
+            current block.
+            </li>
+          </ul>
+          <p>
+            Then the smoothed value, \(\hat{X}[k]\), is computed by
+          </p>
+          <pre class="nohighlight">
+            $$
+              \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]|
+            $$
+
+</pre>
+          <p>
+            for \(k = 0, \ldots, N - 1\).
+          </p>
+          <p>
+            <dfn id="conversion-to-db">Conversion to dB</dfn> consists of the
+            following operation, where \(\hat{X}[k]\) is computed in <a href=
+            "#smoothing-over-time">smoothing over time</a>:
+          </p>
+          <pre class="nohighlight">
+          $$
+            Y[k] = 20\log_{10}\hat{X}[k]
+          $$
+
+</pre>
+          <p>
+            for \(k = 0, \ldots, N-1\).
+          </p>
+          <p>
+            This array, \(Y[k]\), is copied to the output array for
+            <code>getFloatFrequencyData</code>. For
+            <code>getByteFrequencyData</code>, the \(Y[k]\) is clipped to lie
+            between <code><a>minDecibels</a></code> and
+            <code><a>maxDecibels</a></code> and then scaled to fit in an
+            unsigned byte such that <code><a>minDecibels</a></code> is
+            represented by the value 0 and <code><a>maxDecibels</a></code> is
+            represented by the value 255.
+          </p>
         </section>
       </section>
       <section>
@@ -8624,153 +8684,619 @@ function process(numberOfFrames) {
         </section>
       </section>
       <section>
-        <h2 id="ConstantSourceNode">
-          The ConstantSourceNode Interface
+        <h2 id="AudioDestinationNode">
+          The <dfn>AudioDestinationNode</dfn> Interface
         </h2>
         <p>
-          This interface represents a constant audio source whose output is
-          nominally a constant value. It is useful as a constant source node in
-          general and can be used as if it were a constructible
-          <a><code>AudioParam</code></a> by automating its
-          <a><code>offset</code></a> or connecting another node to it.
+          This is an <a><code>AudioNode</code></a> representing the final audio
+          destination and is what the user will ultimately hear. It can often
+          be considered as an audio output device which is connected to
+          speakers. All rendered audio to be heard will be routed to this node,
+          a "terminal" node in the <a><code>AudioContext</code></a>'s routing
+          graph. There is only a single AudioDestinationNode per
+          <a><code>AudioContext</code></a>, provided through the
+          <code>destination</code> attribute of
+          <a><code>AudioContext</code></a>.
         </p>
         <p>
-          The single output of this node consists of one channel (mono).
+          The output of a <a><code>AudioDestinationNode</code></a> is produced
+          by <a href="#SummingJunction">summing its input</a>, allowing to
+          capture the output of an <a><code>AudioContext</code></a> into, for
+          example, a <a><code>MediaStreamAudioDestinationNode</code></a>, or a
+          <code>MediaRecorder</code> (described in [[mediastream-recording]]).
         </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                0
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
+        <pre>
+      numberOfInputs  : 1
+      numberOfOutputs : 1
+
+</pre>
+        <p>
+          The <a>AudioDestinationNode</a> can be either the destination of an
+          <a>AudioContext</a> or <a>OfflineAudioContext</a>, and the channel
+          properties depend on what the context is.
+        </p>
+        <p>
+          For an <a>AudioContext</a>, the defaults are
+        </p>
+        <pre>
+      channelCount = 2
+      channelCountMode = "explicit"
+      channelInterpretation = "speakers"
+</pre>
+        <p>
+          The <a data-link-for="AudioNode">channelCount</a> can be set to any
+          value less than or equal to <a data-link-for=
+          "AudioDestinationNode">maxChannelCount</a>. <span class=
+          "synchronous">An <code>IndexSizeError</code> exception MUST be thrown
+          if this value is not within the valid range.</span> Giving a concrete
+          example, if the audio hardware supports 8-channel output, then we may
+          set <a data-link-for="AudioNode">channelCount</a> to 8, and render 8
+          channels of output.
+        </p>
+        <p>
+          For an <a>OfflineAudioContext</a>, the defaults are
+        </p>
+        <pre>
+      channelCount = numberOfChannels
+      channelCountMode = "explicit"
+      channelInterpretation = "speakers"
+</pre>
+        <p>
+          where <code>numberOfChannels</code> is the number of channels
+          specified when constructing the <a>OfflineAudioContext</a>. This
+          value may not be changed; <span class="synchronous">a
+          <code>NotSupportedError</code> exception MUST be thrown if
+          <a data-link-for="AudioNode">channelCount</a> is changed to a
+          different value</span>.
+        </p>
         <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ConstantSourceOptions options)]
-interface ConstantSourceNode : AudioScheduledSourceNode {
-    readonly        attribute AudioParam offset;
+[Exposed=Window]
+interface AudioDestinationNode : AudioNode {
+    readonly        attribute unsigned long maxChannelCount;
 };
         </pre>
         <section>
           <h3>
-            Constructors
+            Attributes
           </h3>
-          <dl class="methods" data-dfn-for="ConstantSourceNode" data-link-for=
-          "ConstantSourceNode">
+          <dl class="attributes" data-dfn-for="AudioDestinationNode"
+          data-link-for="AudioDestinationNode">
             <dt>
-              <code><dfn>ConstantSourceNode</dfn></code>
+              <code><dfn>maxChannelCount</dfn></code> of type <span class=
+              "idlAttrType"><code>unsigned long</code></span>, readonly
             </dt>
             <dd>
-              Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
-              <a href="#audionode-constructor-init">Initialize</a>
-              <var>node</var>, and return <var>node</var>.
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>ConstantSourceNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>ConstantSourceOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>ConstantSourceNode</a>.
-                  </td>
-                </tr>
-              </table>
+              The maximum number of channels that the <a data-link-for=
+              "AudioNode"><code>channelCount</code></a> attribute can be set
+              to. An <a><code>AudioDestinationNode</code></a> representing the
+              audio hardware end-point (the normal case) can potentially output
+              more than 2 channels of audio if the audio hardware is
+              multi-channel. <code>maxChannelCount</code> is the maximum number
+              of channels that this hardware is capable of supporting.
             </dd>
           </dl>
         </section>
+      </section>
+      <section>
+        <h2 id="AudioListener">
+          The <dfn>AudioListener</dfn> Interface
+        </h2>
+        <p>
+          This interface represents the position and orientation of the person
+          listening to the audio scene. All <a><code>PannerNode</code></a>
+          objects spatialize in relation to the
+          <a><code>BaseAudioContext</code></a>'s <a data-link-for=
+          "BaseAudioContext">listener</a>. See <a>Spatialization/Panning</a>
+          for more details about spatialization.
+        </p>
+        <p>
+          The <code>positionX, positionY, positionZ</code> parameters represent
+          the location of the listener in 3D Cartesian coordinate space.
+          <a><code>PannerNode</code></a> objects use this position relative to
+          individual audio sources for spatialization.
+        </p>
+        <p>
+          The <code>forwardX, forwardY, forwardZ</code> parameters represent a
+          direction vector in 3D space. Both a <code>forward</code> vector and
+          an <code>up</code> vector are used to determine the orientation of
+          the listener. In simple human terms, the <code>forward</code> vector
+          represents which direction the person's nose is pointing. The
+          <code>up</code> vector represents the direction the top of a person's
+          head is pointing. These two vectors are expected to be linearly
+          independent. For normative requirements of how these values are to be
+          interpreted, see the <a>Spatialization/Panning</a> section.
+        </p>
+        <pre class="idl">
+[Exposed=Window]
+interface AudioListener {
+    readonly        attribute AudioParam positionX;
+    readonly        attribute AudioParam positionY;
+    readonly        attribute AudioParam positionZ;
+    readonly        attribute AudioParam forwardX;
+    readonly        attribute AudioParam forwardY;
+    readonly        attribute AudioParam forwardZ;
+    readonly        attribute AudioParam upX;
+    readonly        attribute AudioParam upY;
+    readonly        attribute AudioParam upZ;
+    void setPosition (float x, float y, float z);
+    void setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
+};
+        </pre>
         <section>
           <h3>
             Attributes
           </h3>
-          <dl class="attributes" data-dfn-for="ConstantSourceNode"
-          data-link-for="ConstantSourceNode">
+          <p>
+            For all of the following <a>AudioParam</a>s, the <a>AudioParam</a>
+            rate is specified by the <dfn>listener <a>AudioParam</a> rate</dfn>
+            which is <a>a-rate</a> when any connected <a>PannerNode</a> is
+            <a>a-rate</a> and is <a>k-rate</a> otherwise.
+          </p>
+          <dl class="attributes" data-dfn-for="AudioListener" data-link-for=
+          "AudioListener">
             <dt>
-              <code><dfn>offset</dfn></code> of type <span class=
+              <code><dfn>forwardX</dfn></code> of type <span class=
               "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
             </dt>
             <dd>
               <p>
-                The constant value of the source.
+                Sets the x coordinate component of the forward direction the
+                listener is pointing in 3D Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>forwardY</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the y coordinate component of the forward direction the
+                listener is pointing in 3D Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>forwardZ</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the z coordinate component of the forward direction the
+                listener is pointing in 3D Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      -1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>positionX</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the x coordinate position of the audio listener in a 3D
+                Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>positionY</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the y coordinate position of the audio listener in a 3D
+                Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>positionZ</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the z coordinate position of the audio listener in a 3D
+                Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>upX</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the x coordinate component of the up direction the
+                listener is pointing in 3D Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>upY</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the y coordinate component of the up direction the
+                listener is pointing in 3D Cartesian coordinate space.
               </p>
               <div class="audioparam-info">
                 <table>
@@ -8820,10 +9346,75 @@ interface ConstantSourceNode : AudioScheduledSourceNode {
                     <td>
                       Rate
                     </td>
+                    <td></td>
                     <td>
-                      <a>a-rate</a>
+                      See <a>listener AudioParam rate</a>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>upZ</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Sets the z coordinate component of the up direction the
+                listener is pointing in 3D Cartesian coordinate space.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
                     </td>
                     <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td></td>
+                    <td>
+                      See <a>listener AudioParam rate</a>
+                    </td>
                   </tr>
                 </table>
               </div>
@@ -8831,118 +9422,56 @@ interface ConstantSourceNode : AudioScheduledSourceNode {
           </dl>
         </section>
         <section>
-          <h2>
-            <dfn>ConstantSourceOptions</dfn>
-          </h2>
-          <p>
-            This specifies options for constructing a
-            <a><code>ConstantSourceNode</code></a>. All members are optional;
-            if not specified, the normal defaults are used for constructing the
-            node.
-          </p>
-          <pre class="idl">
-dictionary ConstantSourceOptions {
-             float offset = 1;
-};
-          </pre>
-          <section>
-            <h3>
-              Dictionary <a>ConstantSourceOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="ConstantSourceOptions"
-            data-link-for="ConstantSourceOptions">
-              <dt>
-                <code><dfn>offset</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 1
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "ConstantSourceNode"><code>offset</code></a> AudioParam of this
-                node.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2 id="MediaElementAudioSourceNode">
-          The MediaElementAudioSourceNode Interface
-        </h2>
-        <p>
-          This interface represents an audio source from an <code>audio</code>
-          or <code>video</code> element.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                0
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The number of channels of the output corresponds to the number of
-          channels of the media referenced by the
-          <code>HTMLMediaElement</code>. Thus, changes to the media element's
-          <code>src</code> attribute can change the number of channels output
-          by this node.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, MediaElementAudioSourceOptions options)]
-interface MediaElementAudioSourceNode : AudioNode {
-    [SameObject]
-    readonly        attribute HTMLMediaElement mediaElement;
-};
-        </pre>
-        <section>
           <h3>
-            Constructors
+            Methods
           </h3>
-          <dl class="methods" data-dfn-for="MediaElementAudioSourceNode"
-          data-link-for="MediaElementAudioSourceNode">
+          <dl class="methods" data-dfn-for="AudioListener" data-link-for=
+          "AudioListener">
             <dt>
-              <code><dfn>MediaElementAudioSourceNode</dfn></code>
+              <code><dfn>setOrientation</dfn></code>
             </dt>
             <dd>
               <p>
-                Let <var>node</var> be a new <a>MediaElementAudioSourceNode</a>
-                object. <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>, and return <var>node</var>.
+                This method is DEPRECATED. It is equivalent to setting
+                <a>forwardX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>forwardY</a>.<a data-link-for="AudioParam">value</a>,
+                <a>forwardZ</a>.<a data-link-for="AudioParam">value</a>,
+                <a>upX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>upY</a>.<a data-link-for="AudioParam">value</a>, and
+                <a>upZ</a>.<a data-link-for="AudioParam">value</a> directly
+                with the given <code>x</code>, <code>y</code>, <code>z</code>,
+                <code>xUp</code>, <code>yUp</code>, and <code>zUp</code>
+                values, respectively.
+              </p>
+              <p>
+                Consequently, if any of the <a>forwardX</a>, <a>forwardY</a>,
+                <a>forwardZ</a>, <a>upX</a>, <a>upY</a> and <a>upZ</a>
+                <a>AudioParam</a>s have an automation curve set using
+                <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
+                this method is called, a <code>NotSupportedError</code> MUST be
+                thrown.
+              </p>
+              <p>
+                Describes which direction the listener is pointing in the 3D
+                cartesian coordinate space. Both a <b>front</b> vector and an
+                <b>up</b> vector are provided. In simple human terms, the
+                <b>front</b> vector represents which direction the person's
+                nose is pointing. The <b>up</b> vector represents the direction
+                the top of a person's head is pointing. These two vectors are
+                expected to be linearly independent. For normative requirements
+                of how these values are to be interpreted, see the <a href=
+                "#Spatialization">spatialization section</a>.
+              </p>
+              <p>
+                The <code>x, y, z</code> parameters represent a <b>front</b>
+                direction vector in 3D space, with the default value being
+                (0,0,-1).
+              </p>
+              <p>
+                The <code>xUp, yUp, zUp</code> parameters represent an
+                <b>up</b> direction vector in 3D space, with the default value
+                being (0,1,0).
               </p>
               <table class="parameters">
                 <tr>
@@ -8964,10 +9493,10 @@ interface MediaElementAudioSourceNode : AudioNode {
                 </tr>
                 <tr>
                   <td class="prmName">
-                    context
+                    x
                   </td>
                   <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
+                    <a><code>float</code></a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -8975,18 +9504,14 @@ interface MediaElementAudioSourceNode : AudioNode {
                   <td class="prmOptFalse">
                     <span role="img" aria-label="False">✘</span>
                   </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>MediaElementAudioSourceNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
+                  <td class="prmDesc"></td>
                 </tr>
                 <tr>
                   <td class="prmName">
-                    options
+                    y
                   </td>
                   <td class="prmType">
-                    <a><code>MediaElementAudioSourceOptions</code></a>
+                    <a><code>float</code></a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -8994,116 +9519,292 @@ interface MediaElementAudioSourceNode : AudioNode {
                   <td class="prmOptFalse">
                     <span role="img" aria-label="False">✘</span>
                   </td>
-                  <td class="prmDesc">
-                    Parameter value for this
-                    <a>MediaElementAudioSourceNode</a>.
+                  <td class="prmDesc"></td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    z
                   </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    xUp
+                  </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    yUp
+                  </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    zUp
+                  </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>setPosition</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                This method is DEPRECATED. It is equivalent to setting
+                <a>positionX</a>.<a data-link-for="AudioParam">value</a>,
+                <a>positionY</a>.<a data-link-for="AudioParam">value</a>, and
+                <a>positionZ</a>.<a data-link-for="AudioParam">value</a>
+                directly with the given <code>x</code>, <code>y</code>, and
+                <code>z</code> values, respectively.
+              </p>
+              <p>
+                Consequently, any of the <a>positionX</a>, <a>positionY</a>,
+                and <a>positionZ</a> <a>AudioParam</a>s for this
+                <a>AudioListenerNode</a> have an automation curve set using
+                <a data-link-for=
+                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
+                this method is called, a <code>NotSupportedError</code> MUST be
+                thrown.
+              </p>
+              <p>
+                Sets the position of the listener in a 3D cartesian coordinate
+                space. <a><code>PannerNode</code></a> objects use this position
+                relative to individual audio sources for spatialization.
+              </p>
+              <p>
+                The <code>x, y, z</code> parameters represent the coordinates
+                in 3D space.
+              </p>
+              <p>
+                The default value is (0,0,0)
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    x
+                  </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    y
+                  </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    z
+                  </td>
+                  <td class="prmType">
+                    <a><code>float</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
                 </tr>
               </table>
             </dd>
           </dl>
         </section>
+      </section>
+      <section class="informative">
+        <h2>
+          The <dfn>AudioProcessingEvent</dfn> Interface - DEPRECATED
+        </h2>
+        <p>
+          This is an <code>Event</code> object which is dispatched to
+          <a><code>ScriptProcessorNode</code></a> nodes. It will be removed
+          when the ScriptProcessorNode is removed, as the replacement
+          <a>AudioWorkletNode</a> uses a different approach.
+        </p>
+        <p>
+          The event handler processes audio from the input (if any) by
+          accessing the audio data from the <code>inputBuffer</code> attribute.
+          The audio data which is the result of the processing (or the
+          synthesized data if there are no inputs) is then placed into the
+          <code>outputBuffer</code>.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (DOMString type, AudioProcessingEventInit eventInitDict)]
+interface AudioProcessingEvent : Event {
+    readonly        attribute double      playbackTime;
+    readonly        attribute AudioBuffer inputBuffer;
+    readonly        attribute AudioBuffer outputBuffer;
+};
+          </pre>
         <section>
           <h3>
             Attributes
           </h3>
-          <dl class="attributes" data-dfn-for="MediaElementAudioSourceNode"
-          data-link-for="MediaElementAudioSourceNode">
+          <dl class="attributes" data-dfn-for="AudioProcessingEvent"
+          data-link-for="AudioProcessingEvent">
             <dt>
-              <code><dfn>mediaElement</dfn></code> of type <span class=
-              "idlAttrType"><a><code>HTMLMediaElement</code></a></span>,
-              readonly
+              <code><dfn>inputBuffer</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioBuffer</code></a></span>, readonly
             </dt>
             <dd>
-              the <code>HTMLMediaElement</code> used when constructing this
-              <a>MediaElementAudioSourceNode</a>.
+              An AudioBuffer containing the input audio data. It will have a
+              number of channels equal to the
+              <code>numberOfInputChannels</code> parameter of the
+              createScriptProcessor() method. This AudioBuffer is only valid
+              while in the scope of the <a data-link-for=
+              "ScriptProcessorNode"><code>onaudioprocess</code></a> function.
+              Its values will be meaningless outside of this scope.
+            </dd>
+            <dt>
+              <code><dfn>outputBuffer</dfn></code> of type <span class=
+              "idlAttrType"><code>AudioBuffer</code></span>, readonly
+            </dt>
+            <dd>
+              An AudioBuffer where the output audio data MUST be written. It
+              will have a number of channels equal to the
+              <code>numberOfOutputChannels</code> parameter of the
+              createScriptProcessor() method. Script code within the scope of
+              the <a data-link-for=
+              "ScriptProcessorNode"><code>onaudioprocess</code></a> function is
+              expected to modify the <code>Float32Array</code> arrays
+              representing channel data in this AudioBuffer. Any script
+              modifications to this AudioBuffer outside of this scope will not
+              produce any audible effects.
+            </dd>
+            <dt>
+              <code><dfn>playbackTime</dfn></code> of type <span class=
+              "idlAttrType"><code>double</code></span>, defaulting to 0
+            </dt>
+            <dd>
+              The time when the audio will be played in the same time
+              coordinate system as the <a><code>AudioContext</code></a>'s
+              <a data-link-for="BaseAudioContext">currentTime</a>.
             </dd>
           </dl>
         </section>
-        <p>
-          A <a>MediaElementAudioSourceNode</a> is created given an
-          <code>HTMLMediaElement</code> using the <a>AudioContext</a>
-          <code>createMediaElementSource()</code> method.
-        </p>
-        <p>
-          The number of channels of the single output equals the number of
-          channels of the audio referenced by the <code>HTMLMediaElement</code>
-          passed in as the argument to <code>createMediaElementSource()</code>,
-          or is 1 if the <code>HTMLMediaElement</code> has no audio.
-        </p>
-        <p>
-          The <code>HTMLMediaElement</code> MUST behave in an identical fashion
-          after the <a>MediaElementAudioSourceNode</a> has been created,
-          <em>except</em> that the rendered audio will no longer be heard
-          directly, but instead will be heard as a consequence of the
-          <a>MediaElementAudioSourceNode</a> being connected through the
-          routing graph. Thus pausing, seeking, volume, <code>src</code>
-          attribute changes, and other aspects of the
-          <code>HTMLMediaElement</code> MUST behave as they normally would if
-          <em>not</em> used with a <a>MediaElementAudioSourceNode</a>.
-        </p>
-        <pre class="example">
-  var mediaElement = document.getElementById('mediaElementID');
-  var sourceNode = context.createMediaElementSource(mediaElement);
-  sourceNode.connect(filterNode);
-</pre>
         <section>
-          <h2>
-            <dfn>MediaElementAudioSourceOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options to use in constructing a
-            <a><code>MediaElementAudioSourceNode</code></a>.
-          </p>
+          <h3>
+            <dfn>AudioProcessingEventInit</dfn>
+          </h3>
           <pre class="idl">
-dictionary MediaElementAudioSourceOptions {
-    required HTMLMediaElement mediaElement;
+dictionary AudioProcessingEventInit : EventInit {
+    required double      playbackTime;
+    required AudioBuffer inputBuffer;
+    required AudioBuffer outputBuffer;
 };
-          </pre>
+            </pre>
           <section>
             <h3>
-              Dictionary <a>MediaElementAudioSourceOptions</a> Members
+              Dictionary <a>AudioProcessingEventInit</a> Members
             </h3>
-            <dl class="attributes" data-dfn-for=
-            "MediaElementAudioSourceOptions" data-link-for=
-            "MediaElementAudioSourceOptions">
+            <dl class="attributes" data-dfn-for="AudioProcessingEventInit"
+            data-link-for="AudioProcessingEventInit">
               <dt>
-                <code><dfn>mediaElement</dfn></code> of type <span class=
-                "idlAttrType"><code>HTMLMediaElement</code></span>, required
+                <code><dfn>inputBuffer</dfn></code> of type <span class=
+                "idlAttrType"><code>AudioBuffer</code></span>, required
               </dt>
               <dd>
-                The media element that will be re-routed. This MUST be
-                specified.
+                Value to be assigned to the <a data-link-for=
+                "AudioProcessingEvent"><code>inputBuffer</code></a> attribute
+                of the event.
+              </dd>
+              <dt>
+                <code><dfn>outputBuffer</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, required
+              </dt>
+              <dd>
+                Value to be assigned to the <a data-link-for=
+                "AudioProcessingEvent"><code>outputBuffer</code></a> attribute
+                of the event.
+              </dd>
+              <dt>
+                <code><dfn>playbackTime</dfn></code> of type <span class=
+                "idlAttrType"><code>double</code></span>, required
+              </dt>
+              <dd>
+                Value to be assigned to the <a data-link-for=
+                "AudioProcessingEvent"><code>playbackTime</code></a> attribute
+                of the event.
               </dd>
             </dl>
           </section>
-        </section>
-        <section>
-          <h2>
-            Security with MediaElementAudioSourceNode and cross-origin
-            resources
-          </h2>
-          <p>
-            <code>HTMLMediaElement</code> allows the playback of cross-origin
-            resources. Because Web Audio allows inspection of the content of
-            the resource (e.g. using a <a>MediaElementAudioSourceNode</a>, and
-            a <a>ScriptProcessorNode</a> to read the samples), information
-            leakage can occur if scripts from one <a href=
-            "http://www.w3.org/html/wg/drafts/html/master/browsers.html#origin">
-            origin</a> inspect the content of a resource from another <a href=
-            "http://www.w3.org/html/wg/drafts/html/master/browsers.html#origin">
-            origin</a>.
-          </p>
-          <p>
-            To prevent this, a <a>MediaElementAudioSourceNode</a> MUST output
-            <em>silence</em> instead of the normal output of the
-            <code>HTMLMediaElement</code> if it has been created using an
-            <code>HTMLMediaElement</code> for which the execution of the
-            <a href="https://fetch.spec.whatwg.org/#fetching">fetch
-            algorithm</a> labeled the resource as <a href=
-            "http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cross-origin">
-            CORS-cross-origin</a>.
-          </p>
         </section>
       </section>
       <section>
@@ -9871,279 +10572,6 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
           </section>
         </section>
         <section>
-          <h2 id="AudioWorkletProcessor">
-            The <dfn>AudioWorkletProcessor</dfn> Interface
-          </h2>
-          <p>
-            This interface represents an audio processing code that runs on the
-            audio <a>rendering thread</a>. It lives in an
-            <a><code>AudioWorkletGlobalScope</code></a> and the definition of
-            the class manifests the actual audio processing mechanism of a
-            custom audio node. <a><code>AudioWorkletProcessor</code></a> can
-            only be instantiated by the construction of an
-            <a><code>AudioWorkletNode</code></a> instance. Every
-            <a>AudioWorkletProcessor</a> has an associated <dfn>node
-            reference</dfn>, initially null.
-          </p>
-          <pre class="idl">
-[Exposed=AudioWorklet]
-interface AudioWorkletProcessor {
-    readonly        attribute MessagePort port;
-};
-          </pre>
-          <section>
-            <h3>
-              Attributes
-            </h3>
-            <dl class="attributes" data-dfn-for="AudioWorkletProcessor"
-            data-link-for="AudioWorkletProcessor">
-              <dt>
-                <code><dfn>port</dfn></code> of type <span class=
-                "idlAttrType"><a><code>MessagePort</code></a></span>, readonly
-              </dt>
-              <dd>
-                Every <a>AudioWorkletProcessor</a> has an associated
-                <code>port</code> which is a <a href=
-                "https://html.spec.whatwg.org/multipage/comms.html#message-ports">
-                MessagePort</a>. It is connected to the port on the
-                corresponding <a>AudioWorkletProcessor</a> object allowing
-                bidirectional communication between a pair of
-                <a>AudioWorkletNode</a> and <a>AudioWorkletProcessor</a>.
-              </dd>
-            </dl>
-          </section>
-          <section>
-            <h2 id="defining-a-valid-audioworkletprocessor">
-              Defining A Valid AudioWorkletProcessor
-            </h2>
-            <p>
-              User can define a custom audio processor by extending
-              <a>AudioWorkletProcessor</a>. The subclass MUST define a method
-              named <code>process()</code> that implements the audio processing
-              algorithm and have a valid static property named
-              <code><dfn>parameterDescriptors</dfn></code> which is an iterable
-              of <a>AudioParamDescriptor</a> that is looked up by the
-              <a>AudioWorkletProcessor</a> constructor to create instances of
-              <a>AudioParam</a> in the <code>parameters</code> maplike storage
-              in the node. The step 5 and 6 of <a data-link-for=
-              "AudioWorkletGlobalScope">registerProcessor()</a> ensure the
-              validity of a given <a>AudioWorkletProcessor</a> subclass.
-            </p>
-            <p>
-              An example of a valid subclass is as follows:
-            </p>
-            <pre class="example" title="Subclassing AudioWorkletProcessor">
-class MyProcessor extends AudioWorkletProcessor {
-  static get parameterDescriptors() {
-    return [{
-      name: 'myParam',
-      defaultValue: 0.5,
-      minValue: 0,
-      maxValue: 1
-    }];
-  }
-
-  process(inputs, outputs, parameters) {
-    // Get the first input and output.
-    var input = inputs[0];
-    var output = outputs[0];
-    var myParam = parameters.myParam;
-
-    // A simple amplifier for single input and output.
-    for (var channel = 0; channel &lt; output.length; ++channel) {
-      for (var i = 0; i &lt; output[channel].length; ++i) {
-        output[channel][i] = input[channel][i] * myParam[i];
-      }
-    }
-  }
-}
-</pre>
-            <p>
-              The <code>process()</code> method is called synchronously by the
-              audio <a>rendering thread</a> at every <a>render quantum</a>, if
-              ANY of the following <dfn>active processing conditions</dfn> are
-              true:
-            </p>
-            <ol>
-              <li>The associated <a>AudioWorkletProcessor</a>'s <a>active
-              source</a> flag is equal to <code>true</code>.
-              </li>
-              <li>There are one or more connected inputs to the
-              <a>AudioWorkletNode</a>.
-              </li>
-            </ol>
-            <p>
-              The method is invoked with the following arguments:
-            </p>
-            <ol>
-              <li>
-                <p>
-                  <code>inputs</code> of type
-                  <code>sequence&lt;sequence&lt;Float32Array&gt;&gt;</code><br>
-                  The input audio buffer from the incoming connections provided
-                  by the user agent. <code>inputs[n][m]</code> is a
-                  <code>Float32Array</code> of audio samples for the
-                  <code>m</code>th channel of <code>n</code>th input. While the
-                  number of inputs is fixed at construction, the number of
-                  channels can be changed dynamically based on
-                  <a>computedNumberOfChannels</a>.
-                </p>
-                <p>
-                  If no connections exist to the <code>n</code>th input of the
-                  node during the current render quantum, then the content of
-                  <code>inputs[n]</code> is an empty array, indicating that
-                  zero channels of input are available. This is the only
-                  circumstance under which the number of elements of
-                  <code>inputs[n]</code> can be zero.
-                </p>
-              </li>
-              <li>
-                <code>outputs</code> of type
-                <code>sequence&lt;sequence&lt;Float32Array&gt;&gt;</code><br>
-                The output audio buffer that is to be consumed by the user
-                agent. <code>outputs[n][m]</code> is a
-                <code>Float32Array</code> object containing the audio samples
-                for <code>m</code>th channel of <code>n</code>th output. The
-                number of channels in the output will match
-                <a>computedNumberOfChannels</a> only when the node has single
-                output.
-              </li>
-              <li>
-                <code>parameters</code> of type <code>Object</code><br>
-                A map of string keys and associated <code>Float32Array</code>s.
-                <code>parameters["name"]</code> corresponds to the automation
-                values of the <a><code>AudioParam</code></a> named
-                <code>"name"</code>.
-              </li>
-            </ol>
-            <p>
-              The return value of this method controls the lifetime of the
-              <a>AudioWorkletProcessor</a>'s associated
-              <a>AudioWorkletNode</a>. At the conclusion of each call to the
-              <code>process()</code> method, if the result of applying <a href=
-              "https://tc39.github.io/ecma262/#sec-toboolean"><code>ToBoolean</code></a>
-              (described in [[!ECMASCRIPT]]) to the return value is assigned to
-              the associated <a>AudioWorkletProcessor</a>'s <a>active
-              source</a> flag. This in turn can affects whether subsequent
-              invocations of <code>process()</code> occur and also the flag
-              change is propagated by <a href="#queue">queueing a task</a> on
-              the control thread to update the corresponding
-              <a>AudioWorkletNode</a>'s <code>state</code> property
-              accordingly.
-            </p>
-            <div class="note">
-              This lifetime policy can support a variety of approaches found in
-              built-in nodes, including the following:
-              <ul>
-                <li>Nodes that transform their inputs, and are active only
-                while connected inputs and/or script references exist. Such
-                nodes SHOULD return <code>false</code> from
-                <code>process()</code> which allows the presence or absence of
-                connected inputs to determine whether active processing occurs.
-                </li>
-                <li>Nodes that transform their inputs, but which remain active
-                for a <a>tail-time</a> after their inputs are disconnected. In
-                this case, <code>process()</code> SHOULD return
-                <code>true</code> for some period of time after
-                <code>inputs</code> is found to contain zero channels. The
-                current time may be obtained from the global scope's
-                <a data-link-for="AudioWorkletGlobalScope">currentTime</a> to
-                measure the start and end of this tail-time interval, or the
-                interval could be calculated dynamically depending on the
-                processor's internal state.
-                </li>
-                <li>Nodes that act as sources of output, typically with a
-                lifetime. Such nodes SHOULD return <code>true</code> from
-                <code>process()</code> until the point at which they are no
-                longer producing an output.
-                </li>
-              </ul>Note that the preceding definition implies that when no
-              return value is provided from an implementation of
-              <code>process()</code>, the effect is identical to returning
-              <code>false</code> (since the effective return value is the falsy
-              value <code>undefined</code>). This is a reasonable behavior for
-              any <a>AudioWorkletProcessor</a> that is active only when it has
-              active inputs.
-            </div>
-            <p>
-              If <code>process()</code> is not called during some rendering
-              quantum due to the lack of any applicable <a>active processing
-              conditions</a>, the result is is as if the processor emitted
-              silence for this period.
-            </p>
-          </section>
-          <section>
-            <h2 id="AudioParamDescriptor">
-              <dfn>AudioParamDescriptor</dfn>
-            </h2>
-            <p>
-              The <code>AudioParamDescriptor</code> dictionary is used to
-              specify properties for an <a><code>AudioParam</code></a> object
-              that is used in an <a><code>AudioWorkletNode</code></a>.
-            </p>
-            <pre class="idl">
-dictionary AudioParamDescriptor {
-    required DOMString name;
-             float     defaultValue = 0;
-             float     minValue = -3.4028235e38;
-             float     maxValue = 3.4028235e38;
-};
-            </pre>
-            <section>
-              <h3>
-                Dictionary <a>AudioParamDescriptor</a> Members
-              </h3>
-              <dl class="attributes" data-dfn-for="AudioParamDescriptor"
-              data-link-for="AudioParamDescriptor">
-                <dt>
-                  <code><dfn>defaultValue</dfn></code> of type <span class=
-                  "idlAttrType"><code>float</code></span>, defaulting to 0
-                </dt>
-                <dd>
-                  Represents the default value of the parameter. If this value
-                  is out of the range of float data type or the range defined
-                  by <code>minValue</code> and <code>maxValue</code>, an
-                  <code>NotSupportedError</code> exception MUST be thrown.
-                </dd>
-                <dt>
-                  <code><dfn>maxValue</dfn></code> of type <span class=
-                  "idlAttrType"><code>float</code></span>, defaulting to
-                  3.4028235e38
-                </dt>
-                <dd>
-                  Represents the maximum value. An
-                  <code>NotSupportedError</code> exception MUST be thrown if
-                  this value is out of range of float data type or it is
-                  smaller than <code>minValue</code>. This value is the most
-                  positive finite single precision floating-point number.
-                </dd>
-                <dt>
-                  <code><dfn>minValue</dfn></code> of type <span class=
-                  "idlAttrType"><code>float</code></span>, defaulting to
-                  -3.4028235e38
-                </dt>
-                <dd>
-                  Represents the minimum value. An
-                  <code>NotSupportedError</code> exception MUST be thrown if
-                  this value is out of range of float data type or it is
-                  greater than <code>maxValue</code>. This value is the most
-                  negative finite single precision floating-point number.
-                </dd>
-                <dt>
-                  <code><dfn>name</dfn></code> of type <span class=
-                  "idlAttrType"><code>DOMString</code></span>, required
-                </dt>
-                <dd>
-                  Represents the name of a parameter. An
-                  <code>NotSupportedError</code> exception MUST be thrown when
-                  a duplicated name is found when registering the class
-                  definition.
-                </dd>
-              </dl>
-            </section>
-          </section>
-        </section>
-        <section>
           <h2 id="instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">
             The instantiation of <a>AudioWorkletNode</a> and
             <a>AudioWorkletProcessor</a>
@@ -10594,16 +11022,39 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
           </section>
         </section>
       </section>
-      <section class="informative">
+      <section>
         <h2>
-          The <dfn>ScriptProcessorNode</dfn> Interface - DEPRECATED
+          The BiquadFilterNode Interface
         </h2>
         <p>
-          This interface is an <a><code>AudioNode</code></a> which can
-          generate, process, or analyse audio directly using a script. This
-          node type is deprecated, to be replaced by the
-          <a>AudioWorkletNode</a>; this text is only here for informative
-          purposes until implementations remove this node type.
+          <a><code>BiquadFilterNode</code></a> is an
+          <a><code>AudioNode</code></a> processor implementing very common
+          low-order filters.
+        </p>
+        <p>
+          Low-order filters are the building blocks of basic tone controls
+          (bass, mid, treble), graphic equalizers, and more advanced filters.
+          Multiple <a><code>BiquadFilterNode</code></a> filters can be combined
+          to form more complex filters. The filter parameters such as
+          <a data-link-for="BiquadFilterNode"><code>frequency</code></a> can be
+          changed over time for filter sweeps, etc. Each
+          <a><code>BiquadFilterNode</code></a> can be configured as one of a
+          number of common filter types as shown in the IDL below. The default
+          filter type is <code>"lowpass"</code>.
+        </p>
+        <p>
+          Both <a data-link-for="BiquadFilterNode"><code>frequency</code></a>
+          and <a data-link-for="BiquadFilterNode"><code>detune</code></a> form
+          a <a>compound parameter</a> and are both <a>a-rate</a>. They are used
+          together to determine a <dfn id=
+          "computedFreq-biquad">computedFrequency</dfn> value:
+        </p>
+        <pre class="highlight">
+  computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
+</pre>
+        <p>
+          The <a>nominal range</a> for this <a>compound parameter</a> is [0,
+          <a>Nyquist frequency</a>].
         </p>
         <div class="node-info">
           <table>
@@ -10641,11 +11092,1202 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
                 <a data-link-for="AudioNode">channelCount</a>
               </td>
               <td>
-                <a data-link-for="BaseAudioContext">numberOfInputChannels</a>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
               </td>
               <td>
-                This is the number of channels specified when constructing this
-                node. There are <a>channelCount constraints</a>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                Yes
+              </td>
+              <td>
+                Continues to output non-silent audio with zero input. Since
+                this is an IIR filter, the filter produces non-zero input
+                forever, but in practice, this can be limited after some finite
+                time where the output is sufficiently close to zero. The actual
+                time depends on the filter coefficients.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the output always equals the number of
+          channels of the input.
+        </p>
+        <pre class="idl">
+enum BiquadFilterType {
+    "lowpass",
+    "highpass",
+    "bandpass",
+    "lowshelf",
+    "highshelf",
+    "peaking",
+    "notch",
+    "allpass"
+};
+        </pre>
+        <table class="simple" data-dfn-for="BiquadFilterType" data-link-for=
+        "BiquadFilterType">
+          <tr>
+            <th colspan="2">
+              Enumeration description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <dfn>lowpass</dfn>
+            </td>
+            <td>
+              <p>
+                A <a href=
+                "https://en.wikipedia.org/wiki/Low-pass_filter">lowpass
+                filter</a> allows frequencies below the cutoff frequency to
+                pass through and attenuates frequencies above the cutoff. It
+                implements a standard second-order resonant lowpass filter with
+                12dB/octave rolloff.
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The cutoff frequency
+                  </dd>
+                  <dt>
+                    Q
+                  </dt>
+                  <dd>
+                    Controls how peaked the response will be at the cutoff
+                    frequency. A large value makes the response more peaked.
+                    Please note that for this filter type, this value is not a
+                    traditional Q, but is a resonance value in decibels.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    Not used in this filter type
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>highpass</dfn>
+            </td>
+            <td>
+              <p>
+                A <a href=
+                "https://en.wikipedia.org/wiki/High-pass_filter">highpass
+                filter</a> is the opposite of a lowpass filter. Frequencies
+                above the cutoff frequency are passed through, but frequencies
+                below the cutoff are attenuated. It implements a standard
+                second-order resonant highpass filter with 12dB/octave rolloff.
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The cutoff frequency below which the frequencies are
+                    attenuated
+                  </dd>
+                  <dt>
+                    Q
+                  </dt>
+                  <dd>
+                    Controls how peaked the response will be at the cutoff
+                    frequency. A large value makes the response more peaked.
+                    Please note that for this filter type, this value is not a
+                    traditional Q, but is a resonance value in decibels.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    Not used in this filter type
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>bandpass</dfn>
+            </td>
+            <td>
+              <p>
+                A <a href=
+                "https://en.wikipedia.org/wiki/Band-pass_filter">bandpass
+                filter</a> allows a range of frequencies to pass through and
+                attenuates the frequencies below and above this frequency
+                range. It implements a second-order bandpass filter.
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The center of the frequency band
+                  </dd>
+                  <dt>
+                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                  </dt>
+                  <dd>
+                    Controls the width of the band. The width becomes narrower
+                    as the Q value increases.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    Not used in this filter type
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>lowshelf</dfn>
+            </td>
+            <td>
+              <p>
+                The lowshelf filter allows all frequencies through, but adds a
+                boost (or attenuation) to the lower frequencies. It implements
+                a second-order lowshelf filter.
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The upper limit of the frequences where the boost (or
+                    attenuation) is applied.
+                  </dd>
+                  <dt>
+                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                  </dt>
+                  <dd>
+                    Not used in this filter type.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    The boost, in dB, to be applied. If the value is negative,
+                    the frequencies are attenuated.
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>highshelf</dfn>
+            </td>
+            <td>
+              <p>
+                The highshelf filter is the opposite of the lowshelf filter and
+                allows all frequencies through, but adds a boost to the higher
+                frequencies. It implements a second-order highshelf filter
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The lower limit of the frequences where the boost (or
+                    attenuation) is applied.
+                  </dd>
+                  <dt>
+                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                  </dt>
+                  <dd>
+                    Not used in this filter type.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    The boost, in dB, to be applied. If the value is negative,
+                    the frequencies are attenuated.
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>peaking</dfn>
+            </td>
+            <td>
+              <p>
+                The peaking filter allows all frequencies through, but adds a
+                boost (or attenuation) to a range of frequencies.
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The center frequency of where the boost is applied.
+                  </dd>
+                  <dt>
+                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                  </dt>
+                  <dd>
+                    Controls the width of the band of frequencies that are
+                    boosted. A large value implies a narrow width.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    The boost, in dB, to be applied. If the value is negative,
+                    the frequencies are attenuated.
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>notch</dfn>
+            </td>
+            <td>
+              <p>
+                The notch filter (also known as a <a href=
+                "https://en.wikipedia.org/wiki/Band-stop_filter">band-stop or
+                band-rejection filter</a>) is the opposite of a bandpass
+                filter. It allows all frequencies through, except for a set of
+                frequencies.
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The center frequency of where the notch is applied.
+                  </dd>
+                  <dt>
+                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                  </dt>
+                  <dd>
+                    Controls the width of the band of frequencies that are
+                    attenuated. A large value implies a narrow width.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    Not used in this filter type.
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>allpass</dfn>
+            </td>
+            <td>
+              <p>
+                An <a href=
+                "https://en.wikipedia.org/wiki/All-pass_filter#Digital_Implementation">
+                allpass filter</a> allows all frequencies through, but changes
+                the phase relationship between the various frequencies. It
+                implements a second-order allpass filter
+              </p>
+              <blockquote>
+                <dl>
+                  <dt>
+                    frequency
+                  </dt>
+                  <dd>
+                    The frequency where the center of the phase transition
+                    occurs. Viewed another way, this is the frequency with
+                    maximal <a href=
+                    "https://en.wikipedia.org/wiki/Group_delay">group
+                    delay</a>.
+                  </dd>
+                  <dt>
+                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                  </dt>
+                  <dd>
+                    Controls how sharp the phase transition is at the center
+                    frequency. A larger value implies a sharper transition and
+                    a larger group delay.
+                  </dd>
+                  <dt>
+                    gain
+                  </dt>
+                  <dd>
+                    Not used in this filter type.
+                  </dd>
+                </dl>
+              </blockquote>
+            </td>
+          </tr>
+        </table>
+        <p>
+          All attributes of the <a><code>BiquadFilterNode</code></a> are
+          <a>a-rate</a> <a><code>AudioParam</code></a>.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional BiquadFilterOptions options)]
+interface BiquadFilterNode : AudioNode {
+                    attribute BiquadFilterType type;
+    readonly        attribute AudioParam       frequency;
+    readonly        attribute AudioParam       detune;
+    readonly        attribute AudioParam       Q;
+    readonly        attribute AudioParam       gain;
+    void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="BiquadFilterNode" data-link-for=
+          "BiquadFilterNode">
+            <dt>
+              <code><dfn>BiquadFilterNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
+                <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>, and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>BiquadFilterNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>BiquadFilterOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>BiquadFilterNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="BiquadFilterNode" data-link-for=
+          "BiquadFilterNode">
+            <dt>
+              <code><dfn>Q</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
+                factor of the filter. This is not used for <a data-link-for=
+                "BiquadFilterType">lowshelf</a> or <a data-link-for=
+                "BiquadFilterType">highshelf</a> filters.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>detune</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                A detune value, in cents, for the frequency. It forms a
+                <a>compound parameter</a> with <code>frequency</code>.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>frequency</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The frequency at which the <a><code>BiquadFilterNode</code></a>
+                will operate, in Hz. It forms a <a>compound parameter</a> with
+                <code>detune</code>.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      350
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>gain</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The gain of the filter. Its value is in dB units. The gain is
+                only used for <a data-link-for="BiquadFilterType">lowshelf</a>,
+                <a data-link-for="BiquadFilterType">highshelf</a>, and
+                <a data-link-for="BiquadFilterType">peaking</a> filters.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>type</dfn></code> of type <span class=
+              "idlAttrType"><a><code>BiquadFilterType</code></a></span>
+            </dt>
+            <dd>
+              The type of this <a><code>BiquadFilterNode</code></a>. Its
+              default value is "lowpass". The exact meaning of the other
+              parameters depend on the value of the <a><code>type</code></a>
+              attribute.
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Methods
+          </h3>
+          <dl class="methods" data-dfn-for="BiquadFilterNode" data-link-for=
+          "BiquadFilterNode">
+            <dt>
+              <code><dfn>getFrequencyResponse</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                <span class="sychronous">Given the current filter parameter
+                settings, synchronously calculates the frequency response for
+                the specified frequencies.</span> The three parameters MUST be
+                <code>Float32Array</code>s of the same length, or an
+                <code>InvalidAccessError</code> MUST be thrown.
+              </p>
+              <p>
+                The frequency response returned MUST be computed with the
+                <a><code>AudioParam</code></a> sampled for the current
+                processing block.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    frequencyHz
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    This parameter specifies an array of frequencies at which
+                    the response values will be calculated.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    magResponse
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    <p>
+                      This parameter specifies an output array receiving the
+                      linear magnitude response values.
+                    </p>
+                    <p>
+                      If a value in the <code>frequencyHz</code> parameter is
+                      not within [0; sampleRate/2], where
+                      <code>sampleRate</code> is the value of the
+                      <a data-link-for=
+                      "BaseAudioContext"><code>sampleRate</code></a> property
+                      of the <a>AudioContext</a>, the corresponding value at
+                      the same index of the <code>magResponse</code> array MUST
+                      be <code>NaN</code>.
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    phaseResponse
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    <p>
+                      This parameter specifies an output array receiving the
+                      phase response values in radians.
+                    </p>
+                    <p>
+                      If a value in the <code>frequencyHz</code> parameter is
+                      not within [0; sampleRate/2], where
+                      <code>sampleRate</code> is the value of the
+                      <a data-link-for=
+                      "BaseAudioContext"><code>sampleRate</code></a> property
+                      of the <a>AudioContext</a>, the corresponding value at
+                      the same index of the <code>phaseResponse</code> array
+                      MUST be <code>NaN</code>.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>BiquadFilterOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options to be used when constructing a
+            <a><code>BiquadFilterNode</code></a>. All members are optional; if
+            not specified, the normal default values are used to construct the
+            node.
+          </p>
+          <pre class="idl">
+dictionary BiquadFilterOptions : AudioNodeOptions {
+             BiquadFilterType type = "lowpass";
+             float            Q = 1;
+             float            detune = 0;
+             float            frequency = 350;
+             float            gain = 0;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>BiquadFilterOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="BiquadFilterOptions"
+            data-link-for="BiquadFilterOptions">
+              <dt>
+                <code><dfn>Q</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 1
+              </dt>
+              <dd>
+                The desired initial value for <a><code>Q</code></a>.
+              </dd>
+              <dt>
+                <code><dfn>detune</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 0
+              </dt>
+              <dd>
+                The desired initial value for <a><code>detune</code></a>.
+              </dd>
+              <dt>
+                <code><dfn>frequency</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 350
+              </dt>
+              <dd>
+                The desired initial value for <a><code>frequency</code></a>.
+              </dd>
+              <dt>
+                <code><dfn>gain</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 0
+              </dt>
+              <dd>
+                The desired initial value for <a><code>gain</code></a>.
+              </dd>
+              <dt>
+                <code><dfn>type</dfn></code> of type <span class=
+                "idlAttrType"><code>BiquadFilterType</code></span>, defaulting
+                to "lowpass"
+              </dt>
+              <dd>
+                The desired initial type of the filter.
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h3>
+            Filters characteristics
+          </h3>
+          <p>
+            There are multiple ways of implementing the type of filters
+            available through the <a><code>BiquadFilterNode</code></a> each
+            having very different characteristics. The formulas in this section
+            describe the filters that a <a>conforming implementation</a> MUST
+            implement, as they determine the characteristics of the different
+            filter types. They are inspired by formulas found in the <a href=
+            "http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt">Audio EQ
+            Cookbook</a>.
+          </p>
+          <p>
+            The transfer function for the filters implemented by the
+            <a><code>BiquadFilterNode</code></a> is:
+          </p>
+          <pre class="nohighlight">
+  $$
+  H(z) = \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} + \frac{b_2}{a_0}z^{-2}}
+              {1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}
+  $$
+
+</pre>
+          <p>
+            The initial filter state is 0.
+          </p>The coefficients in the transfer function above are different for
+          each node type. The following intermediate variable are necessary for
+          their computation, based on the <a>computedValue</a> of the
+          <a><code>AudioParam</code></a>s of the
+          <a><code>BiquadFilterNode</code></a>.
+          <ul>
+            <li>Let \(F_s\) be the value of the <a data-link-for=
+            "BaseAudioContext"><code>sampleRate</code></a> attribute for this
+            <a>AudioContext</a>.
+            </li>
+            <li>Let \(f_0\) be the value of the
+            <a><code>computedFrequency</code></a>.
+            </li>
+            <li>Let \(G\) be the value of the <a data-link-for=
+            "BiquadFilterNode"><code>gain</code></a>
+            <a><code>AudioParam</code></a>.
+            </li>
+            <li>Let \(Q\) be the value of the <a data-link-for=
+            "BiquadFilterNode"><code>Q</code></a>
+            <a><code>AudioParam</code></a>.
+            </li>
+            <li>Finally let 
+            <!-- Should \alpha_S be simplified since S is always 1?-->
+              <pre class="nohighlight">
+$$
+\begin{align*}
+  A        &amp;= 10^{\frac{G}{40}} \\
+  \omega_0 &amp;= 2\pi\frac{f_0}{F_s} \\
+  \alpha_Q &amp;= \frac{\sin\omega_0}{2Q} \\
+  \alpha_{Q_{dB}} &amp;= \frac{\sin\omega_0}{2 \cdot 10^{Q/20}} \\
+  S        &amp;= 1 \\
+  \alpha_S &amp;= \frac{\sin\omega_0}{2}\sqrt{\left(A+\frac{1}{A}\right)\left(\frac{1}{S}-1\right)+2}
+\end{align*}
+$$
+
+</pre>
+            </li>
+          </ul>The six coefficients (\(b_0, b_1, b_2, a_0, a_1, a_2\)) for each
+          filter type, are:
+          <dl>
+            <dt>
+              <code>lowpass</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                $$
+                  \begin{align*}
+                    b_0 &amp;= \frac{1 - \cos\omega_0}{2} \\
+                    b_1 &amp;= 1 - \cos\omega_0 \\
+                    b_2 &amp;= \frac{1 - \cos\omega_0}{2} \\
+                    a_0 &amp;= 1 + \alpha_{Q_{dB}} \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \alpha_{Q_{dB}}
+                  \end{align*}
+                $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>highpass</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                  $$
+                    \begin{align*}
+                      b_0 &amp;= \frac{1 + \cos\omega_0}{2} \\
+                      b_1 &amp;= -(1 + \cos\omega_0) \\
+                      b_2 &amp;= \frac{1 + \cos\omega_0}{2} \\
+                      a_0 &amp;= 1 + \alpha_{Q_{dB}} \\
+                      a_1 &amp;= -2 \cos\omega_0 \\
+                      a_2 &amp;= 1 - \alpha_{Q_{dB}}
+                    \end{align*}
+                  $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>bandpass</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+              $$
+                \begin{align*}
+                  b_0 &amp;= \alpha_Q \\
+                  b_1 &amp;= 0 \\
+                  b_2 &amp;= -\alpha_Q \\
+                  a_0 &amp;= 1 + \alpha_Q \\
+                  a_1 &amp;= -2 \cos\omega_0 \\
+                  a_2 &amp;= 1 - \alpha_Q
+                \end{align*}
+              $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>notch</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                $$
+                  \begin{align*}
+                    b_0 &amp;= 1 \\
+                    b_1 &amp;= -2\cos\omega_0 \\
+                    b_2 &amp;= 1 \\
+                    a_0 &amp;= 1 + \alpha_Q \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \alpha_Q
+                  \end{align*}
+                $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>allpass</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                $$
+                  \begin{align*}
+                    b_0 &amp;= 1 - \alpha_Q \\
+                    b_1 &amp;= -2\cos\omega_0 \\
+                    b_2 &amp;= 1 + \alpha_Q \\
+                    a_0 &amp;= 1 + \alpha_Q \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \alpha_Q
+                  \end{align*}
+                $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>peaking</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                $$
+                  \begin{align*}
+                    b_0 &amp;= 1 + \alpha_Q\, A \\
+                    b_1 &amp;= -2\cos\omega_0 \\
+                    b_2 &amp;= 1 - \alpha_Q\,A \\
+                    a_0 &amp;= 1 + \frac{\alpha_Q}{A} \\
+                    a_1 &amp;= -2 \cos\omega_0 \\
+                    a_2 &amp;= 1 - \frac{\alpha_Q}{A}
+                  \end{align*}
+                $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>lowshelf</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                $$
+                  \begin{align*}
+                    b_0 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A})\right] \\
+                    b_1 &amp;= 2 A \left[ (A-1) - (A+1) \cos\omega_0 )\right] \\
+                    b_2 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A}) \right] \\
+                    a_0 &amp;= (A+1) + (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A} \\
+                    a_1 &amp;= -2 \left[ (A-1) + (A+1) \cos\omega_0\right] \\
+                    a_2 &amp;= (A+1) + (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A})
+                  \end{align*}
+                $$
+
+</pre>
+            </dd>
+            <dt>
+              <code>highshelf</code>
+            </dt>
+            <dd>
+              <pre class="nohighlight">
+                $$
+                  \begin{align*}
+                    b_0 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} )\right] \\
+                    b_1 &amp;= -2A\left[ (A-1) + (A+1)\cos\omega_0 )\right] \\
+                    b_2 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A} )\right] \\
+                    a_0 &amp;= (A+1) - (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} \\
+                    a_1 &amp;= 2\left[ (A-1) - (A+1)\cos\omega_0\right] \\
+                    a_2 &amp;= (A+1) - (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A}
+                  \end{align*}
+                $$
+
+</pre>
+            </dd>
+          </dl>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The ChannelMergerNode Interface
+        </h2>
+        <p>
+          The <a><code>ChannelMergerNode</code></a> is for use in more advanced
+          applications and would often be used in conjunction with
+          <a><code>ChannelSplitterNode</code></a>.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td></td>
+              <td>
+                Defaults to 6, but is determined by
+                <a>ChannelMergerOptions</a>,<a data-link-for=
+                "ChannelMergerOptions">numberOfInputs</a> or the value
+                specified by <a data-link-for=
+                "BaseAudioContext">createChannelMerger</a>.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td>
+                Has <a>channelCount constraints</a>
               </td>
             </tr>
             <tr>
@@ -10653,7 +12295,7 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
                 <a data-link-for="AudioNode">channelCountMode</a>
               </td>
               <td>
-                "<a data-link-for="channelCountMode">explicit</a>"
+                "<a data-link-for="channelCountMode">max</a>"
               </td>
               <td>
                 Has <a>channelCountMode constraints</a>
@@ -10680,186 +12322,4248 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
           </table>
         </div>
         <p>
-          The <a><code>ScriptProcessorNode</code></a> is constructed with a
-          <dfn>bufferSize</dfn> which MUST be one of the following values: 256,
-          512, 1024, 2048, 4096, 8192, 16384. This value controls how
-          frequently the <a data-link-for=
-          "ScriptProcessorNode">onaudioprocess</a> event is dispatched and how
-          many sample-frames need to be processed each call. <a data-link-for=
-          "ScriptProcessorNode"><code>onaudioprocess</code></a> events are only
-          dispatched if the <a><code>ScriptProcessorNode</code></a> has at
-          least one input or one output connected. Lower numbers for
-          <a data-link-for="ScriptProcessorNode">bufferSize</a> will result in
-          a lower (better) <a href="#latency">latency</a>. Higher numbers will
-          be necessary to avoid audio breakup and <a href=
-          "#audio-glitching">glitches</a>. This value will be picked by the
-          implementation if the bufferSize argument to
-          <code>createScriptProcessor</code> is not passed in, or is set to 0.
+          This interface represents an <a><code>AudioNode</code></a> for
+          combining channels from multiple audio streams into a single audio
+          stream. It has a variable number of inputs (defaulting to 6), but not
+          all of them need be connected. There is a single output whose audio
+          stream has a number of channels equal to the number of inputs.
         </p>
         <p>
-          <a>numberOfInputChannels</a> and <a>numberOfOutputChannels</a>
-          determine the number of input and output channels. It is invalid for
-          both <a>numberOfInputChannels</a> and <a>numberOfOutputChannels</a>
-          to be zero.
+          To merge multiple inputs into one stream, each input gets downmixed
+          into one channel (mono) based on the specified mixing rule. An
+          unconnected input still counts as <b>one silent channel</b> in the
+          output. Changing input streams does <b>not</b> affect the order of
+          output channels.
         </p>
+        <h3 id="example-2">
+          Example:
+        </h3>
+        <p>
+          For example, if a default <a><code>ChannelMergerNode</code></a> has
+          two connected stereo inputs, the first and second input will be
+          downmixed to mono respectively before merging. The output will be a
+          6-channel stream whose first two channels are be filled with the
+          first two (downmixed) inputs and the rest of channels will be silent.
+        </p>
+        <p>
+          Also the <a><code>ChannelMergerNode</code></a> can be used to arrange
+          multiple audio streams in a certain order for the multi-channel
+          speaker array such as 5.1 surround set up. The merger does not
+          interpret the channel identities (such as left, right, etc.), but
+          simply combines channels in the order that they are input.
+        </p>
+        <figure>
+          <img alt="channel merger" src="images/channel-merger.svg">
+          <figcaption>
+            A diagram of ChannelMerger
+          </figcaption>
+        </figure>
         <pre class="idl">
-[Exposed=Window]
-interface ScriptProcessorNode : AudioNode {
-                    attribute EventHandler onaudioprocess;
-    readonly        attribute long         bufferSize;
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional ChannelMergerOptions options)]
+interface ChannelMergerNode : AudioNode {
 };
         </pre>
         <section>
           <h3>
-            Attributes
+            Constructors
           </h3>
-          <dl class="attributes" data-dfn-for="ScriptProcessorNode"
-          data-link-for="ScriptProcessorNode">
+          <dl class="methods" data-dfn-for="ChannelMergerNode" data-link-for=
+          "ChannelMergerNode">
             <dt>
-              <code><dfn>bufferSize</dfn></code> of type <span class=
-              "idlAttrType"><a><code>long</code></a></span>, readonly
+              <code><dfn>ChannelMergerNode</dfn></code>
             </dt>
             <dd>
-              The size of the buffer (in sample-frames) which needs to be
-              processed each time <a data-link-for=
-              "ScriptProcessorNode"><code>onaudioprocess</code></a> is called.
-              Legal values are (256, 512, 1024, 2048, 4096, 8192, 16384).
-            </dd>
-            <dt>
-              <code><dfn>onaudioprocess</dfn></code> of type <span class=
-              "idlAttrType"><code>EventHandler</code></span>
-            </dt>
-            <dd>
-              A property used to set the <code>EventHandler</code> (described
-              in <cite><a href=
-              "https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">
-              HTML</a></cite>[[!HTML]]) for the <a data-link-for=
-              "ScriptProcessorNode"><code>onaudioprocess</code></a> event that
-              is dispatched to <a><code>ScriptProcessorNode</code></a> node
-              types. An event of type <a><code>AudioProcessingEvent</code></a>
-              will be dispatched to the event handler.
+              <p>
+                Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
+                <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>, and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>ChannelMergerNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>ChannelMergerOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>ChannelMergerNode</a>.
+                  </td>
+                </tr>
+              </table>
             </dd>
           </dl>
         </section>
-        <section class="informative">
+        <section>
           <h2>
-            The <dfn>AudioProcessingEvent</dfn> Interface - DEPRECATED
+            <dfn>ChannelMergerOptions</dfn>
           </h2>
-          <p>
-            This is an <code>Event</code> object which is dispatched to
-            <a><code>ScriptProcessorNode</code></a> nodes. It will be removed
-            when the ScriptProcessorNode is removed, as the replacement
-            <a>AudioWorkletNode</a> uses a different approach.
-          </p>
-          <p>
-            The event handler processes audio from the input (if any) by
-            accessing the audio data from the <code>inputBuffer</code>
-            attribute. The audio data which is the result of the processing (or
-            the synthesized data if there are no inputs) is then placed into
-            the <code>outputBuffer</code>.
-          </p>
           <pre class="idl">
-[Exposed=Window,
- Constructor (DOMString type, AudioProcessingEventInit eventInitDict)]
-interface AudioProcessingEvent : Event {
-    readonly        attribute double      playbackTime;
-    readonly        attribute AudioBuffer inputBuffer;
-    readonly        attribute AudioBuffer outputBuffer;
+dictionary ChannelMergerOptions : AudioNodeOptions {
+             unsigned long numberOfInputs = 6;
 };
           </pre>
           <section>
             <h3>
-              Attributes
+              Dictionary <a>ChannelMergerOptions</a> Members
             </h3>
-            <dl class="attributes" data-dfn-for="AudioProcessingEvent"
-            data-link-for="AudioProcessingEvent">
+            <dl class="attributes" data-dfn-for="ChannelMergerOptions"
+            data-link-for="ChannelMergerOptions">
               <dt>
-                <code><dfn>inputBuffer</dfn></code> of type <span class=
-                "idlAttrType"><a><code>AudioBuffer</code></a></span>, readonly
+                <code><dfn>numberOfInputs</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 6
               </dt>
               <dd>
-                An AudioBuffer containing the input audio data. It will have a
-                number of channels equal to the
-                <code>numberOfInputChannels</code> parameter of the
-                createScriptProcessor() method. This AudioBuffer is only valid
-                while in the scope of the <a data-link-for=
-                "ScriptProcessorNode"><code>onaudioprocess</code></a> function.
-                Its values will be meaningless outside of this scope.
-              </dd>
-              <dt>
-                <code><dfn>outputBuffer</dfn></code> of type <span class=
-                "idlAttrType"><code>AudioBuffer</code></span>, readonly
-              </dt>
-              <dd>
-                An AudioBuffer where the output audio data MUST be written. It
-                will have a number of channels equal to the
-                <code>numberOfOutputChannels</code> parameter of the
-                createScriptProcessor() method. Script code within the scope of
-                the <a data-link-for=
-                "ScriptProcessorNode"><code>onaudioprocess</code></a> function
-                is expected to modify the <code>Float32Array</code> arrays
-                representing channel data in this AudioBuffer. Any script
-                modifications to this AudioBuffer outside of this scope will
-                not produce any audible effects.
-              </dd>
-              <dt>
-                <code><dfn>playbackTime</dfn></code> of type <span class=
-                "idlAttrType"><code>double</code></span>, defaulting to 0
-              </dt>
-              <dd>
-                The time when the audio will be played in the same time
-                coordinate system as the <a><code>AudioContext</code></a>'s
-                <a data-link-for="BaseAudioContext">currentTime</a>.
+                The number inputs for the
+                <a><code>ChannelSplitterNode</code></a>.
               </dd>
             </dl>
           </section>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The ChannelSplitterNode Interface
+        </h2>
+        <p>
+          The <code>ChannelSplitterNode</code> is for use in more advanced
+          applications and would often be used in conjunction with
+          <a><code>ChannelMergerNode</code></a>.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td></td>
+              <td>
+                This defaults to 6, but is otherwise determined from
+                <a>ChannelSplitterOptions</a>.<a data-link-for=
+                "ChannelSplitterOptions">numberOfOutputs</a> or the value
+                specified by <a data-link-for=
+                "BaseAudioContext">createChannelSplitter</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                Has <a>channelCount constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td>
+                Has <a>channelCountMode constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">discrete</a>"
+              </td>
+              <td>
+                Has <a>channelInterpretation constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          This interface represents an <a><code>AudioNode</code></a> for
+          accessing the individual channels of an audio stream in the routing
+          graph. It has a single input, and a number of "active" outputs which
+          equals the number of channels in the input audio stream. For example,
+          if a stereo input is connected to an
+          <a><code>ChannelSplitterNode</code></a> then the number of active
+          outputs will be two (one from the left channel and one from the
+          right). There are always a total number of N outputs (determined by
+          the <code>numberOfOutputs</code> parameter to the
+          <a><code>AudioContext</code></a> method <a data-link-for=
+          "BaseAudioContext"><code>createChannelSplitter()</code></a>), The
+          default number is 6 if this value is not provided. Any outputs which
+          are not "active" will output silence and would typically not be
+          connected to anything.
+        </p>
+        <h3>
+          Example:
+        </h3>
+        <figure>
+          <img alt="channel splitter" src="images/channel-splitter.png" width=
+          "601" height="398">
+          <figcaption>
+            A diagram of a ChannelSplitter
+          </figcaption>
+        </figure>
+        <p>
+          Please note that in this example, the splitter does <b>not</b>
+          interpret the channel identities (such as left, right, etc.), but
+          simply splits out channels in the order that they are input.
+        </p>
+        <p>
+          One application for <code>ChannelSplitterNode</code> is for doing
+          "matrix mixing" where individual gain control of each channel is
+          desired.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional ChannelSplitterNode options)]
+interface ChannelSplitterNode : AudioNode {
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="ChannelSplitterNode" data-link-for=
+          "ChannelSplitterNode">
+            <dt>
+              <code><dfn>ChannelSplitterNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
+                <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>, and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new <a>ChannelSplitter</a>
+                    will be <a href="#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>ChannelSplitterOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>ChannelSplitterNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>ChannelSplitterOptions</dfn>
+          </h2>
+          <pre class="idl">
+dictionary ChannelSplitterOptions : AudioNodeOptions {
+             unsigned long numberOfOutputs = 6;
+};
+        </pre>
           <section>
             <h3>
-              <dfn>AudioProcessingEventInit</dfn>
+              Dictionary <a>ChannelSplitterOptions</a> Members
             </h3>
-            <pre class="idl">
-dictionary AudioProcessingEventInit : EventInit {
-    required double      playbackTime;
-    required AudioBuffer inputBuffer;
-    required AudioBuffer outputBuffer;
-};
-            </pre>
-            <section>
-              <h3>
-                Dictionary <a>AudioProcessingEventInit</a> Members
-              </h3>
-              <dl class="attributes" data-dfn-for="AudioProcessingEventInit"
-              data-link-for="AudioProcessingEventInit">
-                <dt>
-                  <code><dfn>inputBuffer</dfn></code> of type <span class=
-                  "idlAttrType"><code>AudioBuffer</code></span>, required
-                </dt>
-                <dd>
-                  Value to be assigned to the <a data-link-for=
-                  "AudioProcessingEvent"><code>inputBuffer</code></a> attribute
-                  of the event.
-                </dd>
-                <dt>
-                  <code><dfn>outputBuffer</dfn></code> of type <span class=
-                  "idlAttrType"><code>float</code></span>, required
-                </dt>
-                <dd>
-                  Value to be assigned to the <a data-link-for=
-                  "AudioProcessingEvent"><code>outputBuffer</code></a>
-                  attribute of the event.
-                </dd>
-                <dt>
-                  <code><dfn>playbackTime</dfn></code> of type <span class=
-                  "idlAttrType"><code>double</code></span>, required
-                </dt>
-                <dd>
-                  Value to be assigned to the <a data-link-for=
-                  "AudioProcessingEvent"><code>playbackTime</code></a>
-                  attribute of the event.
-                </dd>
-              </dl>
-            </section>
+            <dl class="attributes" data-dfn-for="ChannelSplitterOptions"
+            data-link-for="ChannelSplitterOptions">
+              <dt>
+                <code><dfn>numberOfOutputs</dfn></code> of type <span class=
+                "idlAttrType"><code>unsigned long</code></span>, defaulting to
+                6
+              </dt>
+              <dd>
+                The number outputs for the
+                <a><code>ChannelSplitterNode</code></a>.
+              </dd>
+            </dl>
           </section>
+        </section>
+      </section>
+      <section>
+        <h2 id="ConstantSourceNode">
+          The ConstantSourceNode Interface
+        </h2>
+        <p>
+          This interface represents a constant audio source whose output is
+          nominally a constant value. It is useful as a constant source node in
+          general and can be used as if it were a constructible
+          <a><code>AudioParam</code></a> by automating its
+          <a><code>offset</code></a> or connecting another node to it.
+        </p>
+        <p>
+          The single output of this node consists of one channel (mono).
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                0
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional ConstantSourceOptions options)]
+interface ConstantSourceNode : AudioScheduledSourceNode {
+    readonly        attribute AudioParam offset;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="ConstantSourceNode" data-link-for=
+          "ConstantSourceNode">
+            <dt>
+              <code><dfn>ConstantSourceNode</dfn></code>
+            </dt>
+            <dd>
+              Let <var>node</var> be a new <a>ConstantSourceNode</a> object.
+              <a href="#audionode-constructor-init">Initialize</a>
+              <var>node</var>, and return <var>node</var>.
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>ConstantSourceNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>ConstantSourceOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>ConstantSourceNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="ConstantSourceNode"
+          data-link-for="ConstantSourceNode">
+            <dt>
+              <code><dfn>offset</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The constant value of the source.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>ConstantSourceOptions</dfn>
+          </h2>
+          <p>
+            This specifies options for constructing a
+            <a><code>ConstantSourceNode</code></a>. All members are optional;
+            if not specified, the normal defaults are used for constructing the
+            node.
+          </p>
+          <pre class="idl">
+dictionary ConstantSourceOptions {
+             float offset = 1;
+};
+          </pre>
+          <section>
+            <h3>
+              Dictionary <a>ConstantSourceOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="ConstantSourceOptions"
+            data-link-for="ConstantSourceOptions">
+              <dt>
+                <code><dfn>offset</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 1
+              </dt>
+              <dd>
+                The initial value for the <a data-link-for=
+                "ConstantSourceNode"><code>offset</code></a> AudioParam of this
+                node.
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </section>
+      <section>
+        <h2 id="ConvolverNode">
+          The ConvolverNode Interface
+        </h2>
+        <p>
+          This interface represents a processing node which applies a linear
+          convolution effect given an impulse response.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td>
+                Has <a>channelCount constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">clamped-max</a>"
+              </td>
+              <td>
+                Has <a>channelCountMode constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                Yes
+              </td>
+              <td>
+                Continues to output non-silent audio with zero input for the
+                length of the <a data-link-for="ConvolverNode">buffer</a>.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The input of this node is either mono (1 channel) or stereo (2
+          channels) and cannot be increased. Connections from nodes with more
+          channels will be <a href=
+          "#channel-up-mixing-and-down-mixing">down-mixed appropriately</a>.
+        </p>
+        <p>
+          There are <a>channelCount constraints</a> and <a>channelCountMode
+          constraints</a> for this node. These constraints ensure that the
+          input to the node is either mono or stereo.
+        </p>
+        <p>
+          <a>ConvolverNode</a>s are created with an internal flag <code>buffer
+          set</code>, initially set to false.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional ConvolverOptions options)]
+interface ConvolverNode : AudioNode {
+                    attribute AudioBuffer? buffer;
+                    attribute boolean      normalize;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="ConvolverNode" data-link-for=
+          "ConvolverNode">
+            <dt>
+              <code><dfn>ConvolverNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>ConvolverNode</a> object.
+                <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>. Set an internal boolean slot <var>[[buffer
+                set]]</var>, and initialize it to <code>false</code>. Return
+                <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new <a>ConvolverNode</a>
+                    will be <a href="#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>ConvolverOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>ConvolverNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="ConvolverNode" data-link-for=
+          "ConvolverNode">
+            <dt>
+              <code><dfn>buffer</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioBuffer</code></a></span>, nullable
+            </dt>
+            <dd>
+              <p>
+                A mono, stereo, or 4-channel <a><code>AudioBuffer</code></a>
+                containing the (possibly multi-channel) impulse response used
+                by the <a><code>ConvolverNode</code></a>. <span class=
+                "synchronous">The <code>AudioBuffer</code> MUST have 1, 2, or 4
+                channels or a <code>NotSupportedError</code> exception MUST be
+                thrown</span>. <span class="synchronous">This
+                <a><code>AudioBuffer</code></a> MUST be of the same sample-rate
+                as the <a><code>AudioContext</code></a> or a
+                <code>NotSupportedError</code> exception MUST be thrown</span>.
+                At the time when this attribute is set, the <em>buffer</em> and
+                the state of the <em>normalize</em> attribute will be used to
+                configure the <a><code>ConvolverNode</code></a> with this
+                impulse response having the given normalization. The initial
+                value of this attribute is null.
+              </p>
+              <p>
+                To set the <code>buffer</code> attribute, execute these steps:
+              </p>
+              <ol>
+                <li>Let <code>new buffer</code> be the <a>AudioBuffer</a> to be
+                assigned to <code>buffer</code>.
+                </li>
+                <li>If <code>new buffer</code> is not <code>null</code> and
+                <var>[[buffer set]]</var> is true, <span class=
+                "synchronous">throw an <code>InvalidStateError</code> and abort
+                these steps</span>.
+                </li>
+                <li>If <code>new buffer</code> is not <code>null</code>, set
+                <var>[[buffer set]]</var> to true.
+                </li>
+                <li>Assign <code>new buffer</code> to the <code>buffer</code>
+                attribute.
+                </li>
+              </ol>
+              <p class="norm">
+                <em>The following text is non-normative. For normative
+                information please see the <a href=
+                "#Convolution-channel-configurations">channel configuration
+                diagrams</a>.</em>
+              </p>
+              <p>
+                The <a>ConvolverNode</a> only produces a mono output in the
+                single case where there is a single input channel and a
+                single-channel <code>buffer</code>. In all other cases, the
+                output is stereo. In particular, when the <code>buffer</code>
+                has four channels and there are two input channels, the
+                <a>ConvolverNode</a> performs matrix "true" stereo convolution.
+              </p>
+            </dd>
+            <dt>
+              <code><dfn>normalize</dfn></code> of type <span class=
+              "idlAttrType"><a><code>boolean</code></a></span>
+            </dt>
+            <dd>
+              <p>
+                Controls whether the impulse response from the buffer will be
+                scaled by an equal-power normalization when the
+                <code>buffer</code> atttribute is set. Its default value is
+                <code>true</code> in order to achieve a more uniform output
+                level from the convolver when loaded with diverse impulse
+                responses. If <code>normalize</code> is set to
+                <code>false</code>, then the convolution will be rendered with
+                no pre-processing/scaling of the impulse response. Changes to
+                this value do not take effect until the next time the
+                <em>buffer</em> attribute is set.
+              </p>
+              <p>
+                If the <em>normalize</em> attribute is false when the
+                <em>buffer</em> attribute is set then the
+                <a><code>ConvolverNode</code></a> will perform a linear
+                convolution given the exact impulse response contained within
+                the <em>buffer</em>.
+              </p>
+              <p>
+                Otherwise, if the <em>normalize</em> attribute is true when the
+                <em>buffer</em> attribute is set then the
+                <a><code>ConvolverNode</code></a> will first perform a scaled
+                RMS-power analysis of the audio data contained within
+                <em>buffer</em> to calculate a <em>normalizationScale</em>
+                given this algorithm:
+              </p>
+              <pre>
+
+function calculateNormalizationScale(buffer)
+{
+    var GainCalibration = 0.00125;
+    var GainCalibrationSampleRate = 44100;
+    var MinPower = 0.000125;
+
+    // Normalize by RMS power.
+    var numberOfChannels = buffer.numberOfChannels;
+    var length = buffer.length;
+
+    var power = 0;
+
+    for (var i = 0; i &lt; numberOfChannels; i++) {
+        var channelPower = 0;
+        var channelData = buffer.getChannelData(i);
+
+        for (var j = 0; j &lt; length; j++) {
+            var sample = channelData[j];
+            channelPower += sample * sample;
+        }
+
+        power += channelPower;
+    }
+
+    power = Math.sqrt(power / (numberOfChannels * length));
+
+    // Protect against accidental overload.
+    if (!isFinite(power) || isNaN(power) || power &lt; MinPower)
+        power = MinPower;
+
+    var scale = 1 / power;
+
+    // Calibrate to make perceived volume same as unprocessed.
+    scale *= GainCalibration;
+
+    // Scale depends on sample-rate.
+    if (buffer.sampleRate)
+        scale *= GainCalibrationSampleRate / buffer.sampleRate;
+
+    // True-stereo compensation.
+    if (numberOfChannels == 4)
+        scale *= 0.5;
+
+    return scale;
+}
+
+</pre>
+              <p>
+                During processing, the ConvolverNode will then take this
+                calculated <em>normalizationScale</em> value and multiply it by
+                the result of the linear convolution resulting from processing
+                the input with the impulse response (represented by the
+                <em>buffer</em>) to produce the final output. Or any
+                mathematically equivalent operation may be used, such as
+                pre-multiplying the input by <em>normalizationScale</em>, or
+                pre-multiplying a version of the impulse-response by
+                <em>normalizationScale</em>.
+              </p>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>ConvolverOptions</dfn>
+          </h2>
+          <p>
+            The specifies options for constructing a
+            <a><code>ConvolverNode</code></a>. All members are optional; if not
+            specified, the node is contructing using the normal defaults.
+          </p>
+          <pre class="idl">
+dictionary ConvolverOptions : AudioNodeOptions {
+             AudioBuffer? buffer;
+             boolean      disableNormalization = false;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>ConvolverOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="ConvolverOptions"
+            data-link-for="ConvolverOptions">
+              <dt>
+                <code><dfn>buffer</dfn></code> of type <span class=
+                "idlAttrType"><code>AudioBuffer</code></span>, nullable
+              </dt>
+              <dd>
+                The desired buffer for the <a><code>ConvolverNode</code></a>.
+                This buffer will be normalized according to the value of
+                <code>disableNormalization</code>.
+              </dd>
+              <dt>
+                <code><dfn>disableNormalization</dfn></code> of type
+                <span class="idlAttrType"><code>boolean</code></span>,
+                defaulting to false
+              </dt>
+              <dd>
+                The opposite of the desired initial value for the
+                <a data-link-for="ConvolverNode"><code>normalize</code></a>
+                attribute of the <a><code>ConvolverNode</code></a>.
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h3 id="Convolution-channel-configurations">
+            Channel Configurations for Input, Impulse Response and Output
+          </h3>
+          <p>
+            Implementations MUST support the following allowable configurations
+            of impulse response channels in a <a><code>ConvolverNode</code></a>
+            to achieve various reverb effects with 1 or 2 channels of input.
+          </p>
+          <p>
+            The first image in the diagram illustrates the general case, where
+            the source has N input channels, the impulse response has K
+            channels, and the playback system has M output channels. Because
+            <a><code>ConvolverNode</code></a> is limited to 1 or 2 channels of
+            input, not every case can be handled.
+          </p>
+          <p>
+            Single channel convolution operates on a mono audio input, using a
+            mono impulse response, and generating a mono output. The remaining
+            images in the diagram illustrate the supported cases for mono and
+            stereo playback where N and M are 1 or 2 and K is 1, 2, or 4.
+            Developers desiring more complex and arbitrary matrixing can use a
+            <a><code>ChannelSplitterNode</code></a>, multiple single-channel
+            <a><code>ConvolverNode</code></a>s and a
+            <a><code>ChannelMergerNode</code></a>.
+          </p>
+          <figure id="convolver-diagram">
+            <img alt="reverb matrixing" src="images/convolver-diagram.png">
+            <figcaption>
+              A graphical representation of supported input and output channel
+              count possibilities when using a
+              <a><code>ConvolverNode</code></a>.
+            </figcaption>
+          </figure>
+        </section>
+      </section>
+      <section>
+        <h2 id="DelayNode">
+          The DelayNode Interface
+        </h2>
+        <p>
+          A delay-line is a fundamental building block in audio applications.
+          This interface is an <a><code>AudioNode</code></a> with a single
+          input and single output.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                Yes
+              </td>
+              <td>
+                Continues to output non-silent audio with zero input up to the
+                <a>maxDelayTime</a> of the node.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the output always equals the number of
+          channels of the input.
+        </p>
+        <p>
+          It delays the incoming audio signal by a certain amount.
+          Specifically, at each time <em>t</em>, input signal
+          <em>input(t)</em>, delay time <em>delayTime(t)</em> and output signal
+          <em>output(t)</em>, the output will be <em>output(t) = input(t -
+          delayTime(t))</em>. The default <code>delayTime</code> is 0 seconds
+          (no delay).
+        </p>
+        <p>
+          When the number of channels in a <a>DelayNode</a>'s input changes
+          (thus changing the output channel count also), there may be delayed
+          audio samples which have not yet been output by the node and are part
+          of its internal state. If these samples were received earlier with a
+          different channel count, they MUST be upmixed or downmixed before
+          being combined with newly received input so that all internal
+          delay-line mixing takes place using the single prevailing channel
+          layout.
+        </p>
+        <p class="note">
+          By definition, a <a>DelayNode</a> introduces an audio processing
+          latency equal to the amount of the delay.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional DelayOptions options)]
+interface DelayNode : AudioNode {
+    readonly        attribute AudioParam delayTime;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="DelayNode" data-link-for=
+          "DelayNode">
+            <dt>
+              <code><dfn>DelayNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>DelayNode</a> object. <a href=
+                "#audionode-constructor-init">Initialize</a> <var>node</var>,
+                and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new <a>DelayNode</a> will
+                    be <a href="#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>DelayOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this <a>DelayNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="DelayNode" data-link-for=
+          "DelayNode">
+            <dt>
+              <code><dfn>delayTime</dfn></code> of type <span class=
+              "idlAttrType"><code>AudioParam</code></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                An <a><code>AudioParam</code></a> object representing the
+                amount of delay (in seconds) to apply. Its default
+                <code>value</code> is 0 (no delay). The minimum value is 0 and
+                the maximum value is determined by the
+                <code>maxDelayTime</code> argument to the
+                <code>AudioContext</code> method <code>createDelay</code>.
+              </p>
+              <p>
+                If <a><code>DelayNode</code></a> is part of a <a>cycle</a>,
+                then the value of the <a><code>delayTime</code></a> attribute
+                is clamped to a minimum of one <a>render quantum</a>.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a data-link-for="AudioNode">maxDelayTime</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>DelayOptions</dfn>
+          </h2>
+          <p>
+            This specifies options for constructing a
+            <a><code>DelayNode</code></a>. All members are optional; if not
+            given, the node is constructed using the normal defaults.
+          </p>
+          <pre class="idl">
+dictionary DelayOptions : AudioNodeOptions {
+             double maxDelayTime = 1;
+             double delayTime = 0;
+};
+          </pre>
+          <section>
+            <h3>
+              Dictionary <a>DelayOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="DelayOptions" data-link-for=
+            "DelayOptions">
+              <dt>
+                <code><dfn>delayTime</dfn></code> of type <span class=
+                "idlAttrType"><a>double</a></span>, defaulting to 0
+              </dt>
+              <dd>
+                The maximum delay time for the node.
+              </dd>
+              <dt>
+                <code><dfn>maxDelayTime</dfn></code> of type <span class=
+                "idlAttrType"><a>double</a></span>, defaulting to 1
+              </dt>
+              <dd>
+                The initial delay time for the node.
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The DynamicsCompressorNode Interface
+        </h2>
+        <p>
+          <a><code>DynamicsCompressorNode</code></a> is an
+          <a><code>AudioNode</code></a> processor implementing a dynamics
+          compression effect.
+        </p>
+        <p>
+          Dynamics compression is very commonly used in musical production and
+          game audio. It lowers the volume of the loudest parts of the signal
+          and raises the volume of the softest parts. Overall, a louder,
+          richer, and fuller sound can be achieved. It is especially important
+          in games and musical applications where large numbers of individual
+          sounds are played simultaneous to control the overall signal level
+          and help avoid clipping (distorting) the audio output to the
+          speakers.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td>
+                Has <a>channelCount constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">clamped-max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                Yes
+              </td>
+              <td>
+                This node has a <a>tail-time</a> reference such that this node
+                continues to output non-silent audio with zero input due to the
+                look-ahead delay.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional DynamicsCompressorOptions options)]
+interface DynamicsCompressorNode : AudioNode {
+    readonly        attribute AudioParam threshold;
+    readonly        attribute AudioParam knee;
+    readonly        attribute AudioParam ratio;
+    readonly        attribute float      reduction;
+    readonly        attribute AudioParam attack;
+    readonly        attribute AudioParam release;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="DynamicsCompressorNode"
+          data-link-for="DynamicsCompressorNode">
+            <dt>
+              <code><dfn>DynamicsCompressorNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>DynamicsCompressorNode</a>
+                object. <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>. Let [[internal reduction]] be a private slot
+                on this <a>DynamicsCompressorNode</a>, that holds a floating
+                point number, in decibels. Set [[internal reduction]] to 0.0.
+                Return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>DynamicsCompressorNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>DynamicsCompressorOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>DynamicsCompressorNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="DynamicsCompressorNode"
+          data-link-for="DynamicsCompressorNode">
+            <dt>
+              <code><dfn>attack</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The amount of time (in seconds) to reduce the gain by 10dB.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0.003
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>k-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>knee</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                A decibel value representing the range above the threshold
+                where the curve smoothly transitions to the "ratio" portion.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      30
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      40
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>k-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>ratio</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The amount of dB change in input for a 1 dB change in output.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      12
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      20
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>k-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>reduction</dfn></code> of type <span class=
+              "idlAttrType"><a><code>float</code></a></span>, readonly
+            </dt>
+            <dd>
+              A read-only decibel value for metering purposes, representing the
+              current amount of gain reduction that the compressor is applying
+              to the signal. If fed no signal the value will be 0 (no gain
+              reduction). When this attribute is read, return the value of the
+              private slot [[internal reduction]].
+            </dd>
+            <dt>
+              <code><dfn>release</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The amount of time (in seconds) to increase the gain by 10dB.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0.25
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>k-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>threshold</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The decibel value above which the compression will start taking
+                effect.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      -24
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      -100
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>k-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>DynamicsCompressorOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options to use in constructing a
+            <a><code>DynamicsCompressorNode</code></a>. All members are
+            optional; if not specified the normal defaults are used in
+            constructing the node.
+          </p>
+          <pre class="idl">
+dictionary DynamicsCompressorOptions : AudioNodeOptions {
+             float attack = 0.003;
+             float knee = 30;
+             float ratio = 12;
+             float release = 0.25;
+             float threshold = -24;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>DynamicsCompressorOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="DynamicsCompressorOptions"
+            data-link-for="DynamicsCompressorOptions">
+              <dt>
+                <code><dfn>attack</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 0.003
+              </dt>
+              <dd>
+                The initial value for the <a data-link-for=
+                "DynamicsCompressorNode"><code>attack</code></a> AudioParam.
+              </dd>
+              <dt>
+                <code><dfn>knee</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 30
+              </dt>
+              <dd>
+                The initial value for the <a data-link-for=
+                "DynamicsCompressorNode"><code>knee</code></a> AudioParam.
+              </dd>
+              <dt>
+                <code><dfn>ratio</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 12
+              </dt>
+              <dd>
+                The initial value for the <a data-link-for=
+                "DynamicsCompressorNode"><code>ratio</code></a> AudioParam.
+              </dd>
+              <dt>
+                <code><dfn>release</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 0.25
+              </dt>
+              <dd>
+                The initial value for the <a data-link-for=
+                "DynamicsCompressorNode"><code>release</code></a> AudioParam.
+              </dd>
+              <dt>
+                <code><dfn>threshold</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to -24
+              </dt>
+              <dd>
+                The initial value for the <a data-link-for=
+                "DynamicsCompressorNode"><code>threshold</code></a> AudioParam.
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h2>
+            Processing
+          </h2>
+          <p>
+            Dynamics compression can be implemented in a variety of ways. The
+            <a>DynamicsCompressorNode</a> implements a dynamics processor that
+            has the following characteristics:
+          </p>
+          <ul>
+            <li>Fixed look-ahead (this means that an
+            <a>DynamicsCompressorNode</a> adds a fixed latency to the signal
+            chain).
+            </li>
+            <li>Configurable attack speed, release speed, threshold, knee
+            hardness and ratio.
+            </li>
+            <li>Side-chaining is not supported.
+            </li>
+            <li>The gain reduction is reported <em>via</em> the
+            <code>reduction</code> property on the
+            <a>DynamicsCompressorNode</a>.
+            </li>
+            <li>The compression curve has three parts:
+              <ul>
+                <li>The first part is the identity: \(f(x) = x\).
+                </li>
+                <li>The second part is the soft-knee portion, which MUST be a
+                monotonically increasing function.
+                </li>
+                <li>The third part is a linear function: \(f(x) =
+                \frac{1}{ratio} \cdot x \).
+                </li>
+              </ul>This curve MUST be continuous and piece-wise differentiable,
+              and corresponds to a target output level, based on the input
+              level.
+            </li>
+          </ul>
+          <p>
+            Graphically, such a curve would look something like this:
+          </p>
+          <figure>
+            <img alt="Graphical representation of a compression curve" src=
+            "images/compression-curve.svg" style="width: 50%">
+            <figcaption>
+              A typical compression curve, showing the knee portion (soft or
+              hard) as well as the threshold.
+            </figcaption>
+          </figure>
+          <p>
+            Internally, the <a>DynamicsCompressorNode</a> is described with a
+            combination of other <a>AudioNode</a>s, as well as a special
+            algorithm, to compute the gain reduction value.
+          </p>
+          <p>
+            The following <a>AudioNode</a> graph is used internally,
+            <code>input</code> and <code>output</code> respectively being the
+            input and output <a>AudioNode</a>, <code>context</code> the
+            <a>BaseAudioContext</a> for this <a>DynamicsCompressorNode</a>, and
+            new class, <code>EnvelopeFollower</code>, that instantiate a
+            special object that behaves like an <a>AudioNode</a>, described
+            below:
+          </p>
+          <pre>
+              var delay = new DelayNode(context, {delayTime: 0.006});
+              var gain = new GainNode(context);
+              var compression = new EnvelopeFollower();
+
+              input.connect(delay).connect(gain).connect(output);
+              input.connect(compression).connect(gain.gain);</pre>
+          <figure>
+            <img src="images/dynamicscompressor-internal-graph.svg" alt=
+            "Schema of
+            the internal graph used by the DynamicCompressorNode">
+            <figcaption>
+              The graph of internal <a>AudioNode</a>s used as part of the
+              <a>DynamicsCompressorNode</a> processing algorithm.
+            </figcaption>
+          </figure>
+          <div class="note">
+            This implements the pre-delay and the application of the reduction
+            gain.
+          </div>
+          <p>
+            The following algorithm describes the processing performed by an
+            <code>EnvelopeFollower</code> object, to be applied to the input
+            signal to produce the gain reduction value. An
+            <code>EnvelopeFollower</code> has two slots holding floating point
+            values. Those values persist accros invocation of this algorithm.
+          </p>
+          <ul>
+            <li>Let <code>[[detector average]]</code> be a floating point
+            number, initialized to 0.0.
+            </li>
+            <li>Let <code>[[compression gain]]</code> be a floating point
+            number, initialized to 1.0.
+            </li>
+          </ul>
+          <p>
+            The following algorithm allow determining a value for
+            <var>reduction gain</var>, for each sample of input, for a render
+            quantum of audio.
+          </p>
+          <ol>
+            <li>Let <var>threshold</var>, <var>knee</var> have the value of the
+            <a>AudioParam</a> of the same name, <a href=
+            "#db-to-linear">converted to linear unit</a> sampled at the time of
+            processing of this block (as <a>k-rate</a> parameters).
+            </li>
+            <li>Let <var>ratio</var> have the value of the <code>ratio</code>
+            <a>AudioParam</a>, sampled at the time of processing of this block
+            (as a <a>k-rate</a> parameter).
+            </li>
+            <li>Let <var>attack</var> and <var>release</var> have the value of
+            the <a>AudioParam</a> of the same name, sampled at the time of
+            processing (those are <a>k-rate</a> parameters), mutiplied by the
+            sample-rate of the <a>BaseAudioContext</a> this
+            <a>DynamicsCompressorNode</a> is <a href=
+            "#associated">associated</a> with.
+            </li>
+            <li>Let <var>detector average</var> be the value of the slot <code>
+              [[detector average]]</code>.
+            </li>
+            <li>Let <var>compressor gain</var> be the value of the slot <code>
+              [[compressor gain]]</code>.
+            </li>
+            <li>For each sample <var>input</var> of the render quantum to be
+            processed, execute the following steps:
+              <ol>
+                <li>Let <var>releasing</var> be <code>true</code> if
+                <var>target gain</var> is greater than <var>compressor
+                gain</var>, <code>false</code> otherwise.
+                </li>
+                <li>If the absolute value of <var>input</var> is less than
+                0.0001, let <var>attenuation</var> be 1.0. Else, let
+                <var>shaped input</var> be the value of applying the <a href=
+                "#compression-curve">compression curve</a> to the absolute
+                value of <var>input</var>. Let <var>attenuation</var> be <var>
+                  shaped input</var> divided by the absolute value of
+                  <var>input</var>.
+                </li>
+                <li>Let <var>detector rate</var> be the result of applying the
+                <a href="#detector-curve">detector curve</a> to
+                <var>attenuation</var>.
+                </li>
+                <li>Substract <var>detector average</var> to
+                <var>attenuation</var>, and multiply the result by
+                <var>detector rate</var>. Add this new result to <var>detector
+                average</var>.
+                </li>
+                <li>Clamp <var>detector average</var> to a maximum of 1.0.
+                </li>
+                <li>Let <var>envelope rate</var> be the result of <a href=
+                "#envelope-rate">computing the envelope rate</a>.
+                </li>
+                <li>If <var>releasing</var> is <code>true</code>, set
+                <var>compressor gain</var> to the multiplication of
+                <var>compressor gain</var> by <var>envelope rate</var>, clamped
+                to a maximum of 1.0.
+                </li>
+                <li>Else, if <var>releasing</var> is <code>false</code>, let
+                <var>gain increment</var> to be <var>detector average</var>
+                minus <var>compressor gain</var>. Multiply <var>gain
+                increment</var> by <var>envelope rate</var>, and add the result
+                to <var>compressor gain</var>.
+                </li>
+                <li>Compute <var>reduction gain</var> to be <var>compressor
+                gain</var> multiplied by the return value of <a>computing the
+                makeup gain</a>.
+                </li>
+                <li>Compute <var>metering gain</var> to be <var>final
+                gain</var>, <a href="#linear-to-decibel">converted to
+                decibel</a>.
+                </li>
+              </ol>
+            </li>
+            <li>Set <code>[[compressor gain]]</code> to <var>compressor
+            gain</var>.
+            </li>
+            <li>Set <code>[[detector average]]</code> to <var>detector
+            average</var>.
+            </li>
+            <li>
+              <a href="#atomic">Atomically</a> set the internal slot [[internal
+              reduction]] to the value of <var>metering gain</var>.
+              <div class="note">
+                This step makes the metering gain update once per block, at the
+                end of the block processing.
+              </div>
+            </li>
+          </ol>
+          <p>
+            The makeup gain is a fixed gain stage that only depends on ratio,
+            knee and threshold parameter of the compressor, and not on the
+            input signal. The intent here is to increase the output level of
+            the compressor so it is comparable to the input level.
+          </p>
+          <p>
+            <dfn>Computing the makeup gain</dfn> means executing the following
+            steps:
+          </p>
+          <ol>
+            <li>Let <var>full range gain</var> be the value returned by
+            applying the <a>compression curve</a> to the value 1.0.
+            </li>
+            <li>Let <var>full range makeup gain</var> the inverse of <var>full
+            range gain</var>.
+            </li>
+            <li>Return the result of taking 0.6 power of <var>full range makeup
+            gain</var>.
+            </li>
+          </ol>
+          <p>
+            <dfn id="#envelope-rate">Computing the envelope rate</dfn> is done
+            by applying a function to the ratio of the <var>compressor
+            gain</var> and the <var>detector average</var>. User-agents are
+            allowed to choose the shape the envelope function. However, this
+            function MUST respect the following constraints:
+          </p>
+          <ul>
+            <li>The envelope rate MUST be the calculated from the ratio of the
+            <var>compressor gain</var> and the <var>detector average</var>.
+              <div class="note">
+                When attacking, this number less than or equal to 1, when
+                releasing, this number is strictly greater than 1.
+              </div>
+            </li>
+            <li>The attack curve MUST be a continuous, monotonically increasing
+            function in the range \([0, 1]\).
+            </li>
+            <li>The release curve MUST be a continuous, monotonically
+            decreasing function that is always greater than 1.
+            </li>
+          </ul>
+          <p>
+            This operation returns the value computed by applying this function
+            to the ratio of <var>compressor gain</var> and <var>detector
+            average</var>.
+          </p>
+          <p>
+            Applying the <dfn id="detector-curve">detector curve</dfn> to the
+            change rate when attacking or releasing allow implementing
+            <em>adaptive release</em>. It is a function that MUST respect the
+            following constraints:
+          </p>
+          <ul>
+            <li>The output of the function MUST be in \([0,1]\).
+            </li>
+            <li>The function MUST be monotonically increasing, continuous.
+            </li>
+          </ul>
+          <div class="note">
+            It is allowed, for example, to have a compressor that performs an
+            <em>adaptive release</em>, that is, releasing faster the harder the
+            compression, or to have curves for attack and release that are not
+            of the same shape.
+          </div>
+          <p>
+            Applying a <dfn>compression curve</dfn> to a value means computing
+            the value of this sample when passed to a function, and returning
+            the computed value. This function MUST respect the following
+            characteristics:
+          </p>
+          <ol>
+            <li>This function is the identity up to the value of the linear
+            <code>threshold</code> (i.e., \(f(x) = x\)).
+            </li>
+            <li>From the <code>threshold</code> up to the <code>threshold +
+            knee</code>, User-Agents can choose the curve shape. The whole
+            function MUST be monotonically increasing and continuous.
+              <div class="note">
+                If the <code>knee</code> is 0, the
+                <a>DynamicsCompressorNode</a> is called a hard-knee compressor.
+              </div>
+            </li>
+            <li>This function is linear, based on the ratio, after the
+            <code>threshold</code> and the soft knee (i.e., \(f(x) =
+            \frac{1}{ratio} \cdot x \)).
+            </li>
+          </ol>
+          <p>
+            Converting a value \(v\) in <dfn id="linear-to-decibel">linear gain
+            unit to decibel means</dfn> executing the following steps:
+          </p>
+          <ol>
+            <li>If <var>v</var> is equal to zero, return -1000.
+            </li>
+            <li>Else, return \( 20 \, \log_{10}{v} \)
+            </li>
+          </ol>
+          <p>
+            Converting a value \(v\) in <dfn id="db-to-linear">decibels to
+            linear gain unit</dfn> means returning \(10^\frac{v}{20}\)
+          </p>
+        </section>
+      </section>
+      <section>
+        <h2 id="GainNode">
+          The GainNode Interface
+        </h2>
+        <p>
+          Changing the gain of an audio signal is a fundamental operation in
+          audio applications. The <code>GainNode</code> is one of the building
+          blocks for creating <a href="#mixer-gain-structure">mixers</a>. This
+          interface is an <a><code>AudioNode</code></a> with a single input and
+          single output:
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          Each sample of each channel of the input data of the
+          <a><code>GainNode</code></a> MUST be multiplied by the
+          <a>computedValue</a> of the <a data-link-for=
+          "GainNode"><code>gain</code></a> <a><code>AudioParam</code></a>.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional GainOptions options)]
+interface GainNode : AudioNode {
+    readonly        attribute AudioParam gain;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="GainNode" data-link-for="GainNode">
+            <dt>
+              <code><dfn>GainNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>gain</var> be a new <a>GainNode</a> object. <a href=
+                "#audionode-constructor-init">Initialize</a> <var>gain</var>,
+                and return <var>gain</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new <a>GainNode</a> will
+                    be <a href="#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>GainOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter values for this <a>GainNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="GainNode" data-link-for=
+          "GainNode">
+            <dt>
+              <code><dfn>gain</dfn></code> of type <span class=
+              "idlAttrType"><code>AudioParam</code></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                Represents the amount of gain to apply.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>GainOptions</dfn>
+          </h2>
+          <p>
+            This specifies options to use in constructing a
+            <a><code>GainNode</code></a>. All members are optional; if not
+            specified, the normal defaults are used in constructing the node.
+          </p>
+          <pre class="idl">
+dictionary GainOptions : AudioNodeOptions {
+             float gain = 1.0;
+};
+          </pre>
+          <section>
+            <h3>
+              Dictionary <a>GainOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="GainOptions" data-link-for=
+            "GainOptions">
+              <dt>
+                <code><dfn>gain</dfn></code> of type <span class=
+                "idlAttrType"><a>float</a></span>, defaulting to 1.0
+              </dt>
+              <dd>
+                The initial gain value for the <a data-link-for=
+                "GainNode"><code>gain</code></a> AudioParam.
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The IIRFilterNode Interface
+        </h2>
+        <p>
+          <a><code>IIRFilterNode</code></a> is an <a><code>AudioNode</code></a>
+          processor implementing a general IIR Filter. In general, it is best
+          to use <a><code>BiquadFilterNode</code></a>'s to implement
+          higher-order filters for the following reasons:
+        </p>
+        <ul>
+          <li>Generally less sensitive to numeric issues
+          </li>
+          <li>Filter parameters can be automated
+          </li>
+          <li>Can be used to create all even-ordered IIR filters
+          </li>
+        </ul>
+        <p>
+          However, odd-ordered filters cannot be created, so if such filters
+          are needed or automation is not needed, then IIR filters may be
+          appropriate.
+        </p>
+        <p>
+          Once created, the coefficients of the IIR filter cannot be changed.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                Yes
+              </td>
+              <td>
+                Continues to output non-silent audio with zero input. Since
+                this is an IIR filter, the filter produces non-zero input
+                forever, but in practice, this can be limited after some finite
+                time where the output is sufficiently close to zero. The actual
+                time depends on the filter coefficients.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the output always equals the number of
+          channels of the input.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, IIRFilterOptions options)]
+interface IIRFilterNode : AudioNode {
+    void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="IIRFilterNode" data-link-for=
+          "IIRFilterNode">
+            <dt>
+              <code><dfn>IIRFilterNode</dfn></code>
+            </dt>
+            <dd>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new <a>IIRFilterNode</a>
+                    will be <a href="#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>IIRFilterOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>IIRFilterNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Methods
+          </h3>
+          <dl class="methods" data-dfn-for="IIRFilterNode" data-link-for=
+          "IIRFilterNode">
+            <dt>
+              <code><dfn>getFrequencyResponse</dfn></code>
+            </dt>
+            <dd>
+              <span class="synchronous">Given the current filter parameter
+              settings, synchronously calculates the frequency response for the
+              specified frequencies.</span> The three parameters MUST be
+              <code>Float32Array</code>s of the same length, or an
+              <code>InvalidAccessError</code> MUST be thrown.
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    frequencyHz
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    This parameter specifies an array of frequencies at which
+                    the response values will be calculated.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    magResponse
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    <p>
+                      This parameter specifies an output array receiving the
+                      linear magnitude response values.
+                    </p>
+                    <p>
+                      If a value in the <code>frequencyHz</code> parameter is
+                      not within [0; sampleRate/2], where
+                      <code>sampleRate</code> is the value of the
+                      <a data-link-for=
+                      "BaseAudioContext"><code>sampleRate</code></a> property
+                      of the <a>AudioContext</a>, the corresponding value at
+                      the same index of the <code>magResponse</code> array MUST
+                      be <code>NaN</code>.
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    phaseResponse
+                  </td>
+                  <td class="prmType">
+                    <a><code>Float32Array</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    <p>
+                      This parameter specifies an output array receiving the
+                      phase response values in radians.
+                    </p>
+                    <p>
+                      If a value in the <code>frequencyHz</code> parameter is
+                      not within [0; sampleRate/2], where
+                      <code>sampleRate</code> is the value of the
+                      <a data-link-for=
+                      "BaseAudioContext"><code>sampleRate</code></a> property
+                      of the <a>AudioContext</a>, the corresponding value at
+                      the same index of the <code>phaseResponse</code> array
+                      MUST be <code>NaN</code>.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>IIRFilterOptions</dfn>
+          </h2>
+          <p>
+            The <code>IIRFilterOptions</code> dictionary is used to specify the
+            filter coefficients of the <a><code>IIRFilterNode</code></a>.
+          </p>
+          <pre class="idl">
+dictionary IIRFilterOptions : AudioNodeOptions {
+    required sequence&lt;double&gt; feedforward;
+    required sequence&lt;double&gt; feedback;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>IIRFilterOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="IIRFilterOptions"
+            data-link-for="IIRFilterOptions">
+              <dt>
+                <code><dfn>feedforward</dfn></code> of type <span class=
+                "idlAttrType"><code>sequence&lt;double&gt;</code></span>,
+                required
+              </dt>
+              <dd>
+                The feedforward coefficients for the
+                <a><code>IIRFilterNode</code></a>. This member is required. If
+                not specifed, a <code>NotFoundError</code> MUST be thrown.
+              </dd>
+              <dt>
+                <code><dfn>feedback</dfn></code> of type <span class=
+                "idlAttrType"><code>sequence&lt;double&gt;</code></span>,
+                required
+              </dt>
+              <dd>
+                The feedback coefficients for the
+                <a><code>IIRFilterNode</code></a>. This member is required. If
+                not specifed, a <code>NotFoundError</code> MUST be thrown.
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h3>
+            Filter Definition
+          </h3>
+          <p>
+            Let \(b_m\) be the <code>feedforward</code> coefficients and
+            \(a_n\) be the <code>feedback</code> coefficients specified by
+            <a data-link-for="BaseAudioContext">createIIRFilter</a>. Then the
+            transfer function of the general IIR filter is given by
+          </p>
+          <pre class="nohighlight">
+            $$
+              H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}}
+            $$
+
+</pre>
+          <p>
+            where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is
+            the length of the \(a\) array. The coefficient \(a_0\) cannot be 0.
+            At least one of \(b_m\) MUST be non-zero.
+          </p>
+          <p>
+            Equivalently, the time-domain equation is:
+          </p>
+          <pre class="nohighlight">
+            $$
+              \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k)
+            $$
+
+</pre>
+          <p>
+            The initial filter state is the all-zeroes state.
+          </p>
+        </section>
+      </section>
+      <section>
+        <h2 id="MediaElementAudioSourceNode">
+          The MediaElementAudioSourceNode Interface
+        </h2>
+        <p>
+          This interface represents an audio source from an <code>audio</code>
+          or <code>video</code> element.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                0
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the output corresponds to the number of
+          channels of the media referenced by the
+          <code>HTMLMediaElement</code>. Thus, changes to the media element's
+          <code>src</code> attribute can change the number of channels output
+          by this node.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, MediaElementAudioSourceOptions options)]
+interface MediaElementAudioSourceNode : AudioNode {
+    [SameObject]
+    readonly        attribute HTMLMediaElement mediaElement;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="MediaElementAudioSourceNode"
+          data-link-for="MediaElementAudioSourceNode">
+            <dt>
+              <code><dfn>MediaElementAudioSourceNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>MediaElementAudioSourceNode</a>
+                object. <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>, and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>MediaElementAudioSourceNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>MediaElementAudioSourceOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    Parameter value for this
+                    <a>MediaElementAudioSourceNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="MediaElementAudioSourceNode"
+          data-link-for="MediaElementAudioSourceNode">
+            <dt>
+              <code><dfn>mediaElement</dfn></code> of type <span class=
+              "idlAttrType"><a><code>HTMLMediaElement</code></a></span>,
+              readonly
+            </dt>
+            <dd>
+              the <code>HTMLMediaElement</code> used when constructing this
+              <a>MediaElementAudioSourceNode</a>.
+            </dd>
+          </dl>
+        </section>
+        <p>
+          A <a>MediaElementAudioSourceNode</a> is created given an
+          <code>HTMLMediaElement</code> using the <a>AudioContext</a>
+          <code>createMediaElementSource()</code> method.
+        </p>
+        <p>
+          The number of channels of the single output equals the number of
+          channels of the audio referenced by the <code>HTMLMediaElement</code>
+          passed in as the argument to <code>createMediaElementSource()</code>,
+          or is 1 if the <code>HTMLMediaElement</code> has no audio.
+        </p>
+        <p>
+          The <code>HTMLMediaElement</code> MUST behave in an identical fashion
+          after the <a>MediaElementAudioSourceNode</a> has been created,
+          <em>except</em> that the rendered audio will no longer be heard
+          directly, but instead will be heard as a consequence of the
+          <a>MediaElementAudioSourceNode</a> being connected through the
+          routing graph. Thus pausing, seeking, volume, <code>src</code>
+          attribute changes, and other aspects of the
+          <code>HTMLMediaElement</code> MUST behave as they normally would if
+          <em>not</em> used with a <a>MediaElementAudioSourceNode</a>.
+        </p>
+        <pre class="example">
+  var mediaElement = document.getElementById('mediaElementID');
+  var sourceNode = context.createMediaElementSource(mediaElement);
+  sourceNode.connect(filterNode);
+</pre>
+        <section>
+          <h2>
+            <dfn>MediaElementAudioSourceOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options to use in constructing a
+            <a><code>MediaElementAudioSourceNode</code></a>.
+          </p>
+          <pre class="idl">
+dictionary MediaElementAudioSourceOptions {
+    required HTMLMediaElement mediaElement;
+};
+          </pre>
+          <section>
+            <h3>
+              Dictionary <a>MediaElementAudioSourceOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for=
+            "MediaElementAudioSourceOptions" data-link-for=
+            "MediaElementAudioSourceOptions">
+              <dt>
+                <code><dfn>mediaElement</dfn></code> of type <span class=
+                "idlAttrType"><code>HTMLMediaElement</code></span>, required
+              </dt>
+              <dd>
+                The media element that will be re-routed. This MUST be
+                specified.
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h2>
+            Security with MediaElementAudioSourceNode and cross-origin
+            resources
+          </h2>
+          <p>
+            <code>HTMLMediaElement</code> allows the playback of cross-origin
+            resources. Because Web Audio allows inspection of the content of
+            the resource (e.g. using a <a>MediaElementAudioSourceNode</a>, and
+            a <a>ScriptProcessorNode</a> to read the samples), information
+            leakage can occur if scripts from one <a href=
+            "http://www.w3.org/html/wg/drafts/html/master/browsers.html#origin">
+            origin</a> inspect the content of a resource from another <a href=
+            "http://www.w3.org/html/wg/drafts/html/master/browsers.html#origin">
+            origin</a>.
+          </p>
+          <p>
+            To prevent this, a <a>MediaElementAudioSourceNode</a> MUST output
+            <em>silence</em> instead of the normal output of the
+            <code>HTMLMediaElement</code> if it has been created using an
+            <code>HTMLMediaElement</code> for which the execution of the
+            <a href="https://fetch.spec.whatwg.org/#fetching">fetch
+            algorithm</a> labeled the resource as <a href=
+            "http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#cors-cross-origin">
+            CORS-cross-origin</a>.
+          </p>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The MediaStreamAudioDestinationNode Interface
+        </h2>
+        <p>
+          This interface is an audio destination representing a
+          <code>MediaStream</code> with a single <code>MediaStreamTrack</code>
+          whose <code>kind</code> is <code>"audio"</code>. This MediaStream is
+          created when the node is created and is accessible via the
+          <dfn>stream</dfn> attribute. This stream can be used in a similar way
+          as a <code>MediaStream</code> obtained via
+          <code>getUserMedia()</code>, and can, for example, be sent to a
+          remote peer using the <code>RTCPeerConnection</code> (described in
+          [[!webrtc]]) <code>addStream()</code> method.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                0
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the input is by default 2 (stereo).
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional AudioNodeOptions options)]
+interface MediaStreamAudioDestinationNode : AudioNode {
+    readonly        attribute MediaStream stream;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="MediaStreamAudioDestinationNode"
+          data-link-for="MediaStreamAudioDestinationNode">
+            <dt>
+              <code><dfn>MediaStreamAudioDestinationNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new
+                <a>MediaStreamAudioDestinationNode</a> object. <a href=
+                "#audionode-constructor-init">Initialize</a> <var>node</var>,
+                and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>MediaStreamAudioDestinationNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>AudioNodeOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>MediaStreamAudioDestinationNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="MediaStreamAudioDestinationNode"
+          data-link-for="MediaStreamAudioDestinationNode">
+            <dt>
+              <code><dfn>stream</dfn></code> of type <span class=
+              "idlAttrType"><a><code>MediaStream</code></a></span>, readonly
+            </dt>
+            <dd>
+              A MediaStream containing a single MediaStreamTrack with the same
+              number of channels as the node itself, and whose
+              <code>kind</code> attribute has the value <code>"audio"</code>.
+            </dd>
+          </dl>
+        </section>
+      </section>
+      <section>
+        <h2 id="MediaStreamAudioSourceNode">
+          The MediaStreamAudioSourceNode Interface
+        </h2>
+        <p>
+          This interface represents an audio source from a
+          <code>MediaStream</code>. The track that will be used as the source
+          of audio and will be output from this node is the first
+          <code>MediaStreamTrack</code> whose <code>kind</code> attribute has
+          the value <code>"audio"</code>, when alphabetically sorting the
+          tracks of this <code>MediaStream</code> by their <code>id</code>
+          attribute. Those interfaces are described in
+          [[!mediacapture-streams]].
+        </p>
+        <p class="note">
+          The behaviour for picking the track to output is weird for legacy
+          reasons. <a>MediaStreamTrackAudioSourceNode</a> should be used
+          instead.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                0
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the output corresponds to the number of
+          channels of the <code>MediaStreamTrack</code>. If there is no valid
+          audio track, then the number of channels output will be one silent
+          channel.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, MediaStreamAudioSourceOptions options)]
+interface MediaStreamAudioSourceNode : AudioNode {
+    [SameObject] readonly        attribute MediaStream mediaStream;
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="MediaStreamAudioSourceNode"
+          data-link-for="MediaStreamAudioSourceNode">
+            <dt>
+              <code><dfn>MediaStreamAudioSourceNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a>
+                object. <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>, and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>MediaStreamAudioSourceNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>MediaStreamAudioSourceOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    Initial parameter values for this
+                    <a>MediaStreamAudioSourceNode</a>. If the
+                    <code>mediaStream</code> parameter does not reference a
+                    <code>MediaStream</code> whose <code>kind</code> attribute
+                    has the value <code>"audio"</code>, <span class=
+                    "synchronous">an <code>InvalidStateError</code> MUST be
+                    thrown</span>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="MediaStreamAudioSourceNode"
+          data-link-for="MediaStreamAudioSourceNode">
+            <dt>
+              <code><dfn>mediaStream</dfn></code> of type <span class=
+              "idlAttrType"><a><code>MediaStream</code></a></span>, readonly
+            </dt>
+            <dd>
+              The <code>MediaStream</code> used when constructing this
+              <a>MediaStreamAudioSourceNode</a>.
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>MediaStreamAudioSourceOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options for constructing a
+            <a><code>MediaStreamAudioSourceNode</code></a>.
+          </p>
+          <pre class="idl">
+dictionary MediaStreamAudioSourceOptions {
+    required MediaStream mediaStream;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>MediaStreamAudioSourceOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="MediaStreamAudioSourceOptions"
+            data-link-for="MediaStreamAudioSourceOptions">
+              <dt>
+                <code><dfn>mediaStream</dfn></code> of type <span class=
+                "idlAttrType"><code>MediaStream</code></span>, required
+              </dt>
+              <dd>
+                The media stream that will act as a source. This MUST be
+                specified.
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </section>
+      <section>
+        <h2 id="MediaStreamTrackAudioSourceNode">
+          The MediaStreamTrackAudioSourceNode Interface
+        </h2>
+        <p>
+          This interface represents an audio source from a
+          <code>MediaStreamTrack</code>.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                0
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The number of channels of the output corresponds to the number of
+          channels of the <code>MediaStreamTrack</code>.
+        </p>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (AudioContext context, MediaStreamTrackAudioSourceOptions options)]
+interface MediaStreamTrackAudioSourceNode : AudioNode {
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="MediaStreamTrackAudioSourceNode"
+          data-link-for="MediaStreamTrackAudioSourceNode">
+            <dt>
+              <code><dfn>MediaStreamTrackAudioSourceNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new
+                <a>MediaStreamTrackAudioSourceNode</a> object. <a href=
+                "#audionode-constructor-init">Initialize</a> <var>node</var>,
+                and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new
+                    <a>MediaStreamTrackAudioSourceNode</a> will be <a href=
+                    "#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>MediaStreamTrackAudioSourceOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    Initial parameter value for this
+                    <a>MediaStreamTrackAudioSourceNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>MediaStreamTrackAudioSourceOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options for constructing a
+            <a><code>MediaStreamTrackAudioSourceNode</code></a>. This is
+            required.
+          </p>
+          <pre class="idl">
+dictionary MediaStreamTrackAudioSourceOptions {
+    required MediaStreamTrack mediaStreamTrack;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>MediaStreamTrackAudioSourceOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for=
+            "MediaStreamTrackAudioSourceOptions" data-link-for=
+            "MediaStreamTrackAudioSourceOptions">
+              <dt>
+                <code><dfn>mediaStreamTrack</dfn></code> of type <span class=
+                "idlAttrType"><code>MediaStreamTrack</code></span>, readonly
+              </dt>
+              <dd>
+                The audio media stream track that will act as a source.
+              </dd>
+            </dl>
+          </section>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The OscillatorNode Interface
+        </h2>
+        <p>
+          <a><code>OscillatorNode</code></a> represents an audio source
+          generating a periodic waveform. It can be set to a few commonly used
+          waveforms. Additionally, it can be set to an arbitrary periodic
+          waveform through the use of a <a><code>PeriodicWave</code></a>
+          object.
+        </p>
+        <p>
+          Oscillators are common foundational building blocks in audio
+          synthesis. An OscillatorNode will start emitting sound at the time
+          specified by the <code>start()</code> method.
+        </p>
+        <p>
+          Mathematically speaking, a <em>continuous-time</em> periodic waveform
+          can have very high (or infinitely high) frequency information when
+          considered in the frequency domain. When this waveform is sampled as
+          a discrete-time digital audio signal at a particular sample-rate,
+          then care MUST be taken to discard (filter out) the high-frequency
+          information higher than the <a>Nyquist frequency</a> before
+          converting the waveform to a digital form. If this is not done, then
+          <em>aliasing</em> of higher frequencies (than the <a>Nyquist
+          frequency</a>) will fold back as mirror images into frequencies lower
+          than the <a>Nyquist frequency</a>. In many cases this will cause
+          audibly objectionable artifacts. This is a basic and well understood
+          principle of audio DSP.
+        </p>
+        <p>
+          There are several practical approaches that an implementation may
+          take to avoid this aliasing. Regardless of approach, the
+          <em>idealized</em> discrete-time digital audio signal is well defined
+          mathematically. The trade-off for the implementation is a matter of
+          implementation cost (in terms of CPU usage) versus fidelity to
+          achieving this ideal.
+        </p>
+        <p>
+          It is expected that an implementation will take some care in
+          achieving this ideal, but it is reasonable to consider lower-quality,
+          less-costly approaches on lower-end hardware.
+        </p>
+        <p>
+          Both <code>frequency</code> and <code>detune</code> are <a>a-rate</a>
+          parameters, and form a <a>compound parameter</a>. They are used
+          together to determine a <dfn>computedOscFrequency</dfn> value:
+        </p>
+        <pre>
+  computedOscFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
+</pre>
+        <p>
+          The OscillatorNode's instantaneous phase at each time is the definite
+          time integral of <a>computedOscFrequency</a>, assuming a phase angle
+          of zero at the node's exact start time. Its <a>nominal range</a> is
+          [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                0
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <pre class="idl">
+enum OscillatorType {
+    "sine",
+    "square",
+    "sawtooth",
+    "triangle",
+    "custom"
+};
+        </pre>
+        <table class="simple" data-dfn-for="OscillatorType" data-link-for=
+        "OscillatorType">
+          <tr>
+            <th colspan="2">
+              Enumeration description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <dfn>sine</dfn>
+            </td>
+            <td>
+              A sine wave
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>square</dfn>
+            </td>
+            <td>
+              A square wave of duty period 0.5
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>sawtooth</dfn>
+            </td>
+            <td>
+              A sawtooth wave
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>triangle</dfn>
+            </td>
+            <td>
+              A triangle wave
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>custom</dfn>
+            </td>
+            <td>
+              A custom periodic wave
+            </td>
+          </tr>
+        </table>
+        <pre class="idl">
+[Exposed=Window,
+ Constructor (BaseAudioContext context, optional OscillatorOptions options)]
+interface OscillatorNode : AudioScheduledSourceNode {
+                    attribute OscillatorType type;
+    readonly        attribute AudioParam     frequency;
+    readonly        attribute AudioParam     detune;
+    void setPeriodicWave (PeriodicWave periodicWave);
+};
+        </pre>
+        <section>
+          <h3>
+            Constructors
+          </h3>
+          <dl class="methods" data-dfn-for="OscillatorNode" data-link-for=
+          "OscillatorNode">
+            <dt>
+              <code><dfn>OscillatorNode</dfn></code>
+            </dt>
+            <dd>
+              <p>
+                Let <var>node</var> be a new <a>OscillatorNode</a> object.
+                <a href="#audionode-constructor-init">Initialize</a>
+                <var>node</var>, and return <var>node</var>.
+              </p>
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    context
+                  </td>
+                  <td class="prmType">
+                    <a><code>BaseAudioContext</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc">
+                    The <a>BaseAudioContext</a> this new <a>OscillatorNode</a>
+                    will be <a href="#associated">associated</a> with.
+                  </td>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    options
+                  </td>
+                  <td class="prmType">
+                    <a><code>OscillatorOptions</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
+                  </td>
+                  <td class="prmDesc">
+                    Optional initial parameter value for this
+                    <a>OscillatorNode</a>.
+                  </td>
+                </tr>
+              </table>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="OscillatorNode" data-link-for=
+          "OscillatorNode">
+            <dt>
+              <code><dfn>detune</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                A detuning value (in cents) which will offset the
+                <a><code>frequency</code></a> by the given amount. Its default
+                <code>value</code> is 0. This parameter is <a>a-rate</a>. It
+                forms a <a>compound parameter</a> with <code>frequency</code>
+                to form the <a>computedOscFrequency</a>.
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      <a>most-negative-single-float</a>
+                    </td>
+                    <td>
+                      Approximately -3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>most-positive-single-float</a>
+                    </td>
+                    <td>
+                      Approximately 3.4028235e38
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>frequency</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
+            </dt>
+            <dd>
+              <p>
+                The frequency (in Hertz) of the periodic waveform. Its default
+                <code>value</code> is 440. This parameter is <a>a-rate</a>. It
+                forms a <a>compound parameter</a> with <code>detune</code> to
+                form the <a>computedOscFrequency</a>. Its <a>nominal range</a>
+                is [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
+              </p>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      440
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      -<a>Nyquist frequency</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      <a>Nyquist frequency</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
+            </dd>
+            <dt>
+              <code><dfn>type</dfn></code> of type <span class=
+              "idlAttrType"><a><code>OscillatorType</code></a></span>
+            </dt>
+            <dd>
+              The shape of the periodic waveform. It may directly be set to any
+              of the type constant values except for "custom". <span class=
+              "synchronous">Doing so MUST throw an
+              <code>InvalidStateError</code> exception.</span> The
+              <a data-link-for=
+              "OscillatorNode"><code>setPeriodicWave()</code></a> method can be
+              used to set a custom waveform, which results in this attribute
+              being set to "custom". The default value is "sine". When this
+              attribute is set, the phase of the oscillator MUST be conserved.
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h3>
+            Methods
+          </h3>
+          <dl class="methods" data-dfn-for="OscillatorNode" data-link-for=
+          "OscillatorNode">
+            <dt>
+              <code><dfn>setPeriodicWave</dfn></code>
+            </dt>
+            <dd>
+              Sets an arbitrary custom periodic waveform given a
+              <a><code>PeriodicWave</code></a>.
+              <table class="parameters">
+                <tr>
+                  <th>
+                    Parameter
+                  </th>
+                  <th>
+                    Type
+                  </th>
+                  <th>
+                    Nullable
+                  </th>
+                  <th>
+                    Optional
+                  </th>
+                  <th>
+                    Description
+                  </th>
+                </tr>
+                <tr>
+                  <td class="prmName">
+                    periodicWave
+                  </td>
+                  <td class="prmType">
+                    <a><code>PeriodicWave</code></a>
+                  </td>
+                  <td class="prmNullFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmOptFalse">
+                    <span role="img" aria-label="False">✘</span>
+                  </td>
+                  <td class="prmDesc"></td>
+                </tr>
+              </table>
+              <div>
+                <em>Return type:</em> <code>void</code>
+              </div>
+            </dd>
+          </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>OscillatorOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options to be used when constructing an
+            <a><code>OscillatorNode</code></a>. All of the members are
+            optional; if not specified, the normal default values are used for
+            constructing the oscillator.
+          </p>
+          <pre class="idl">
+dictionary OscillatorOptions : AudioNodeOptions {
+             OscillatorType type = "sine";
+             float          frequency = 440;
+             float          detune = 0;
+             PeriodicWave   periodicWave;
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>OscillatorOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="OscillatorOptions"
+            data-link-for="OscillatorOptions">
+              <dt>
+                <code><dfn>detune</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 0
+              </dt>
+              <dd>
+                The initial detune value for the
+                <a><code>OscillatorNode</code></a>.
+              </dd>
+              <dt>
+                <code><dfn>frequency</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 440
+              </dt>
+              <dd>
+                The initial frequency for the
+                <a><code>OscillatorNode</code></a>.
+              </dd>
+              <dt>
+                <code><dfn>periodicWave</dfn></code> of type <span class=
+                "idlAttrType"><code>PeriodicWave</code></span>
+              </dt>
+              <dd>
+                The <a><code>PeriodicWave</code></a> for the
+                <a><code>OscillatorNode</code></a>. If this is specified, then
+                any valid value for <a data-link-for=
+                "OscillatorOptions"><code>type</code></a> is ignored; it is
+                treated as if "custom" were specified.
+              </dd>
+              <dt>
+                <code><dfn>type</dfn></code> of type <span class=
+                "idlAttrType"><code>OscillatorType</code></span>, defaulting to
+                "sine"
+              </dt>
+              <dd>
+                The type of oscillator to be constructed. If this is set to
+                "custom" without also specifying a <a data-link-for=
+                "OscillatorOptions"><code>periodicWave</code></a>, then an
+                <span class="synchronous"><code>InvalidStateError</code>
+                exception MUST be thrown</span>. If <a data-link-for=
+                "OscillatorOptions"><code>periodicWave</code></a> is specified,
+                then any valid value for <a data-link-for=
+                "OscillatorOptions"><code>type</code></a> is ignored; it is
+                treated as if it were set to "custom".
+              </dd>
+            </dl>
+          </section>
+        </section>
+        <section>
+          <h2>
+            Basic Waveform Phase
+          </h2>
+          <p>
+            The idealized mathematical waveforms for the various oscillator
+            types are defined here. In summary, all waveforms are defined
+            mathematically to be an odd function with a positive slope at time
+            0. The actual waveforms produced by the oscillator may differ to
+            prevent aliasing affects.
+          </p>
+          <p>
+            The oscillator MUST produce the same result as if a PeriodicWave
+            with the appropriate <a href="#oscillator-coefficients">Fourier
+            series</a> and with normalization enabled were used to create these
+            basic waveforms.
+          </p>
+          <dl>
+            <dt>
+              "sine"
+            </dt>
+            <dd>
+              The waveform for sine oscillator is:
+              <pre class="nohighlight">
+                $$
+                  x(t) = \sin t
+                $$.
+
+</pre>
+            </dd>
+            <dt>
+              "square"
+            </dt>
+            <dd>
+              The waveform for the square wave oscillator is:
+              <pre class="nohighlight">
+                $$
+                  x(t) = \begin{cases}
+                         1 & \mbox{for } 0≤ t &lt; \pi \\
+                         -1 & \mbox{for } -\pi &lt; t &lt; 0.
+                         \end{cases}
+                $$
+              </pre>
+              <p>
+                This is extended to all \(t\) by using the fact that the
+                waveform is an odd function with period \(2\pi\).
+              </p>
+            </dd>
+            <dt>
+              "sawtooth"
+            </dt>
+            <dd>
+              The waveform for the sawtooth oscillator is the ramp:
+              <pre class="nohighlight">
+                $$
+                  x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi;
+                $$
+              </pre>
+              <p>
+                This is extended to all \(t\) by using the fact that the
+                waveform is an odd function with period \(2\pi\).
+              </p>
+            </dd>
+            <dt>
+              "triangle"
+            </dt>
+            <dd>
+              The waveform for the triangle oscillator is:
+              <pre class="nohighlight">
+                $$
+                  x(t) = \begin{cases}
+                           \frac{2}{\pi} t & \mbox{for } 0 ≤ t ≤ \frac{\pi}{2} \\
+                           1-\frac{2}{\pi} (t-\frac{\pi}{2}) & \mbox{for }
+                           \frac{\pi}{2} &lt; t ≤ \pi.
+                         \end{cases}
+                $$
+              </pre>
+              <p>
+                This is extended to all \(t\) by using the fact that the
+                waveform is an odd function with period \(2\pi\).
+              </p>
+            </dd>
+          </dl>
         </section>
       </section>
       <section>
@@ -12098,6232 +17802,6 @@ dictionary PannerOptions : AudioNodeOptions {
         </section>
       </section>
       <section>
-        <h2 id="AudioListener">
-          The <dfn>AudioListener</dfn> Interface
-        </h2>
-        <p>
-          This interface represents the position and orientation of the person
-          listening to the audio scene. All <a><code>PannerNode</code></a>
-          objects spatialize in relation to the
-          <a><code>BaseAudioContext</code></a>'s <a data-link-for=
-          "BaseAudioContext">listener</a>. See <a>Spatialization/Panning</a>
-          for more details about spatialization.
-        </p>
-        <p>
-          The <code>positionX, positionY, positionZ</code> parameters represent
-          the location of the listener in 3D Cartesian coordinate space.
-          <a><code>PannerNode</code></a> objects use this position relative to
-          individual audio sources for spatialization.
-        </p>
-        <p>
-          The <code>forwardX, forwardY, forwardZ</code> parameters represent a
-          direction vector in 3D space. Both a <code>forward</code> vector and
-          an <code>up</code> vector are used to determine the orientation of
-          the listener. In simple human terms, the <code>forward</code> vector
-          represents which direction the person's nose is pointing. The
-          <code>up</code> vector represents the direction the top of a person's
-          head is pointing. These two vectors are expected to be linearly
-          independent. For normative requirements of how these values are to be
-          interpreted, see the <a>Spatialization/Panning</a> section.
-        </p>
-        <pre class="idl">
-[Exposed=Window]
-interface AudioListener {
-    readonly        attribute AudioParam positionX;
-    readonly        attribute AudioParam positionY;
-    readonly        attribute AudioParam positionZ;
-    readonly        attribute AudioParam forwardX;
-    readonly        attribute AudioParam forwardY;
-    readonly        attribute AudioParam forwardZ;
-    readonly        attribute AudioParam upX;
-    readonly        attribute AudioParam upY;
-    readonly        attribute AudioParam upZ;
-    void setPosition (float x, float y, float z);
-    void setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
-};
-        </pre>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <p>
-            For all of the following <a>AudioParam</a>s, the <a>AudioParam</a>
-            rate is specified by the <dfn>listener <a>AudioParam</a> rate</dfn>
-            which is <a>a-rate</a> when any connected <a>PannerNode</a> is
-            <a>a-rate</a> and is <a>k-rate</a> otherwise.
-          </p>
-          <dl class="attributes" data-dfn-for="AudioListener" data-link-for=
-          "AudioListener">
-            <dt>
-              <code><dfn>forwardX</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the x coordinate component of the forward direction the
-                listener is pointing in 3D Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>forwardY</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the y coordinate component of the forward direction the
-                listener is pointing in 3D Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>forwardZ</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the z coordinate component of the forward direction the
-                listener is pointing in 3D Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      -1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>positionX</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the x coordinate position of the audio listener in a 3D
-                Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>positionY</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the y coordinate position of the audio listener in a 3D
-                Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>positionZ</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the z coordinate position of the audio listener in a 3D
-                Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>upX</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the x coordinate component of the up direction the
-                listener is pointing in 3D Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>upY</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the y coordinate component of the up direction the
-                listener is pointing in 3D Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>upZ</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                Sets the z coordinate component of the up direction the
-                listener is pointing in 3D Cartesian coordinate space.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td></td>
-                    <td>
-                      See <a>listener AudioParam rate</a>
-                    </td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Methods
-          </h3>
-          <dl class="methods" data-dfn-for="AudioListener" data-link-for=
-          "AudioListener">
-            <dt>
-              <code><dfn>setOrientation</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                This method is DEPRECATED. It is equivalent to setting
-                <a>forwardX</a>.<a data-link-for="AudioParam">value</a>,
-                <a>forwardY</a>.<a data-link-for="AudioParam">value</a>,
-                <a>forwardZ</a>.<a data-link-for="AudioParam">value</a>,
-                <a>upX</a>.<a data-link-for="AudioParam">value</a>,
-                <a>upY</a>.<a data-link-for="AudioParam">value</a>, and
-                <a>upZ</a>.<a data-link-for="AudioParam">value</a> directly
-                with the given <code>x</code>, <code>y</code>, <code>z</code>,
-                <code>xUp</code>, <code>yUp</code>, and <code>zUp</code>
-                values, respectively.
-              </p>
-              <p>
-                Consequently, if any of the <a>forwardX</a>, <a>forwardY</a>,
-                <a>forwardZ</a>, <a>upX</a>, <a>upY</a> and <a>upZ</a>
-                <a>AudioParam</a>s have an automation curve set using
-                <a data-link-for=
-                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
-                this method is called, a <code>NotSupportedError</code> MUST be
-                thrown.
-              </p>
-              <p>
-                Describes which direction the listener is pointing in the 3D
-                cartesian coordinate space. Both a <b>front</b> vector and an
-                <b>up</b> vector are provided. In simple human terms, the
-                <b>front</b> vector represents which direction the person's
-                nose is pointing. The <b>up</b> vector represents the direction
-                the top of a person's head is pointing. These two vectors are
-                expected to be linearly independent. For normative requirements
-                of how these values are to be interpreted, see the <a href=
-                "#Spatialization">spatialization section</a>.
-              </p>
-              <p>
-                The <code>x, y, z</code> parameters represent a <b>front</b>
-                direction vector in 3D space, with the default value being
-                (0,0,-1).
-              </p>
-              <p>
-                The <code>xUp, yUp, zUp</code> parameters represent an
-                <b>up</b> direction vector in 3D space, with the default value
-                being (0,1,0).
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    x
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    y
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    z
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    xUp
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    yUp
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    zUp
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>setPosition</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                This method is DEPRECATED. It is equivalent to setting
-                <a>positionX</a>.<a data-link-for="AudioParam">value</a>,
-                <a>positionY</a>.<a data-link-for="AudioParam">value</a>, and
-                <a>positionZ</a>.<a data-link-for="AudioParam">value</a>
-                directly with the given <code>x</code>, <code>y</code>, and
-                <code>z</code> values, respectively.
-              </p>
-              <p>
-                Consequently, any of the <a>positionX</a>, <a>positionY</a>,
-                and <a>positionZ</a> <a>AudioParam</a>s for this
-                <a>AudioListenerNode</a> have an automation curve set using
-                <a data-link-for=
-                "AudioParam">setValueCurveAtTime</a><code>()</code> at the time
-                this method is called, a <code>NotSupportedError</code> MUST be
-                thrown.
-              </p>
-              <p>
-                Sets the position of the listener in a 3D cartesian coordinate
-                space. <a><code>PannerNode</code></a> objects use this position
-                relative to individual audio sources for spatialization.
-              </p>
-              <p>
-                The <code>x, y, z</code> parameters represent the coordinates
-                in 3D space.
-              </p>
-              <p>
-                The default value is (0,0,0)
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    x
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    y
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    z
-                  </td>
-                  <td class="prmType">
-                    <a><code>float</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The StereoPannerNode Interface
-        </h2>
-        <p>
-          This interface represents a processing node which positions an
-          incoming audio stream in a stereo image using a low-cost <a href=
-          "#Spatialzation-equal-power-panning">equal-power panning
-          algorithm</a>. This panning effect is common in positioning audio
-          components in a stereo stream.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td>
-                Has <a>channelCount constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">clamped-max</a>"
-              </td>
-              <td>
-                Has <a>channelCountMode constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The input of this node is stereo (2 channels) and cannot be
-          increased. Connections from nodes with fewer or more channels will be
-          <a href="#channel-up-mixing-and-down-mixing">up-mixed or down-mixed
-          appropriately</a>.
-        </p>
-        <p>
-          The output of this node is hard-coded to stereo (2 channels) and
-          cannot be configured.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional StereoPannerOptions options)]
-interface StereoPannerNode : AudioNode {
-    readonly        attribute AudioParam pan;
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="StereoPannerNode" data-link-for=
-          "StereoPannerNode">
-            <dt>
-              <code><dfn>StereoPannerNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>StereoStereoPannerNode</a>
-                object. <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>, and return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>StereoPannerNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>StereoPannerOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>StereoPannerNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="StereoPannerNode" data-link-for=
-          "StereoPannerNode">
-            <dt>
-              <code><dfn>pan</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The position of the input in the output's stereo image. -1
-                represents full left, +1 represents full right.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      -1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>StereoPannerOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options to use in constructing a
-            <a><code>StereoPannerNode</code></a>. All members are optional; if
-            not specified, the normal default is used in constructing the node.
-          </p>
-          <pre class="idl">
-dictionary StereoPannerOptions : AudioNodeOptions {
-             float pan = 0;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>StereoPannerOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="StereoPannerOptions"
-            data-link-for="StereoPannerOptions">
-              <dt>
-                <code><dfn>pan</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 0
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "StereoPannerNode"><code>pan</code></a> AudioParam.
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section class="informative">
-          <h3>
-            Channel Limitations
-          </h3>
-          <p>
-            Because its processing is constrained by the above definitions,
-            <a><code>StereoPannerNode</code></a> is limited to mixing no more
-            than 2 channels of audio, and producing exactly 2 channels. It is
-            possible to use a <a><code>ChannelSplitterNode</code></a>,
-            intermediate processing by a subgraph of
-            <a><code>GainNode</code></a>s and/or other nodes, and recombination
-            via a <a><code>ChannelMergerNode</code></a> to realize arbitrary
-            approaches to panning and mixing.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2 id="ConvolverNode">
-          The ConvolverNode Interface
-        </h2>
-        <p>
-          This interface represents a processing node which applies a linear
-          convolution effect given an impulse response.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td>
-                Has <a>channelCount constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">clamped-max</a>"
-              </td>
-              <td>
-                Has <a>channelCountMode constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                Yes
-              </td>
-              <td>
-                Continues to output non-silent audio with zero input for the
-                length of the <a data-link-for="ConvolverNode">buffer</a>.
-              </td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The input of this node is either mono (1 channel) or stereo (2
-          channels) and cannot be increased. Connections from nodes with more
-          channels will be <a href=
-          "#channel-up-mixing-and-down-mixing">down-mixed appropriately</a>.
-        </p>
-        <p>
-          There are <a>channelCount constraints</a> and <a>channelCountMode
-          constraints</a> for this node. These constraints ensure that the
-          input to the node is either mono or stereo.
-        </p>
-        <p>
-          <a>ConvolverNode</a>s are created with an internal flag <code>buffer
-          set</code>, initially set to false.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ConvolverOptions options)]
-interface ConvolverNode : AudioNode {
-                    attribute AudioBuffer? buffer;
-                    attribute boolean      normalize;
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="ConvolverNode" data-link-for=
-          "ConvolverNode">
-            <dt>
-              <code><dfn>ConvolverNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>ConvolverNode</a> object.
-                <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>. Set an internal boolean slot <var>[[buffer
-                set]]</var>, and initialize it to <code>false</code>. Return
-                <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>ConvolverNode</a>
-                    will be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>ConvolverOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>ConvolverNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="ConvolverNode" data-link-for=
-          "ConvolverNode">
-            <dt>
-              <code><dfn>buffer</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioBuffer</code></a></span>, nullable
-            </dt>
-            <dd>
-              <p>
-                A mono, stereo, or 4-channel <a><code>AudioBuffer</code></a>
-                containing the (possibly multi-channel) impulse response used
-                by the <a><code>ConvolverNode</code></a>. <span class=
-                "synchronous">The <code>AudioBuffer</code> MUST have 1, 2, or 4
-                channels or a <code>NotSupportedError</code> exception MUST be
-                thrown</span>. <span class="synchronous">This
-                <a><code>AudioBuffer</code></a> MUST be of the same sample-rate
-                as the <a><code>AudioContext</code></a> or a
-                <code>NotSupportedError</code> exception MUST be thrown</span>.
-                At the time when this attribute is set, the <em>buffer</em> and
-                the state of the <em>normalize</em> attribute will be used to
-                configure the <a><code>ConvolverNode</code></a> with this
-                impulse response having the given normalization. The initial
-                value of this attribute is null.
-              </p>
-              <p>
-                To set the <code>buffer</code> attribute, execute these steps:
-              </p>
-              <ol>
-                <li>Let <code>new buffer</code> be the <a>AudioBuffer</a> to be
-                assigned to <code>buffer</code>.
-                </li>
-                <li>If <code>new buffer</code> is not <code>null</code> and
-                <var>[[buffer set]]</var> is true, <span class=
-                "synchronous">throw an <code>InvalidStateError</code> and abort
-                these steps</span>.
-                </li>
-                <li>If <code>new buffer</code> is not <code>null</code>, set
-                <var>[[buffer set]]</var> to true.
-                </li>
-                <li>Assign <code>new buffer</code> to the <code>buffer</code>
-                attribute.
-                </li>
-              </ol>
-              <p class="norm">
-                <em>The following text is non-normative. For normative
-                information please see the <a href=
-                "#Convolution-channel-configurations">channel configuration
-                diagrams</a>.</em>
-              </p>
-              <p>
-                The <a>ConvolverNode</a> only produces a mono output in the
-                single case where there is a single input channel and a
-                single-channel <code>buffer</code>. In all other cases, the
-                output is stereo. In particular, when the <code>buffer</code>
-                has four channels and there are two input channels, the
-                <a>ConvolverNode</a> performs matrix "true" stereo convolution.
-              </p>
-            </dd>
-            <dt>
-              <code><dfn>normalize</dfn></code> of type <span class=
-              "idlAttrType"><a><code>boolean</code></a></span>
-            </dt>
-            <dd>
-              <p>
-                Controls whether the impulse response from the buffer will be
-                scaled by an equal-power normalization when the
-                <code>buffer</code> atttribute is set. Its default value is
-                <code>true</code> in order to achieve a more uniform output
-                level from the convolver when loaded with diverse impulse
-                responses. If <code>normalize</code> is set to
-                <code>false</code>, then the convolution will be rendered with
-                no pre-processing/scaling of the impulse response. Changes to
-                this value do not take effect until the next time the
-                <em>buffer</em> attribute is set.
-              </p>
-              <p>
-                If the <em>normalize</em> attribute is false when the
-                <em>buffer</em> attribute is set then the
-                <a><code>ConvolverNode</code></a> will perform a linear
-                convolution given the exact impulse response contained within
-                the <em>buffer</em>.
-              </p>
-              <p>
-                Otherwise, if the <em>normalize</em> attribute is true when the
-                <em>buffer</em> attribute is set then the
-                <a><code>ConvolverNode</code></a> will first perform a scaled
-                RMS-power analysis of the audio data contained within
-                <em>buffer</em> to calculate a <em>normalizationScale</em>
-                given this algorithm:
-              </p>
-              <pre>
-
-function calculateNormalizationScale(buffer)
-{
-    var GainCalibration = 0.00125;
-    var GainCalibrationSampleRate = 44100;
-    var MinPower = 0.000125;
-
-    // Normalize by RMS power.
-    var numberOfChannels = buffer.numberOfChannels;
-    var length = buffer.length;
-
-    var power = 0;
-
-    for (var i = 0; i &lt; numberOfChannels; i++) {
-        var channelPower = 0;
-        var channelData = buffer.getChannelData(i);
-
-        for (var j = 0; j &lt; length; j++) {
-            var sample = channelData[j];
-            channelPower += sample * sample;
-        }
-
-        power += channelPower;
-    }
-
-    power = Math.sqrt(power / (numberOfChannels * length));
-
-    // Protect against accidental overload.
-    if (!isFinite(power) || isNaN(power) || power &lt; MinPower)
-        power = MinPower;
-
-    var scale = 1 / power;
-
-    // Calibrate to make perceived volume same as unprocessed.
-    scale *= GainCalibration;
-
-    // Scale depends on sample-rate.
-    if (buffer.sampleRate)
-        scale *= GainCalibrationSampleRate / buffer.sampleRate;
-
-    // True-stereo compensation.
-    if (numberOfChannels == 4)
-        scale *= 0.5;
-
-    return scale;
-}
-
-</pre>
-              <p>
-                During processing, the ConvolverNode will then take this
-                calculated <em>normalizationScale</em> value and multiply it by
-                the result of the linear convolution resulting from processing
-                the input with the impulse response (represented by the
-                <em>buffer</em>) to produce the final output. Or any
-                mathematically equivalent operation may be used, such as
-                pre-multiplying the input by <em>normalizationScale</em>, or
-                pre-multiplying a version of the impulse-response by
-                <em>normalizationScale</em>.
-              </p>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>ConvolverOptions</dfn>
-          </h2>
-          <p>
-            The specifies options for constructing a
-            <a><code>ConvolverNode</code></a>. All members are optional; if not
-            specified, the node is contructing using the normal defaults.
-          </p>
-          <pre class="idl">
-dictionary ConvolverOptions : AudioNodeOptions {
-             AudioBuffer? buffer;
-             boolean      disableNormalization = false;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>ConvolverOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="ConvolverOptions"
-            data-link-for="ConvolverOptions">
-              <dt>
-                <code><dfn>buffer</dfn></code> of type <span class=
-                "idlAttrType"><code>AudioBuffer</code></span>, nullable
-              </dt>
-              <dd>
-                The desired buffer for the <a><code>ConvolverNode</code></a>.
-                This buffer will be normalized according to the value of
-                <code>disableNormalization</code>.
-              </dd>
-              <dt>
-                <code><dfn>disableNormalization</dfn></code> of type
-                <span class="idlAttrType"><code>boolean</code></span>,
-                defaulting to false
-              </dt>
-              <dd>
-                The opposite of the desired initial value for the
-                <a data-link-for="ConvolverNode"><code>normalize</code></a>
-                attribute of the <a><code>ConvolverNode</code></a>.
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h3 id="Convolution-channel-configurations">
-            Channel Configurations for Input, Impulse Response and Output
-          </h3>
-          <p>
-            Implementations MUST support the following allowable configurations
-            of impulse response channels in a <a><code>ConvolverNode</code></a>
-            to achieve various reverb effects with 1 or 2 channels of input.
-          </p>
-          <p>
-            The first image in the diagram illustrates the general case, where
-            the source has N input channels, the impulse response has K
-            channels, and the playback system has M output channels. Because
-            <a><code>ConvolverNode</code></a> is limited to 1 or 2 channels of
-            input, not every case can be handled.
-          </p>
-          <p>
-            Single channel convolution operates on a mono audio input, using a
-            mono impulse response, and generating a mono output. The remaining
-            images in the diagram illustrate the supported cases for mono and
-            stereo playback where N and M are 1 or 2 and K is 1, 2, or 4.
-            Developers desiring more complex and arbitrary matrixing can use a
-            <a><code>ChannelSplitterNode</code></a>, multiple single-channel
-            <a><code>ConvolverNode</code></a>s and a
-            <a><code>ChannelMergerNode</code></a>.
-          </p>
-          <figure id="convolver-diagram">
-            <img alt="reverb matrixing" src="images/convolver-diagram.png">
-            <figcaption>
-              A graphical representation of supported input and output channel
-              count possibilities when using a
-              <a><code>ConvolverNode</code></a>.
-            </figcaption>
-          </figure>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The AnalyserNode Interface
-        </h2>
-        <p>
-          This interface represents a node which is able to provide real-time
-          frequency and time-domain analysis information. The audio stream will
-          be passed un-processed from input to output.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td>
-                This output may be left unconnected.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">max</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional AnalyserOptions options)]
-interface AnalyserNode : AudioNode {
-    void getFloatFrequencyData (Float32Array array);
-    void getByteFrequencyData (Uint8Array array);
-    void getFloatTimeDomainData (Float32Array array);
-    void getByteTimeDomainData (Uint8Array array);
-                    attribute unsigned long fftSize;
-    readonly        attribute unsigned long frequencyBinCount;
-                    attribute double        minDecibels;
-                    attribute double        maxDecibels;
-                    attribute double        smoothingTimeConstant;
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="AnalyserNode" data-link-for=
-          "AnalyserNode">
-            <dt>
-              <code><dfn>AnalyserNode</dfn></code>
-            </dt>
-            <dd>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>AnalyserNode</a>
-                    will be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>AnalyserOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>AnalyserNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="AnalyserNode" data-link-for=
-          "AnalyserNode">
-            <dt>
-              <code><dfn>fftSize</dfn></code> of type <span class=
-              "idlAttrType"><a><code>unsigned long</code></a></span>
-            </dt>
-            <dd>
-              <p>
-                The size of the FFT used for frequency-domain analysis.
-                <span class="synchronous">This MUST be a power of two in the
-                range 32 to 32768, otherwise an <code>IndexSizeError</code>
-                exception MUST be thrown</span>. The default value is 2048.
-                Note that large FFT sizes can be costly to compute.
-              </p>
-              <p>
-                If the <code>fftSize</code> is changed to a different value,
-                then all state associated with smoothing of the frequency data
-                (for <a data-link-for=
-                "AnalyserNode"><code>getByteFrequencyData</code></a> and
-                <a data-link-for=
-                "AnalyserNode"><code>getFloatFrequencyData</code></a>) is
-                reset. That is the <a>previous block</a>, \(\hat{X}_{-1}[k]\),
-                used for <a href="#smoothing-over-time">smoothing over time</a>
-                is set to 0 for all \(k\).
-              </p>
-            </dd>
-            <dt>
-              <code><dfn>frequencyBinCount</dfn></code> of type <span class=
-              "idlAttrType"><a><code>unsigned long</code></a></span>, readonly
-            </dt>
-            <dd>
-              Half the FFT size.
-            </dd>
-            <dt>
-              <code><dfn>maxDecibels</dfn></code> of type <span class=
-              "idlAttrType"><a><code>double</code></a></span>
-            </dt>
-            <dd>
-              <a>maxDecibels</a> is the maximum power value in the scaling
-              range for the FFT analysis data for conversion to unsigned byte
-              values. The default value is -30. <span class="synchronous">If
-              the value of this attribute is set to a value less than or equal
-              to <code><a>minDecibels</a></code>, an
-              <code>IndexSizeError</code> exception MUST be thrown.</span>
-            </dd>
-            <dt>
-              <code><dfn>minDecibels</dfn></code> of type <span class=
-              "idlAttrType"><a><code>double</code></a></span>
-            </dt>
-            <dd>
-              <a>minDecibels</a> is the minimum power value in the scaling
-              range for the FFT analysis data for conversion to unsigned byte
-              values. The default value is -100. <span class="synchronous">If
-              the value of this attribute is set to a value more than or equal
-              to <code><a>maxDecibels</a></code>, an
-              <code>IndexSizeError</code> exception MUST be thrown.</span>
-            </dd>
-            <dt>
-              <code><dfn>smoothingTimeConstant</dfn></code> of type
-              <span class="idlAttrType"><a><code>double</code></a></span>
-            </dt>
-            <dd>
-              A value from 0 -&gt; 1 where 0 represents no time averaging with
-              the last analysis frame. The default value is 0.8. <span class=
-              "synchronous">If the value of this attribute is set to a value
-              less than 0 or more than 1, an <code>IndexSizeError</code>
-              exception MUST be thrown.</span>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Methods
-          </h3>
-          <dl class="methods" data-dfn-for="AnalyserNode" data-link-for=
-          "AnalyserNode">
-            <dt>
-              <code><dfn>getByteFrequencyData</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Copies the <a>current frequency data</a> into the passed
-                unsigned byte array. If the array has fewer elements than the
-                <a><code>frequencyBinCount</code></a>, the excess elements will
-                be dropped. If the array has more elements than the
-                <a><code>frequencyBinCount</code></a>, the excess elements will
-                be ignored. The most recent <a data-link-for=
-                "AnalyserNode"><code>fftSize</code></a> frames are used in
-                computing the frequency data.
-              </p>
-              <p>
-                If another call to <code>getByteFreqencyData</code> or
-                <code>getFloatFrequencyData</code> occurs within the same
-                <a>render quantum</a> as a previous call, the <a>current
-                frequency data</a> is not updated with the same data. Instead,
-                the previously computed data is returned.
-              </p>
-              <p>
-                The values stored in the unsigned byte array are computed in
-                the following way. Let \(Y[k]\) be the <a>current frequency
-                data</a> as described in <a href=
-                "#fft-windowing-and-smoothing-over-time">FFT windowing and
-                smoothing</a>. Then the byte value, \(b[k]\), is
-              </p>
-              <pre class="nohighlight">
-                  $$
-                    b[k] = \left\lfloor
-                        \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
-                        \left(Y[k] - \mbox{dB}_{min}\right)
-                      \right\rfloor
-                  $$
-</pre>
-              <p>
-                where \(\mbox{dB}_{min}\) is <code><a>minDecibels</a></code>
-                and \(\mbox{dB}_{max}\) is <code><a>maxDecibels</a></code>. If
-                \(b[k]\) lies outside the range of 0 to 255, \(b[k]\) is
-                clipped to lie in that range.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    array
-                  </td>
-                  <td class="prmType">
-                    <a><code>Uint8Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter is where the frequency-domain analysis data
-                    will be copied.
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>getByteTimeDomainData</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Copies the <a>current time-domain data</a> (waveform data) into
-                the passed unsigned byte array. If the array has fewer elements
-                than the value of <a data-link-for=
-                "AnalyserNode"><code>fftSize</code></a>, the excess elements
-                will be dropped. If the array has more elements than
-                <a data-link-for="AnalyserNode"><code>fftSize</code></a>, the
-                excess elements will be ignored. The most recent
-                <a data-link-for="AnalyserNode"><code>fftSize</code></a> frames
-                are used in computing the byte data.
-              </p>
-              <p>
-                The values stored in the unsigned byte array are computed in
-                the following way. Let \(x[k]\) be the time-domain data. Then
-                the byte value, \(b[k]\), is
-              </p>
-              <pre class="nohighlight">
-              $$
-                b[k] = \left\lfloor 128(1 + x[k]) \right\rfloor.
-              $$
-</pre>
-              <p>
-                If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is
-                clipped to lie in that range.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    array
-                  </td>
-                  <td class="prmType">
-                    <a><code>Uint8Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter is where the time-domain sample data will be
-                    copied.
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>getFloatFrequencyData</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Copies the <a>current frequency data</a> into the passed
-                floating-point array. If the array has fewer elements than the
-                <a><code>frequencyBinCount</code></a>, the excess elements will
-                be dropped. If the array has more elements than the
-                <a><code>frequencyBinCount</code></a>, the excess elements will
-                be ignored. The most recent <a data-link-for=
-                "AnalyserNode"><code>fftSize</code></a> frames are used in
-                computing the frequency data.
-              </p>
-              <p>
-                If another call to <code>getFloatFrequencyData</code> or
-                <code>getByteFrequencyData</code> occurs within the same
-                <a>render quantum</a> as a previous call, the <a>current
-                frequency data</a> is not updated with the same data. Instead,
-                the previously computed data is returned.
-              </p>
-              <p>
-                The frequency data are in dB units.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    array
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter is where the frequency-domain analysis data
-                    will be copied.
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>getFloatTimeDomainData</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Copies the <a>current time-domain data</a> (waveform data) into
-                the passed floating-point array. If the array has fewer
-                elements than the value of <a data-link-for=
-                "AnalyserNode"><code>fftSize</code></a>, the excess elements
-                will be dropped. If the array has more elements than
-                <a data-link-for="AnalyserNode"><code>fftSize</code></a>, the
-                excess elements will be ignored. The most recent
-                <a data-link-for="AnalyserNode"><code>fftSize</code></a> frames
-                are returned (after downmixing).
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    array
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter is where the time-domain sample data will be
-                    copied.
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>AnalyserOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options to be used when constructing an
-            <a><code>AnalyserNode</code></a>. All members are optional; if not
-            specified, the normal default values are used to construct the
-            node.
-          </p>
-          <pre class="idl">
-dictionary AnalyserOptions : AudioNodeOptions {
-             unsigned long fftSize = 2048;
-             double        maxDecibels = -30;
-             double        minDecibels = -100;
-             double        smoothingTimeConstant = 0.8;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>AnalyserOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="AnalyserOptions"
-            data-link-for="AnalyserOptions">
-              <dt>
-                <code><dfn>fftSize</dfn></code> of type <span class=
-                "idlAttrType"><code>unsigned long</code></span>, defaulting to
-                2048
-              </dt>
-              <dd>
-                The desired initial size of the FFT for frequency-domain
-                analysis.
-              </dd>
-              <dt>
-                <code><dfn>maxDecibels</dfn></code> of type <span class=
-                "idlAttrType"><code>double</code></span>, defaulting to -30
-              </dt>
-              <dd>
-                The desired initial maximum power in dB for FFT analysis.
-              </dd>
-              <dt>
-                <code><dfn>minDecibels</dfn></code> of type <span class=
-                "idlAttrType"><code>double</code></span>, defaulting to -100
-              </dt>
-              <dd>
-                The desired initial minimum power in dB for FFT analysis.
-              </dd>
-              <dt>
-                <code><dfn>smoothingTimeConstant</dfn></code> of type
-                <span class="idlAttrType"><code>unsigned long</code></span>,
-                defaulting to 0.8
-              </dt>
-              <dd>
-                The desired initial smoothing constant for the FFT analysis.
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h3>
-            Time-Domain Down-Mixing
-          </h3>
-          <p>
-            When the <dfn>current time-domain data</dfn> are computed, the
-            input signal must be <a href=
-            "#channel-up-mixing-and-down-mixing">down-mixed</a> to mono as if
-            <a data-link-for="AudioNode">channelCount</a> is 1,
-            <a data-link-for="AudioNode">channelCountMode</a> is
-            "<a data-link-for="ChannelCountMode">max</a>" and <a data-link-for=
-            "AudioNode">channelInterpretation</a> is "<a data-link-for=
-            "ChannelInterpretation">speakers</a>". This is independent of the
-            settings for the <a>AnalyserNode</a> itself. The most recent
-            <a data-link-for="AnalyserNode">fftSize</a> frames are used for the
-            down-mixing operation.
-          </p>
-        </section>
-        <section data-link-for="AnalyserNode">
-          <h3>
-            FFT Windowing and smoothing over time
-          </h3>When the <dfn id="current-frequency-data">current frequency
-          data</dfn> are computed, the following operations are to be
-          performed:
-          <ol>
-            <li>Compute the <a>current time-domain data</a>.
-            </li>
-            <li>
-              <a href="#blackman-window">Apply a Blackman window</a> to the
-              time domain input data.
-            </li>
-            <li>
-              <a href="#fourier-transform">Apply a Fourier transform</a> to the
-              windowed time domain input data to get imaginary and real
-              frequency data.
-            </li>
-            <li>
-              <a href="#smoothing-over-time">Smooth over time</a> the frequency
-              domain data.
-            </li>
-            <li>
-              <a href="#conversion-to-db">Conversion to dB</a>.
-            </li>
-          </ol>
-          <p>
-            In the following, let \(N\) be the value of the
-            <code>.fftSize</code> attribute of this <code>AnalyserNode</code>.
-          </p>
-          <p>
-            <dfn id="blackman-window">Applying a Blackman window</dfn> consists
-            in the following operation on the input time domain data. Let
-            \(x[n]\) for \(n = 0, \ldots, N - 1\) be the time domain data. The
-            Blackman window is defined by
-          </p>
-          <pre class="nohighlight">
-          $$
-          \begin{align*}
-            \alpha &amp;= \mbox{0.16} \\ a_0 &amp;= \frac{1-\alpha}{2} \\
-             a_1   &amp;= \frac{1}{2} \\
-             a_2   &amp;= \frac{\alpha}{2} \\
-             w[n] &amp;= a_0 - a_1 \cos\frac{2\pi n}{N} + a_2 \cos\frac{4\pi n}{N}, \mbox{ for } n = 0, \ldots, N - 1
-           \end{align*}
-           $$
-
-</pre>
-          <p>
-            The windowed signal \(\hat{x}[n]\) is
-          </p>
-          <pre class="nohighlight">
-            $$
-              \hat{x}[n] = x[n] w[n], \mbox{ for } n = 0, \ldots, N - 1
-            $$
-
-</pre>
-          <p>
-            <dfn id="fourier-transform">Applying a Fourier transform</dfn>
-            consists of computing the Fourier transform in the following way.
-            Let \(X[k]\) be the complex frequency domain data and
-            \(\hat{x}[n]\) be the windowed time domain data computed above.
-            Then
-          </p>
-          <pre class="nohighlight">
-            $$
-              X[k] = \frac{1}{N} \sum_{n = 0}^{N - 1} \hat{x}[n]\, e^{\frac{-2\pi i k n}{N}}
-            $$
-</pre>
-          <p>
-            for \(k = 0, \dots, N/2-1\).
-          </p>
-          <p>
-            <dfn id="smoothing-over-time">Smoothing over time</dfn> frequency
-            data consists in the following operation:
-          </p>
-          <ul>
-            <li>Let \(\hat{X}_{-1}[k]\) be the result of this operation on the
-            <a>previous block</a>. The <dfn>previous block</dfn> is defined as
-            being the buffer computed by the previous <a href=
-            "#smoothing-over-time">smoothing over time</a> operation, or an
-            array of \(N\) zeros if this is the first time we are <a href=
-            "#smoothing-over-time">smoothing over time</a>.
-            </li>
-            <li>Let \(\tau\) be the value of the <a data-link-for=
-            "AnalyserNode"><code>smoothingTimeConstant</code></a> attribute for
-            this <a><code>AnalyserNode</code></a>.
-            </li>
-            <li>Let \(X[k]\) be the result of <a href=
-            "#fourier-transform">applying a Fourier transform</a> of the
-            current block.
-            </li>
-          </ul>
-          <p>
-            Then the smoothed value, \(\hat{X}[k]\), is computed by
-          </p>
-          <pre class="nohighlight">
-            $$
-              \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, |X[k]|
-            $$
-
-</pre>
-          <p>
-            for \(k = 0, \ldots, N - 1\).
-          </p>
-          <p>
-            <dfn id="conversion-to-db">Conversion to dB</dfn> consists of the
-            following operation, where \(\hat{X}[k]\) is computed in <a href=
-            "#smoothing-over-time">smoothing over time</a>:
-          </p>
-          <pre class="nohighlight">
-          $$
-            Y[k] = 20\log_{10}\hat{X}[k]
-          $$
-
-</pre>
-          <p>
-            for \(k = 0, \ldots, N-1\).
-          </p>
-          <p>
-            This array, \(Y[k]\), is copied to the output array for
-            <code>getFloatFrequencyData</code>. For
-            <code>getByteFrequencyData</code>, the \(Y[k]\) is clipped to lie
-            between <code><a>minDecibels</a></code> and
-            <code><a>maxDecibels</a></code> and then scaled to fit in an
-            unsigned byte such that <code><a>minDecibels</a></code> is
-            represented by the value 0 and <code><a>maxDecibels</a></code> is
-            represented by the value 255.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The ChannelSplitterNode Interface
-        </h2>
-        <p>
-          The <code>ChannelSplitterNode</code> is for use in more advanced
-          applications and would often be used in conjunction with
-          <a><code>ChannelMergerNode</code></a>.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td></td>
-              <td>
-                This defaults to 6, but is otherwise determined from
-                <a>ChannelSplitterOptions</a>.<a data-link-for=
-                "ChannelSplitterOptions">numberOfOutputs</a> or the value
-                specified by <a data-link-for=
-                "BaseAudioContext">createChannelSplitter</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                Has <a>channelCount constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">explicit</a>"
-              </td>
-              <td>
-                Has <a>channelCountMode constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">discrete</a>"
-              </td>
-              <td>
-                Has <a>channelInterpretation constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          This interface represents an <a><code>AudioNode</code></a> for
-          accessing the individual channels of an audio stream in the routing
-          graph. It has a single input, and a number of "active" outputs which
-          equals the number of channels in the input audio stream. For example,
-          if a stereo input is connected to an
-          <a><code>ChannelSplitterNode</code></a> then the number of active
-          outputs will be two (one from the left channel and one from the
-          right). There are always a total number of N outputs (determined by
-          the <code>numberOfOutputs</code> parameter to the
-          <a><code>AudioContext</code></a> method <a data-link-for=
-          "BaseAudioContext"><code>createChannelSplitter()</code></a>), The
-          default number is 6 if this value is not provided. Any outputs which
-          are not "active" will output silence and would typically not be
-          connected to anything.
-        </p>
-        <h3>
-          Example:
-        </h3>
-        <figure>
-          <img alt="channel splitter" src="images/channel-splitter.png" width=
-          "601" height="398">
-          <figcaption>
-            A diagram of a ChannelSplitter
-          </figcaption>
-        </figure>
-        <p>
-          Please note that in this example, the splitter does <b>not</b>
-          interpret the channel identities (such as left, right, etc.), but
-          simply splits out channels in the order that they are input.
-        </p>
-        <p>
-          One application for <code>ChannelSplitterNode</code> is for doing
-          "matrix mixing" where individual gain control of each channel is
-          desired.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelSplitterNode options)]
-interface ChannelSplitterNode : AudioNode {
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="ChannelSplitterNode" data-link-for=
-          "ChannelSplitterNode">
-            <dt>
-              <code><dfn>ChannelSplitterNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>ChannelSplitterNode</a> object.
-                <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>, and return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>ChannelSplitter</a>
-                    will be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>ChannelSplitterOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>ChannelSplitterNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>ChannelSplitterOptions</dfn>
-          </h2>
-          <pre class="idl">
-dictionary ChannelSplitterOptions : AudioNodeOptions {
-             unsigned long numberOfOutputs = 6;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>ChannelSplitterOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="ChannelSplitterOptions"
-            data-link-for="ChannelSplitterOptions">
-              <dt>
-                <code><dfn>numberOfOutputs</dfn></code> of type <span class=
-                "idlAttrType"><code>unsigned long</code></span>, defaulting to
-                6
-              </dt>
-              <dd>
-                The number outputs for the
-                <a><code>ChannelSplitterNode</code></a>.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The ChannelMergerNode Interface
-        </h2>
-        <p>
-          The <a><code>ChannelMergerNode</code></a> is for use in more advanced
-          applications and would often be used in conjunction with
-          <a><code>ChannelSplitterNode</code></a>.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td></td>
-              <td>
-                Defaults to 6, but is determined by
-                <a>ChannelMergerOptions</a>,<a data-link-for=
-                "ChannelMergerOptions">numberOfInputs</a> or the value
-                specified by <a data-link-for=
-                "BaseAudioContext">createChannelMerger</a>.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td>
-                Has <a>channelCount constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">max</a>"
-              </td>
-              <td>
-                Has <a>channelCountMode constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          This interface represents an <a><code>AudioNode</code></a> for
-          combining channels from multiple audio streams into a single audio
-          stream. It has a variable number of inputs (defaulting to 6), but not
-          all of them need be connected. There is a single output whose audio
-          stream has a number of channels equal to the number of inputs.
-        </p>
-        <p>
-          To merge multiple inputs into one stream, each input gets downmixed
-          into one channel (mono) based on the specified mixing rule. An
-          unconnected input still counts as <b>one silent channel</b> in the
-          output. Changing input streams does <b>not</b> affect the order of
-          output channels.
-        </p>
-        <h3 id="example-2">
-          Example:
-        </h3>
-        <p>
-          For example, if a default <a><code>ChannelMergerNode</code></a> has
-          two connected stereo inputs, the first and second input will be
-          downmixed to mono respectively before merging. The output will be a
-          6-channel stream whose first two channels are be filled with the
-          first two (downmixed) inputs and the rest of channels will be silent.
-        </p>
-        <p>
-          Also the <a><code>ChannelMergerNode</code></a> can be used to arrange
-          multiple audio streams in a certain order for the multi-channel
-          speaker array such as 5.1 surround set up. The merger does not
-          interpret the channel identities (such as left, right, etc.), but
-          simply combines channels in the order that they are input.
-        </p>
-        <figure>
-          <img alt="channel merger" src="images/channel-merger.svg">
-          <figcaption>
-            A diagram of ChannelMerger
-          </figcaption>
-        </figure>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelMergerOptions options)]
-interface ChannelMergerNode : AudioNode {
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="ChannelMergerNode" data-link-for=
-          "ChannelMergerNode">
-            <dt>
-              <code><dfn>ChannelMergerNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>ChannelMergerNode</a> object.
-                <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>, and return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>ChannelMergerNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>ChannelMergerOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>ChannelMergerNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>ChannelMergerOptions</dfn>
-          </h2>
-          <pre class="idl">
-dictionary ChannelMergerOptions : AudioNodeOptions {
-             unsigned long numberOfInputs = 6;
-};
-          </pre>
-          <section>
-            <h3>
-              Dictionary <a>ChannelMergerOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="ChannelMergerOptions"
-            data-link-for="ChannelMergerOptions">
-              <dt>
-                <code><dfn>numberOfInputs</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 6
-              </dt>
-              <dd>
-                The number inputs for the
-                <a><code>ChannelSplitterNode</code></a>.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The DynamicsCompressorNode Interface
-        </h2>
-        <p>
-          <a><code>DynamicsCompressorNode</code></a> is an
-          <a><code>AudioNode</code></a> processor implementing a dynamics
-          compression effect.
-        </p>
-        <p>
-          Dynamics compression is very commonly used in musical production and
-          game audio. It lowers the volume of the loudest parts of the signal
-          and raises the volume of the softest parts. Overall, a louder,
-          richer, and fuller sound can be achieved. It is especially important
-          in games and musical applications where large numbers of individual
-          sounds are played simultaneous to control the overall signal level
-          and help avoid clipping (distorting) the audio output to the
-          speakers.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td>
-                Has <a>channelCount constraints</a>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">clamped-max</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                Yes
-              </td>
-              <td>
-                This node has a <a>tail-time</a> reference such that this node
-                continues to output non-silent audio with zero input due to the
-                look-ahead delay.
-              </td>
-            </tr>
-          </table>
-        </div>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional DynamicsCompressorOptions options)]
-interface DynamicsCompressorNode : AudioNode {
-    readonly        attribute AudioParam threshold;
-    readonly        attribute AudioParam knee;
-    readonly        attribute AudioParam ratio;
-    readonly        attribute float      reduction;
-    readonly        attribute AudioParam attack;
-    readonly        attribute AudioParam release;
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="DynamicsCompressorNode"
-          data-link-for="DynamicsCompressorNode">
-            <dt>
-              <code><dfn>DynamicsCompressorNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>DynamicsCompressorNode</a>
-                object. <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>. Let [[internal reduction]] be a private slot
-                on this <a>DynamicsCompressorNode</a>, that holds a floating
-                point number, in decibels. Set [[internal reduction]] to 0.0.
-                Return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>DynamicsCompressorNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>DynamicsCompressorOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>DynamicsCompressorNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="DynamicsCompressorNode"
-          data-link-for="DynamicsCompressorNode">
-            <dt>
-              <code><dfn>attack</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The amount of time (in seconds) to reduce the gain by 10dB.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0.003
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>k-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>knee</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                A decibel value representing the range above the threshold
-                where the curve smoothly transitions to the "ratio" portion.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      30
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      40
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>k-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>ratio</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The amount of dB change in input for a 1 dB change in output.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      12
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      20
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>k-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>reduction</dfn></code> of type <span class=
-              "idlAttrType"><a><code>float</code></a></span>, readonly
-            </dt>
-            <dd>
-              A read-only decibel value for metering purposes, representing the
-              current amount of gain reduction that the compressor is applying
-              to the signal. If fed no signal the value will be 0 (no gain
-              reduction). When this attribute is read, return the value of the
-              private slot [[internal reduction]].
-            </dd>
-            <dt>
-              <code><dfn>release</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The amount of time (in seconds) to increase the gain by 10dB.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0.25
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>k-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>threshold</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The decibel value above which the compression will start taking
-                effect.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      -24
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      -100
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>k-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>DynamicsCompressorOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options to use in constructing a
-            <a><code>DynamicsCompressorNode</code></a>. All members are
-            optional; if not specified the normal defaults are used in
-            constructing the node.
-          </p>
-          <pre class="idl">
-dictionary DynamicsCompressorOptions : AudioNodeOptions {
-             float attack = 0.003;
-             float knee = 30;
-             float ratio = 12;
-             float release = 0.25;
-             float threshold = -24;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>DynamicsCompressorOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="DynamicsCompressorOptions"
-            data-link-for="DynamicsCompressorOptions">
-              <dt>
-                <code><dfn>attack</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 0.003
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "DynamicsCompressorNode"><code>attack</code></a> AudioParam.
-              </dd>
-              <dt>
-                <code><dfn>knee</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 30
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "DynamicsCompressorNode"><code>knee</code></a> AudioParam.
-              </dd>
-              <dt>
-                <code><dfn>ratio</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 12
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "DynamicsCompressorNode"><code>ratio</code></a> AudioParam.
-              </dd>
-              <dt>
-                <code><dfn>release</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 0.25
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "DynamicsCompressorNode"><code>release</code></a> AudioParam.
-              </dd>
-              <dt>
-                <code><dfn>threshold</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to -24
-              </dt>
-              <dd>
-                The initial value for the <a data-link-for=
-                "DynamicsCompressorNode"><code>threshold</code></a> AudioParam.
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h2>
-            Processing
-          </h2>
-          <p>
-            Dynamics compression can be implemented in a variety of ways. The
-            <a>DynamicsCompressorNode</a> implements a dynamics processor that
-            has the following characteristics:
-          </p>
-          <ul>
-            <li>Fixed look-ahead (this means that an
-            <a>DynamicsCompressorNode</a> adds a fixed latency to the signal
-            chain).
-            </li>
-            <li>Configurable attack speed, release speed, threshold, knee
-            hardness and ratio.
-            </li>
-            <li>Side-chaining is not supported.
-            </li>
-            <li>The gain reduction is reported <em>via</em> the
-            <code>reduction</code> property on the
-            <a>DynamicsCompressorNode</a>.
-            </li>
-            <li>The compression curve has three parts:
-              <ul>
-                <li>The first part is the identity: \(f(x) = x\).
-                </li>
-                <li>The second part is the soft-knee portion, which MUST be a
-                monotonically increasing function.
-                </li>
-                <li>The third part is a linear function: \(f(x) =
-                \frac{1}{ratio} \cdot x \).
-                </li>
-              </ul>This curve MUST be continuous and piece-wise differentiable,
-              and corresponds to a target output level, based on the input
-              level.
-            </li>
-          </ul>
-          <p>
-            Graphically, such a curve would look something like this:
-          </p>
-          <figure>
-            <img alt="Graphical representation of a compression curve" src=
-            "images/compression-curve.svg" style="width: 50%">
-            <figcaption>
-              A typical compression curve, showing the knee portion (soft or
-              hard) as well as the threshold.
-            </figcaption>
-          </figure>
-          <p>
-            Internally, the <a>DynamicsCompressorNode</a> is described with a
-            combination of other <a>AudioNode</a>s, as well as a special
-            algorithm, to compute the gain reduction value.
-          </p>
-          <p>
-            The following <a>AudioNode</a> graph is used internally,
-            <code>input</code> and <code>output</code> respectively being the
-            input and output <a>AudioNode</a>, <code>context</code> the
-            <a>BaseAudioContext</a> for this <a>DynamicsCompressorNode</a>, and
-            new class, <code>EnvelopeFollower</code>, that instantiate a
-            special object that behaves like an <a>AudioNode</a>, described
-            below:
-          </p>
-          <pre>
-              var delay = new DelayNode(context, {delayTime: 0.006});
-              var gain = new GainNode(context);
-              var compression = new EnvelopeFollower();
-
-              input.connect(delay).connect(gain).connect(output);
-              input.connect(compression).connect(gain.gain);</pre>
-          <figure>
-            <img src="images/dynamicscompressor-internal-graph.svg" alt=
-            "Schema of
-            the internal graph used by the DynamicCompressorNode">
-            <figcaption>
-              The graph of internal <a>AudioNode</a>s used as part of the
-              <a>DynamicsCompressorNode</a> processing algorithm.
-            </figcaption>
-          </figure>
-          <div class="note">
-            This implements the pre-delay and the application of the reduction
-            gain.
-          </div>
-          <p>
-            The following algorithm describes the processing performed by an
-            <code>EnvelopeFollower</code> object, to be applied to the input
-            signal to produce the gain reduction value. An
-            <code>EnvelopeFollower</code> has two slots holding floating point
-            values. Those values persist accros invocation of this algorithm.
-          </p>
-          <ul>
-            <li>Let <code>[[detector average]]</code> be a floating point
-            number, initialized to 0.0.
-            </li>
-            <li>Let <code>[[compression gain]]</code> be a floating point
-            number, initialized to 1.0.
-            </li>
-          </ul>
-          <p>
-            The following algorithm allow determining a value for
-            <var>reduction gain</var>, for each sample of input, for a render
-            quantum of audio.
-          </p>
-          <ol>
-            <li>Let <var>threshold</var>, <var>knee</var> have the value of the
-            <a>AudioParam</a> of the same name, <a href=
-            "#db-to-linear">converted to linear unit</a> sampled at the time of
-            processing of this block (as <a>k-rate</a> parameters).
-            </li>
-            <li>Let <var>ratio</var> have the value of the <code>ratio</code>
-            <a>AudioParam</a>, sampled at the time of processing of this block
-            (as a <a>k-rate</a> parameter).
-            </li>
-            <li>Let <var>attack</var> and <var>release</var> have the value of
-            the <a>AudioParam</a> of the same name, sampled at the time of
-            processing (those are <a>k-rate</a> parameters), mutiplied by the
-            sample-rate of the <a>BaseAudioContext</a> this
-            <a>DynamicsCompressorNode</a> is <a href=
-            "#associated">associated</a> with.
-            </li>
-            <li>Let <var>detector average</var> be the value of the slot <code>
-              [[detector average]]</code>.
-            </li>
-            <li>Let <var>compressor gain</var> be the value of the slot <code>
-              [[compressor gain]]</code>.
-            </li>
-            <li>For each sample <var>input</var> of the render quantum to be
-            processed, execute the following steps:
-              <ol>
-                <li>Let <var>releasing</var> be <code>true</code> if
-                <var>target gain</var> is greater than <var>compressor
-                gain</var>, <code>false</code> otherwise.
-                </li>
-                <li>If the absolute value of <var>input</var> is less than
-                0.0001, let <var>attenuation</var> be 1.0. Else, let
-                <var>shaped input</var> be the value of applying the <a href=
-                "#compression-curve">compression curve</a> to the absolute
-                value of <var>input</var>. Let <var>attenuation</var> be <var>
-                  shaped input</var> divided by the absolute value of
-                  <var>input</var>.
-                </li>
-                <li>Let <var>detector rate</var> be the result of applying the
-                <a href="#detector-curve">detector curve</a> to
-                <var>attenuation</var>.
-                </li>
-                <li>Substract <var>detector average</var> to
-                <var>attenuation</var>, and multiply the result by
-                <var>detector rate</var>. Add this new result to <var>detector
-                average</var>.
-                </li>
-                <li>Clamp <var>detector average</var> to a maximum of 1.0.
-                </li>
-                <li>Let <var>envelope rate</var> be the result of <a href=
-                "#envelope-rate">computing the envelope rate</a>.
-                </li>
-                <li>If <var>releasing</var> is <code>true</code>, set
-                <var>compressor gain</var> to the multiplication of
-                <var>compressor gain</var> by <var>envelope rate</var>, clamped
-                to a maximum of 1.0.
-                </li>
-                <li>Else, if <var>releasing</var> is <code>false</code>, let
-                <var>gain increment</var> to be <var>detector average</var>
-                minus <var>compressor gain</var>. Multiply <var>gain
-                increment</var> by <var>envelope rate</var>, and add the result
-                to <var>compressor gain</var>.
-                </li>
-                <li>Compute <var>reduction gain</var> to be <var>compressor
-                gain</var> multiplied by the return value of <a>computing the
-                makeup gain</a>.
-                </li>
-                <li>Compute <var>metering gain</var> to be <var>final
-                gain</var>, <a href="#linear-to-decibel">converted to
-                decibel</a>.
-                </li>
-              </ol>
-            </li>
-            <li>Set <code>[[compressor gain]]</code> to <var>compressor
-            gain</var>.
-            </li>
-            <li>Set <code>[[detector average]]</code> to <var>detector
-            average</var>.
-            </li>
-            <li>
-              <a href="#atomic">Atomically</a> set the internal slot [[internal
-              reduction]] to the value of <var>metering gain</var>.
-              <div class="note">
-                This step makes the metering gain update once per block, at the
-                end of the block processing.
-              </div>
-            </li>
-          </ol>
-          <p>
-            The makeup gain is a fixed gain stage that only depends on ratio,
-            knee and threshold parameter of the compressor, and not on the
-            input signal. The intent here is to increase the output level of
-            the compressor so it is comparable to the input level.
-          </p>
-          <p>
-            <dfn>Computing the makeup gain</dfn> means executing the following
-            steps:
-          </p>
-          <ol>
-            <li>Let <var>full range gain</var> be the value returned by
-            applying the <a>compression curve</a> to the value 1.0.
-            </li>
-            <li>Let <var>full range makeup gain</var> the inverse of <var>full
-            range gain</var>.
-            </li>
-            <li>Return the result of taking 0.6 power of <var>full range makeup
-            gain</var>.
-            </li>
-          </ol>
-          <p>
-            <dfn id="#envelope-rate">Computing the envelope rate</dfn> is done
-            by applying a function to the ratio of the <var>compressor
-            gain</var> and the <var>detector average</var>. User-agents are
-            allowed to choose the shape the envelope function. However, this
-            function MUST respect the following constraints:
-          </p>
-          <ul>
-            <li>The envelope rate MUST be the calculated from the ratio of the
-            <var>compressor gain</var> and the <var>detector average</var>.
-              <div class="note">
-                When attacking, this number less than or equal to 1, when
-                releasing, this number is strictly greater than 1.
-              </div>
-            </li>
-            <li>The attack curve MUST be a continuous, monotonically increasing
-            function in the range \([0, 1]\).
-            </li>
-            <li>The release curve MUST be a continuous, monotonically
-            decreasing function that is always greater than 1.
-            </li>
-          </ul>
-          <p>
-            This operation returns the value computed by applying this function
-            to the ratio of <var>compressor gain</var> and <var>detector
-            average</var>.
-          </p>
-          <p>
-            Applying the <dfn id="detector-curve">detector curve</dfn> to the
-            change rate when attacking or releasing allow implementing
-            <em>adaptive release</em>. It is a function that MUST respect the
-            following constraints:
-          </p>
-          <ul>
-            <li>The output of the function MUST be in \([0,1]\).
-            </li>
-            <li>The function MUST be monotonically increasing, continuous.
-            </li>
-          </ul>
-          <div class="note">
-            It is allowed, for example, to have a compressor that performs an
-            <em>adaptive release</em>, that is, releasing faster the harder the
-            compression, or to have curves for attack and release that are not
-            of the same shape.
-          </div>
-          <p>
-            Applying a <dfn>compression curve</dfn> to a value means computing
-            the value of this sample when passed to a function, and returning
-            the computed value. This function MUST respect the following
-            characteristics:
-          </p>
-          <ol>
-            <li>This function is the identity up to the value of the linear
-            <code>threshold</code> (i.e., \(f(x) = x\)).
-            </li>
-            <li>From the <code>threshold</code> up to the <code>threshold +
-            knee</code>, User-Agents can choose the curve shape. The whole
-            function MUST be monotonically increasing and continuous.
-              <div class="note">
-                If the <code>knee</code> is 0, the
-                <a>DynamicsCompressorNode</a> is called a hard-knee compressor.
-              </div>
-            </li>
-            <li>This function is linear, based on the ratio, after the
-            <code>threshold</code> and the soft knee (i.e., \(f(x) =
-            \frac{1}{ratio} \cdot x \)).
-            </li>
-          </ol>
-          <p>
-            Converting a value \(v\) in <dfn id="linear-to-decibel">linear gain
-            unit to decibel means</dfn> executing the following steps:
-          </p>
-          <ol>
-            <li>If <var>v</var> is equal to zero, return -1000.
-            </li>
-            <li>Else, return \( 20 \, \log_{10}{v} \)
-            </li>
-          </ol>
-          <p>
-            Converting a value \(v\) in <dfn id="db-to-linear">decibels to
-            linear gain unit</dfn> means returning \(10^\frac{v}{20}\)
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The BiquadFilterNode Interface
-        </h2>
-        <p>
-          <a><code>BiquadFilterNode</code></a> is an
-          <a><code>AudioNode</code></a> processor implementing very common
-          low-order filters.
-        </p>
-        <p>
-          Low-order filters are the building blocks of basic tone controls
-          (bass, mid, treble), graphic equalizers, and more advanced filters.
-          Multiple <a><code>BiquadFilterNode</code></a> filters can be combined
-          to form more complex filters. The filter parameters such as
-          <a data-link-for="BiquadFilterNode"><code>frequency</code></a> can be
-          changed over time for filter sweeps, etc. Each
-          <a><code>BiquadFilterNode</code></a> can be configured as one of a
-          number of common filter types as shown in the IDL below. The default
-          filter type is <code>"lowpass"</code>.
-        </p>
-        <p>
-          Both <a data-link-for="BiquadFilterNode"><code>frequency</code></a>
-          and <a data-link-for="BiquadFilterNode"><code>detune</code></a> form
-          a <a>compound parameter</a> and are both <a>a-rate</a>. They are used
-          together to determine a <dfn id=
-          "computedFreq-biquad">computedFrequency</dfn> value:
-        </p>
-        <pre class="highlight">
-  computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
-</pre>
-        <p>
-          The <a>nominal range</a> for this <a>compound parameter</a> is [0,
-          <a>Nyquist frequency</a>].
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">max</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                Yes
-              </td>
-              <td>
-                Continues to output non-silent audio with zero input. Since
-                this is an IIR filter, the filter produces non-zero input
-                forever, but in practice, this can be limited after some finite
-                time where the output is sufficiently close to zero. The actual
-                time depends on the filter coefficients.
-              </td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The number of channels of the output always equals the number of
-          channels of the input.
-        </p>
-        <pre class="idl">
-enum BiquadFilterType {
-    "lowpass",
-    "highpass",
-    "bandpass",
-    "lowshelf",
-    "highshelf",
-    "peaking",
-    "notch",
-    "allpass"
-};
-        </pre>
-        <table class="simple" data-dfn-for="BiquadFilterType" data-link-for=
-        "BiquadFilterType">
-          <tr>
-            <th colspan="2">
-              Enumeration description
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <dfn>lowpass</dfn>
-            </td>
-            <td>
-              <p>
-                A <a href=
-                "https://en.wikipedia.org/wiki/Low-pass_filter">lowpass
-                filter</a> allows frequencies below the cutoff frequency to
-                pass through and attenuates frequencies above the cutoff. It
-                implements a standard second-order resonant lowpass filter with
-                12dB/octave rolloff.
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The cutoff frequency
-                  </dd>
-                  <dt>
-                    Q
-                  </dt>
-                  <dd>
-                    Controls how peaked the response will be at the cutoff
-                    frequency. A large value makes the response more peaked.
-                    Please note that for this filter type, this value is not a
-                    traditional Q, but is a resonance value in decibels.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    Not used in this filter type
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>highpass</dfn>
-            </td>
-            <td>
-              <p>
-                A <a href=
-                "https://en.wikipedia.org/wiki/High-pass_filter">highpass
-                filter</a> is the opposite of a lowpass filter. Frequencies
-                above the cutoff frequency are passed through, but frequencies
-                below the cutoff are attenuated. It implements a standard
-                second-order resonant highpass filter with 12dB/octave rolloff.
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The cutoff frequency below which the frequencies are
-                    attenuated
-                  </dd>
-                  <dt>
-                    Q
-                  </dt>
-                  <dd>
-                    Controls how peaked the response will be at the cutoff
-                    frequency. A large value makes the response more peaked.
-                    Please note that for this filter type, this value is not a
-                    traditional Q, but is a resonance value in decibels.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    Not used in this filter type
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>bandpass</dfn>
-            </td>
-            <td>
-              <p>
-                A <a href=
-                "https://en.wikipedia.org/wiki/Band-pass_filter">bandpass
-                filter</a> allows a range of frequencies to pass through and
-                attenuates the frequencies below and above this frequency
-                range. It implements a second-order bandpass filter.
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The center of the frequency band
-                  </dd>
-                  <dt>
-                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                  </dt>
-                  <dd>
-                    Controls the width of the band. The width becomes narrower
-                    as the Q value increases.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    Not used in this filter type
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>lowshelf</dfn>
-            </td>
-            <td>
-              <p>
-                The lowshelf filter allows all frequencies through, but adds a
-                boost (or attenuation) to the lower frequencies. It implements
-                a second-order lowshelf filter.
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The upper limit of the frequences where the boost (or
-                    attenuation) is applied.
-                  </dd>
-                  <dt>
-                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                  </dt>
-                  <dd>
-                    Not used in this filter type.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    The boost, in dB, to be applied. If the value is negative,
-                    the frequencies are attenuated.
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>highshelf</dfn>
-            </td>
-            <td>
-              <p>
-                The highshelf filter is the opposite of the lowshelf filter and
-                allows all frequencies through, but adds a boost to the higher
-                frequencies. It implements a second-order highshelf filter
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The lower limit of the frequences where the boost (or
-                    attenuation) is applied.
-                  </dd>
-                  <dt>
-                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                  </dt>
-                  <dd>
-                    Not used in this filter type.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    The boost, in dB, to be applied. If the value is negative,
-                    the frequencies are attenuated.
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>peaking</dfn>
-            </td>
-            <td>
-              <p>
-                The peaking filter allows all frequencies through, but adds a
-                boost (or attenuation) to a range of frequencies.
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The center frequency of where the boost is applied.
-                  </dd>
-                  <dt>
-                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                  </dt>
-                  <dd>
-                    Controls the width of the band of frequencies that are
-                    boosted. A large value implies a narrow width.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    The boost, in dB, to be applied. If the value is negative,
-                    the frequencies are attenuated.
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>notch</dfn>
-            </td>
-            <td>
-              <p>
-                The notch filter (also known as a <a href=
-                "https://en.wikipedia.org/wiki/Band-stop_filter">band-stop or
-                band-rejection filter</a>) is the opposite of a bandpass
-                filter. It allows all frequencies through, except for a set of
-                frequencies.
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The center frequency of where the notch is applied.
-                  </dd>
-                  <dt>
-                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                  </dt>
-                  <dd>
-                    Controls the width of the band of frequencies that are
-                    attenuated. A large value implies a narrow width.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    Not used in this filter type.
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>allpass</dfn>
-            </td>
-            <td>
-              <p>
-                An <a href=
-                "https://en.wikipedia.org/wiki/All-pass_filter#Digital_Implementation">
-                allpass filter</a> allows all frequencies through, but changes
-                the phase relationship between the various frequencies. It
-                implements a second-order allpass filter
-              </p>
-              <blockquote>
-                <dl>
-                  <dt>
-                    frequency
-                  </dt>
-                  <dd>
-                    The frequency where the center of the phase transition
-                    occurs. Viewed another way, this is the frequency with
-                    maximal <a href=
-                    "https://en.wikipedia.org/wiki/Group_delay">group
-                    delay</a>.
-                  </dd>
-                  <dt>
-                    <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                  </dt>
-                  <dd>
-                    Controls how sharp the phase transition is at the center
-                    frequency. A larger value implies a sharper transition and
-                    a larger group delay.
-                  </dd>
-                  <dt>
-                    gain
-                  </dt>
-                  <dd>
-                    Not used in this filter type.
-                  </dd>
-                </dl>
-              </blockquote>
-            </td>
-          </tr>
-        </table>
-        <p>
-          All attributes of the <a><code>BiquadFilterNode</code></a> are
-          <a>a-rate</a> <a><code>AudioParam</code></a>.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional BiquadFilterOptions options)]
-interface BiquadFilterNode : AudioNode {
-                    attribute BiquadFilterType type;
-    readonly        attribute AudioParam       frequency;
-    readonly        attribute AudioParam       detune;
-    readonly        attribute AudioParam       Q;
-    readonly        attribute AudioParam       gain;
-    void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="BiquadFilterNode" data-link-for=
-          "BiquadFilterNode">
-            <dt>
-              <code><dfn>BiquadFilterNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>BiquadFilterNode</a> object.
-                <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>, and return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>BiquadFilterNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>BiquadFilterOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>BiquadFilterNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="BiquadFilterNode" data-link-for=
-          "BiquadFilterNode">
-            <dt>
-              <code><dfn>Q</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
-                factor of the filter. This is not used for <a data-link-for=
-                "BiquadFilterType">lowshelf</a> or <a data-link-for=
-                "BiquadFilterType">highshelf</a> filters.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      1
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>detune</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                A detune value, in cents, for the frequency. It forms a
-                <a>compound parameter</a> with <code>frequency</code>.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>frequency</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The frequency at which the <a><code>BiquadFilterNode</code></a>
-                will operate, in Hz. It forms a <a>compound parameter</a> with
-                <code>detune</code>.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      350
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>gain</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The gain of the filter. Its value is in dB units. The gain is
-                only used for <a data-link-for="BiquadFilterType">lowshelf</a>,
-                <a data-link-for="BiquadFilterType">highshelf</a>, and
-                <a data-link-for="BiquadFilterType">peaking</a> filters.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>type</dfn></code> of type <span class=
-              "idlAttrType"><a><code>BiquadFilterType</code></a></span>
-            </dt>
-            <dd>
-              The type of this <a><code>BiquadFilterNode</code></a>. Its
-              default value is "lowpass". The exact meaning of the other
-              parameters depend on the value of the <a><code>type</code></a>
-              attribute.
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Methods
-          </h3>
-          <dl class="methods" data-dfn-for="BiquadFilterNode" data-link-for=
-          "BiquadFilterNode">
-            <dt>
-              <code><dfn>getFrequencyResponse</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                <span class="sychronous">Given the current filter parameter
-                settings, synchronously calculates the frequency response for
-                the specified frequencies.</span> The three parameters MUST be
-                <code>Float32Array</code>s of the same length, or an
-                <code>InvalidAccessError</code> MUST be thrown.
-              </p>
-              <p>
-                The frequency response returned MUST be computed with the
-                <a><code>AudioParam</code></a> sampled for the current
-                processing block.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    frequencyHz
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter specifies an array of frequencies at which
-                    the response values will be calculated.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    magResponse
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    <p>
-                      This parameter specifies an output array receiving the
-                      linear magnitude response values.
-                    </p>
-                    <p>
-                      If a value in the <code>frequencyHz</code> parameter is
-                      not within [0; sampleRate/2], where
-                      <code>sampleRate</code> is the value of the
-                      <a data-link-for=
-                      "BaseAudioContext"><code>sampleRate</code></a> property
-                      of the <a>AudioContext</a>, the corresponding value at
-                      the same index of the <code>magResponse</code> array MUST
-                      be <code>NaN</code>.
-                    </p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    phaseResponse
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    <p>
-                      This parameter specifies an output array receiving the
-                      phase response values in radians.
-                    </p>
-                    <p>
-                      If a value in the <code>frequencyHz</code> parameter is
-                      not within [0; sampleRate/2], where
-                      <code>sampleRate</code> is the value of the
-                      <a data-link-for=
-                      "BaseAudioContext"><code>sampleRate</code></a> property
-                      of the <a>AudioContext</a>, the corresponding value at
-                      the same index of the <code>phaseResponse</code> array
-                      MUST be <code>NaN</code>.
-                    </p>
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>BiquadFilterOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options to be used when constructing a
-            <a><code>BiquadFilterNode</code></a>. All members are optional; if
-            not specified, the normal default values are used to construct the
-            node.
-          </p>
-          <pre class="idl">
-dictionary BiquadFilterOptions : AudioNodeOptions {
-             BiquadFilterType type = "lowpass";
-             float            Q = 1;
-             float            detune = 0;
-             float            frequency = 350;
-             float            gain = 0;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>BiquadFilterOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="BiquadFilterOptions"
-            data-link-for="BiquadFilterOptions">
-              <dt>
-                <code><dfn>Q</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 1
-              </dt>
-              <dd>
-                The desired initial value for <a><code>Q</code></a>.
-              </dd>
-              <dt>
-                <code><dfn>detune</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 0
-              </dt>
-              <dd>
-                The desired initial value for <a><code>detune</code></a>.
-              </dd>
-              <dt>
-                <code><dfn>frequency</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 350
-              </dt>
-              <dd>
-                The desired initial value for <a><code>frequency</code></a>.
-              </dd>
-              <dt>
-                <code><dfn>gain</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 0
-              </dt>
-              <dd>
-                The desired initial value for <a><code>gain</code></a>.
-              </dd>
-              <dt>
-                <code><dfn>type</dfn></code> of type <span class=
-                "idlAttrType"><code>BiquadFilterType</code></span>, defaulting
-                to "lowpass"
-              </dt>
-              <dd>
-                The desired initial type of the filter.
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h3>
-            Filters characteristics
-          </h3>
-          <p>
-            There are multiple ways of implementing the type of filters
-            available through the <a><code>BiquadFilterNode</code></a> each
-            having very different characteristics. The formulas in this section
-            describe the filters that a <a>conforming implementation</a> MUST
-            implement, as they determine the characteristics of the different
-            filter types. They are inspired by formulas found in the <a href=
-            "http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt">Audio EQ
-            Cookbook</a>.
-          </p>
-          <p>
-            The transfer function for the filters implemented by the
-            <a><code>BiquadFilterNode</code></a> is:
-          </p>
-          <pre class="nohighlight">
-  $$
-  H(z) = \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} + \frac{b_2}{a_0}z^{-2}}
-              {1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}
-  $$
-
-</pre>
-          <p>
-            The initial filter state is 0.
-          </p>The coefficients in the transfer function above are different for
-          each node type. The following intermediate variable are necessary for
-          their computation, based on the <a>computedValue</a> of the
-          <a><code>AudioParam</code></a>s of the
-          <a><code>BiquadFilterNode</code></a>.
-          <ul>
-            <li>Let \(F_s\) be the value of the <a data-link-for=
-            "BaseAudioContext"><code>sampleRate</code></a> attribute for this
-            <a>AudioContext</a>.
-            </li>
-            <li>Let \(f_0\) be the value of the
-            <a><code>computedFrequency</code></a>.
-            </li>
-            <li>Let \(G\) be the value of the <a data-link-for=
-            "BiquadFilterNode"><code>gain</code></a>
-            <a><code>AudioParam</code></a>.
-            </li>
-            <li>Let \(Q\) be the value of the <a data-link-for=
-            "BiquadFilterNode"><code>Q</code></a>
-            <a><code>AudioParam</code></a>.
-            </li>
-            <li>Finally let 
-            <!-- Should \alpha_S be simplified since S is always 1?-->
-              <pre class="nohighlight">
-$$
-\begin{align*}
-  A        &amp;= 10^{\frac{G}{40}} \\
-  \omega_0 &amp;= 2\pi\frac{f_0}{F_s} \\
-  \alpha_Q &amp;= \frac{\sin\omega_0}{2Q} \\
-  \alpha_{Q_{dB}} &amp;= \frac{\sin\omega_0}{2 \cdot 10^{Q/20}} \\
-  S        &amp;= 1 \\
-  \alpha_S &amp;= \frac{\sin\omega_0}{2}\sqrt{\left(A+\frac{1}{A}\right)\left(\frac{1}{S}-1\right)+2}
-\end{align*}
-$$
-
-</pre>
-            </li>
-          </ul>The six coefficients (\(b_0, b_1, b_2, a_0, a_1, a_2\)) for each
-          filter type, are:
-          <dl>
-            <dt>
-              <code>lowpass</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                $$
-                  \begin{align*}
-                    b_0 &amp;= \frac{1 - \cos\omega_0}{2} \\
-                    b_1 &amp;= 1 - \cos\omega_0 \\
-                    b_2 &amp;= \frac{1 - \cos\omega_0}{2} \\
-                    a_0 &amp;= 1 + \alpha_{Q_{dB}} \\
-                    a_1 &amp;= -2 \cos\omega_0 \\
-                    a_2 &amp;= 1 - \alpha_{Q_{dB}}
-                  \end{align*}
-                $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>highpass</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                  $$
-                    \begin{align*}
-                      b_0 &amp;= \frac{1 + \cos\omega_0}{2} \\
-                      b_1 &amp;= -(1 + \cos\omega_0) \\
-                      b_2 &amp;= \frac{1 + \cos\omega_0}{2} \\
-                      a_0 &amp;= 1 + \alpha_{Q_{dB}} \\
-                      a_1 &amp;= -2 \cos\omega_0 \\
-                      a_2 &amp;= 1 - \alpha_{Q_{dB}}
-                    \end{align*}
-                  $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>bandpass</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-              $$
-                \begin{align*}
-                  b_0 &amp;= \alpha_Q \\
-                  b_1 &amp;= 0 \\
-                  b_2 &amp;= -\alpha_Q \\
-                  a_0 &amp;= 1 + \alpha_Q \\
-                  a_1 &amp;= -2 \cos\omega_0 \\
-                  a_2 &amp;= 1 - \alpha_Q
-                \end{align*}
-              $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>notch</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                $$
-                  \begin{align*}
-                    b_0 &amp;= 1 \\
-                    b_1 &amp;= -2\cos\omega_0 \\
-                    b_2 &amp;= 1 \\
-                    a_0 &amp;= 1 + \alpha_Q \\
-                    a_1 &amp;= -2 \cos\omega_0 \\
-                    a_2 &amp;= 1 - \alpha_Q
-                  \end{align*}
-                $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>allpass</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                $$
-                  \begin{align*}
-                    b_0 &amp;= 1 - \alpha_Q \\
-                    b_1 &amp;= -2\cos\omega_0 \\
-                    b_2 &amp;= 1 + \alpha_Q \\
-                    a_0 &amp;= 1 + \alpha_Q \\
-                    a_1 &amp;= -2 \cos\omega_0 \\
-                    a_2 &amp;= 1 - \alpha_Q
-                  \end{align*}
-                $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>peaking</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                $$
-                  \begin{align*}
-                    b_0 &amp;= 1 + \alpha_Q\, A \\
-                    b_1 &amp;= -2\cos\omega_0 \\
-                    b_2 &amp;= 1 - \alpha_Q\,A \\
-                    a_0 &amp;= 1 + \frac{\alpha_Q}{A} \\
-                    a_1 &amp;= -2 \cos\omega_0 \\
-                    a_2 &amp;= 1 - \frac{\alpha_Q}{A}
-                  \end{align*}
-                $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>lowshelf</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                $$
-                  \begin{align*}
-                    b_0 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A})\right] \\
-                    b_1 &amp;= 2 A \left[ (A-1) - (A+1) \cos\omega_0 )\right] \\
-                    b_2 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A}) \right] \\
-                    a_0 &amp;= (A+1) + (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A} \\
-                    a_1 &amp;= -2 \left[ (A-1) + (A+1) \cos\omega_0\right] \\
-                    a_2 &amp;= (A+1) + (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A})
-                  \end{align*}
-                $$
-
-</pre>
-            </dd>
-            <dt>
-              <code>highshelf</code>
-            </dt>
-            <dd>
-              <pre class="nohighlight">
-                $$
-                  \begin{align*}
-                    b_0 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} )\right] \\
-                    b_1 &amp;= -2A\left[ (A-1) + (A+1)\cos\omega_0 )\right] \\
-                    b_2 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A} )\right] \\
-                    a_0 &amp;= (A+1) - (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} \\
-                    a_1 &amp;= 2\left[ (A-1) - (A+1)\cos\omega_0\right] \\
-                    a_2 &amp;= (A+1) - (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A}
-                  \end{align*}
-                $$
-
-</pre>
-            </dd>
-          </dl>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The IIRFilterNode Interface
-        </h2>
-        <p>
-          <a><code>IIRFilterNode</code></a> is an <a><code>AudioNode</code></a>
-          processor implementing a general IIR Filter. In general, it is best
-          to use <a><code>BiquadFilterNode</code></a>'s to implement
-          higher-order filters for the following reasons:
-        </p>
-        <ul>
-          <li>Generally less sensitive to numeric issues
-          </li>
-          <li>Filter parameters can be automated
-          </li>
-          <li>Can be used to create all even-ordered IIR filters
-          </li>
-        </ul>
-        <p>
-          However, odd-ordered filters cannot be created, so if such filters
-          are needed or automation is not needed, then IIR filters may be
-          appropriate.
-        </p>
-        <p>
-          Once created, the coefficients of the IIR filter cannot be changed.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">max</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                Yes
-              </td>
-              <td>
-                Continues to output non-silent audio with zero input. Since
-                this is an IIR filter, the filter produces non-zero input
-                forever, but in practice, this can be limited after some finite
-                time where the output is sufficiently close to zero. The actual
-                time depends on the filter coefficients.
-              </td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The number of channels of the output always equals the number of
-          channels of the input.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, IIRFilterOptions options)]
-interface IIRFilterNode : AudioNode {
-    void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="IIRFilterNode" data-link-for=
-          "IIRFilterNode">
-            <dt>
-              <code><dfn>IIRFilterNode</dfn></code>
-            </dt>
-            <dd>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>IIRFilterNode</a>
-                    will be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>IIRFilterOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>IIRFilterNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Methods
-          </h3>
-          <dl class="methods" data-dfn-for="IIRFilterNode" data-link-for=
-          "IIRFilterNode">
-            <dt>
-              <code><dfn>getFrequencyResponse</dfn></code>
-            </dt>
-            <dd>
-              <span class="synchronous">Given the current filter parameter
-              settings, synchronously calculates the frequency response for the
-              specified frequencies.</span> The three parameters MUST be
-              <code>Float32Array</code>s of the same length, or an
-              <code>InvalidAccessError</code> MUST be thrown.
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    frequencyHz
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    This parameter specifies an array of frequencies at which
-                    the response values will be calculated.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    magResponse
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    <p>
-                      This parameter specifies an output array receiving the
-                      linear magnitude response values.
-                    </p>
-                    <p>
-                      If a value in the <code>frequencyHz</code> parameter is
-                      not within [0; sampleRate/2], where
-                      <code>sampleRate</code> is the value of the
-                      <a data-link-for=
-                      "BaseAudioContext"><code>sampleRate</code></a> property
-                      of the <a>AudioContext</a>, the corresponding value at
-                      the same index of the <code>magResponse</code> array MUST
-                      be <code>NaN</code>.
-                    </p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    phaseResponse
-                  </td>
-                  <td class="prmType">
-                    <a><code>Float32Array</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    <p>
-                      This parameter specifies an output array receiving the
-                      phase response values in radians.
-                    </p>
-                    <p>
-                      If a value in the <code>frequencyHz</code> parameter is
-                      not within [0; sampleRate/2], where
-                      <code>sampleRate</code> is the value of the
-                      <a data-link-for=
-                      "BaseAudioContext"><code>sampleRate</code></a> property
-                      of the <a>AudioContext</a>, the corresponding value at
-                      the same index of the <code>phaseResponse</code> array
-                      MUST be <code>NaN</code>.
-                    </p>
-                  </td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>IIRFilterOptions</dfn>
-          </h2>
-          <p>
-            The <code>IIRFilterOptions</code> dictionary is used to specify the
-            filter coefficients of the <a><code>IIRFilterNode</code></a>.
-          </p>
-          <pre class="idl">
-dictionary IIRFilterOptions : AudioNodeOptions {
-    required sequence&lt;double&gt; feedforward;
-    required sequence&lt;double&gt; feedback;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>IIRFilterOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="IIRFilterOptions"
-            data-link-for="IIRFilterOptions">
-              <dt>
-                <code><dfn>feedforward</dfn></code> of type <span class=
-                "idlAttrType"><code>sequence&lt;double&gt;</code></span>,
-                required
-              </dt>
-              <dd>
-                The feedforward coefficients for the
-                <a><code>IIRFilterNode</code></a>. This member is required. If
-                not specifed, a <code>NotFoundError</code> MUST be thrown.
-              </dd>
-              <dt>
-                <code><dfn>feedback</dfn></code> of type <span class=
-                "idlAttrType"><code>sequence&lt;double&gt;</code></span>,
-                required
-              </dt>
-              <dd>
-                The feedback coefficients for the
-                <a><code>IIRFilterNode</code></a>. This member is required. If
-                not specifed, a <code>NotFoundError</code> MUST be thrown.
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h3>
-            Filter Definition
-          </h3>
-          <p>
-            Let \(b_m\) be the <code>feedforward</code> coefficients and
-            \(a_n\) be the <code>feedback</code> coefficients specified by
-            <a data-link-for="BaseAudioContext">createIIRFilter</a>. Then the
-            transfer function of the general IIR filter is given by
-          </p>
-          <pre class="nohighlight">
-            $$
-              H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}}
-            $$
-
-</pre>
-          <p>
-            where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is
-            the length of the \(a\) array. The coefficient \(a_0\) cannot be 0.
-            At least one of \(b_m\) MUST be non-zero.
-          </p>
-          <p>
-            Equivalently, the time-domain equation is:
-          </p>
-          <pre class="nohighlight">
-            $$
-              \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k)
-            $$
-
-</pre>
-          <p>
-            The initial filter state is the all-zeroes state.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2 id="WaveShaperNode">
-          The WaveShaperNode Interface
-        </h2>
-        <p>
-          <a><code>WaveShaperNode</code></a> is an
-          <a><code>AudioNode</code></a> processor implementing non-linear
-          distortion effects.
-        </p>
-        <p>
-          Non-linear waveshaping distortion is commonly used for both subtle
-          non-linear warming, or more obvious distortion effects. Arbitrary
-          non-linear shaping curves may be specified.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCount</a>
-              </td>
-              <td>
-                2
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelCountMode</a>
-              </td>
-              <td>
-                "<a data-link-for="channelCountMode">max</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">channelInterpretation</a>
-              </td>
-              <td>
-                "<a data-link-for="channelInterpretation">speakers</a>"
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                Maybe
-              </td>
-              <td>
-                There is a <a>tail-time</a> reference only if the
-                <a data-link-for="WaveShaperNode">oversample</a> attribute is
-                set to "<a data-link-for="OverSampleType">2x</a>" or
-                "<a data-link-for="OverSampleType">4x</a>". The actual duration
-                of this <a>tail-time</a> depends on the implementation.
-              </td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The number of channels of the output always equals the number of
-          channels of the input.
-        </p>
-        <p>
-          <a>WaveShaperNode</a>s are created with an internal flag <code>curve
-          set</code>, initially set to false.
-        </p>
-        <pre class="idl">
-enum OverSampleType {
-    "none",
-    "2x",
-    "4x"
-};
-        </pre>
-        <table class="simple" data-dfn-for="OverSampleType" data-link-for=
-        "OverSampleType">
-          <tr>
-            <th colspan="2">
-              Enumeration description
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <dfn>none</dfn>
-            </td>
-            <td>
-              Don't oversample
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>2x</dfn>
-            </td>
-            <td>
-              Oversample two times
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>4x</dfn>
-            </td>
-            <td>
-              Oversample four times
-            </td>
-          </tr>
-        </table>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional WaveShaperOptions options)]
-interface WaveShaperNode : AudioNode {
-                    attribute Float32Array?  curve;
-                    attribute OverSampleType oversample;
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="WaveShaperNode" data-link-for=
-          "WaveShaperNode">
-            <dt>
-              <code><dfn>WaveShaperNode</dfn></code>
-            </dt>
-            <dd>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>WaveShaperNode</a>
-                    will be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>WaveShaperOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>WaveShaperNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="WaveShaperNode" data-link-for=
-          "WaveShaperNode">
-            <dt>
-              <code><dfn>curve</dfn></code> of type <span class=
-              "idlAttrType"><a><code>Float32Array</code></a></span>, nullable
-            </dt>
-            <dd>
-              <p>
-                The shaping curve used for the waveshaping effect. The input
-                signal is nominally within the range [-1; 1]. Each input sample
-                within this range will index into the shaping curve, with a
-                signal level of zero corresponding to the center value of the
-                curve array if there are an odd number of entries, or
-                interpolated between the two centermost values if there are an
-                even number of entries in the array. Any sample value less than
-                -1 will correspond to the first value in the curve array. Any
-                sample value greater than +1 will correspond to the last value
-                in the curve array.
-              </p>
-              <p>
-                The implementation MUST perform linear interpolation between
-                adjacent points in the curve. Initially the curve attribute is
-                null, which means that the WaveShaperNode will pass its input
-                to its output without modification.
-              </p>
-              <p>
-                Values of the curve are spread with equal spacing in the [-1;
-                1] range. This means that a <a><code>curve</code></a> with a
-                even number of value will not have a value for a signal at
-                zero, and a <a><code>curve</code></a> with an odd number of
-                value will have a value for a signal at zero.
-              </p>
-              <p>
-                A <code>InvalidStateError</code> MUST be thrown if this
-                attribute is set with a <code>Float32Array</code> that has a
-                <code>length</code> less than 2.
-              </p>
-              <p>
-                When this attribute is set, an internal copy of the curve is
-                created by the <a><code>WaveShaperNode</code></a>. Subsequent
-                modifications of the contents of the array used to set the
-                attribute therefore have no effect: the attribute MUST be set
-                again in order to change the curve.
-              </p>
-              <p>
-                To set the <code>curve</code> attribute, execute these steps:
-              </p>
-              <ol>
-                <li>Let <code>new curve</code> be the <code>Float32Array</code>
-                to be assigned to <code>curve</code>.
-                </li>
-                <li>If <code>new curve</code> is not <code>null</code> and
-                <code>curve set</code> is true, throw an
-                <code>InvalidStateError</code> and abort these steps.
-                </li>
-                <li>If <code>new curve</code> is not <code>null</code>, set
-                <code>curve set</code> to true.
-                </li>
-                <li>Assign <code>new curve</code> to the <code>curve</code>
-                attribute.
-                </li>
-              </ol>
-            </dd>
-            <dt>
-              <code><dfn>overSample</dfn></code> of type <span class=
-              "idlAttrType"><a><code>OverSampleType</code></a></span>
-            </dt>
-            <dd>
-              <p>
-                Specifies what type of oversampling (if any) should be used
-                when applying the shaping curve. The default value is "none",
-                meaning the curve will be applied directly to the input
-                samples. A value of "2x" or "4x" can improve the quality of the
-                processing by avoiding some aliasing, with the "4x" value
-                yielding the highest quality. For some applications, it's
-                better to use no oversampling in order to get a very precise
-                shaping curve.
-              </p>
-              <p>
-                A value of "2x" or "4x" means that the following steps MUST be
-                performed:
-              </p>
-              <ol>
-                <li>Up-sample the input samples to 2x or 4x the sample-rate of
-                the <a><code>AudioContext</code></a>. Thus for each <a>render
-                quantum</a>, generate 256 (for 2x) or 512 (for 4x) samples.
-                </li>
-                <li>Apply the shaping curve.
-                </li>
-                <li>Down-sample the result back to the sample-rate of the
-                <a><code>AudioContext</code></a>. Thus taking the 256 (or 512)
-                processed samples, generating 128 as the final result.
-                </li>
-              </ol>
-              <p>
-                The exact up-sampling and down-sampling filters are not
-                specified, and can be tuned for sound quality (low aliasing,
-                etc.), low latency, and performance.
-              </p>
-              <p class="note">
-                Use of oversampling introduces some degree of audio processing
-                latency due to the up-sampling and down-sampling filters. The
-                amount of this latency can vary from one implementation to
-                another.
-              </p>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>WaveShaperOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options for constructing a
-            <a><code>WaveShaperNode</code></a>. All members are optional; if
-            not specified, the normal default is used in constructing the node.
-          </p>
-          <pre class="idl">
-dictionary WaveShaperOptions : AudioNodeOptions {
-             sequence&lt;float&gt; curve;
-             OverSampleType  oversample = "none";
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>WaveShaperOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="WaveShaperOptions"
-            data-link-for="WaveShaperOptions">
-              <dt>
-                <code><dfn>curve</dfn></code> of type <span class=
-                "idlAttrType"><code>sequence&lt;float&gt;</code></span>
-              </dt>
-              <dd>
-                The shaping curve for the waveshaping effect.
-              </dd>
-              <dt>
-                <code><dfn>oversample</dfn></code> of type <span class=
-                "idlAttrType"><a><code>OverSampleType</code></a></span>,
-                defaulting to "none"
-              </dt>
-              <dd>
-                The type of oversampling to use for the shaping curve.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2>
-          The OscillatorNode Interface
-        </h2>
-        <p>
-          <a><code>OscillatorNode</code></a> represents an audio source
-          generating a periodic waveform. It can be set to a few commonly used
-          waveforms. Additionally, it can be set to an arbitrary periodic
-          waveform through the use of a <a><code>PeriodicWave</code></a>
-          object.
-        </p>
-        <p>
-          Oscillators are common foundational building blocks in audio
-          synthesis. An OscillatorNode will start emitting sound at the time
-          specified by the <code>start()</code> method.
-        </p>
-        <p>
-          Mathematically speaking, a <em>continuous-time</em> periodic waveform
-          can have very high (or infinitely high) frequency information when
-          considered in the frequency domain. When this waveform is sampled as
-          a discrete-time digital audio signal at a particular sample-rate,
-          then care MUST be taken to discard (filter out) the high-frequency
-          information higher than the <a>Nyquist frequency</a> before
-          converting the waveform to a digital form. If this is not done, then
-          <em>aliasing</em> of higher frequencies (than the <a>Nyquist
-          frequency</a>) will fold back as mirror images into frequencies lower
-          than the <a>Nyquist frequency</a>. In many cases this will cause
-          audibly objectionable artifacts. This is a basic and well understood
-          principle of audio DSP.
-        </p>
-        <p>
-          There are several practical approaches that an implementation may
-          take to avoid this aliasing. Regardless of approach, the
-          <em>idealized</em> discrete-time digital audio signal is well defined
-          mathematically. The trade-off for the implementation is a matter of
-          implementation cost (in terms of CPU usage) versus fidelity to
-          achieving this ideal.
-        </p>
-        <p>
-          It is expected that an implementation will take some care in
-          achieving this ideal, but it is reasonable to consider lower-quality,
-          less-costly approaches on lower-end hardware.
-        </p>
-        <p>
-          Both <code>frequency</code> and <code>detune</code> are <a>a-rate</a>
-          parameters, and form a <a>compound parameter</a>. They are used
-          together to determine a <dfn>computedOscFrequency</dfn> value:
-        </p>
-        <pre>
-  computedOscFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
-</pre>
-        <p>
-          The OscillatorNode's instantaneous phase at each time is the definite
-          time integral of <a>computedOscFrequency</a>, assuming a phase angle
-          of zero at the node's exact start time. Its <a>nominal range</a> is
-          [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                0
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <pre class="idl">
-enum OscillatorType {
-    "sine",
-    "square",
-    "sawtooth",
-    "triangle",
-    "custom"
-};
-        </pre>
-        <table class="simple" data-dfn-for="OscillatorType" data-link-for=
-        "OscillatorType">
-          <tr>
-            <th colspan="2">
-              Enumeration description
-            </th>
-          </tr>
-          <tr>
-            <td>
-              <dfn>sine</dfn>
-            </td>
-            <td>
-              A sine wave
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>square</dfn>
-            </td>
-            <td>
-              A square wave of duty period 0.5
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>sawtooth</dfn>
-            </td>
-            <td>
-              A sawtooth wave
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>triangle</dfn>
-            </td>
-            <td>
-              A triangle wave
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <dfn>custom</dfn>
-            </td>
-            <td>
-              A custom periodic wave
-            </td>
-          </tr>
-        </table>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional OscillatorOptions options)]
-interface OscillatorNode : AudioScheduledSourceNode {
-                    attribute OscillatorType type;
-    readonly        attribute AudioParam     frequency;
-    readonly        attribute AudioParam     detune;
-    void setPeriodicWave (PeriodicWave periodicWave);
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="OscillatorNode" data-link-for=
-          "OscillatorNode">
-            <dt>
-              <code><dfn>OscillatorNode</dfn></code>
-            </dt>
-            <dd>
-              <p>
-                Let <var>node</var> be a new <a>OscillatorNode</a> object.
-                <a href="#audionode-constructor-init">Initialize</a>
-                <var>node</var>, and return <var>node</var>.
-              </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new <a>OscillatorNode</a>
-                    will be <a href="#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>OscillatorOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptTrue">
-                    <span role="img" aria-label="True">✔</span>
-                  </td>
-                  <td class="prmDesc">
-                    Optional initial parameter value for this
-                    <a>OscillatorNode</a>.
-                  </td>
-                </tr>
-              </table>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Attributes
-          </h3>
-          <dl class="attributes" data-dfn-for="OscillatorNode" data-link-for=
-          "OscillatorNode">
-            <dt>
-              <code><dfn>detune</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                A detuning value (in cents) which will offset the
-                <a><code>frequency</code></a> by the given amount. Its default
-                <code>value</code> is 0. This parameter is <a>a-rate</a>. It
-                forms a <a>compound parameter</a> with <code>frequency</code>
-                to form the <a>computedOscFrequency</a>.
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      0
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      <a>most-negative-single-float</a>
-                    </td>
-                    <td>
-                      Approximately -3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>most-positive-single-float</a>
-                    </td>
-                    <td>
-                      Approximately 3.4028235e38
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>frequency</dfn></code> of type <span class=
-              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
-            </dt>
-            <dd>
-              <p>
-                The frequency (in Hertz) of the periodic waveform. Its default
-                <code>value</code> is 440. This parameter is <a>a-rate</a>. It
-                forms a <a>compound parameter</a> with <code>detune</code> to
-                form the <a>computedOscFrequency</a>. Its <a>nominal range</a>
-                is [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
-              </p>
-              <div class="audioparam-info">
-                <table>
-                  <tr>
-                    <th>
-                      Parameter
-                    </th>
-                    <th>
-                      Value
-                    </th>
-                    <th>
-                      Notes
-                    </th>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">defaultValue</a>
-                    </td>
-                    <td>
-                      440
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">minValue</a>
-                    </td>
-                    <td>
-                      -<a>Nyquist frequency</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <a data-link-for="AudioParam">maxValue</a>
-                    </td>
-                    <td>
-                      <a>Nyquist frequency</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Rate
-                    </td>
-                    <td>
-                      <a>a-rate</a>
-                    </td>
-                    <td></td>
-                  </tr>
-                </table>
-              </div>
-            </dd>
-            <dt>
-              <code><dfn>type</dfn></code> of type <span class=
-              "idlAttrType"><a><code>OscillatorType</code></a></span>
-            </dt>
-            <dd>
-              The shape of the periodic waveform. It may directly be set to any
-              of the type constant values except for "custom". <span class=
-              "synchronous">Doing so MUST throw an
-              <code>InvalidStateError</code> exception.</span> The
-              <a data-link-for=
-              "OscillatorNode"><code>setPeriodicWave()</code></a> method can be
-              used to set a custom waveform, which results in this attribute
-              being set to "custom". The default value is "sine". When this
-              attribute is set, the phase of the oscillator MUST be conserved.
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h3>
-            Methods
-          </h3>
-          <dl class="methods" data-dfn-for="OscillatorNode" data-link-for=
-          "OscillatorNode">
-            <dt>
-              <code><dfn>setPeriodicWave</dfn></code>
-            </dt>
-            <dd>
-              Sets an arbitrary custom periodic waveform given a
-              <a><code>PeriodicWave</code></a>.
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    periodicWave
-                  </td>
-                  <td class="prmType">
-                    <a><code>PeriodicWave</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-              </table>
-              <div>
-                <em>Return type:</em> <code>void</code>
-              </div>
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>OscillatorOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options to be used when constructing an
-            <a><code>OscillatorNode</code></a>. All of the members are
-            optional; if not specified, the normal default values are used for
-            constructing the oscillator.
-          </p>
-          <pre class="idl">
-dictionary OscillatorOptions : AudioNodeOptions {
-             OscillatorType type = "sine";
-             float          frequency = 440;
-             float          detune = 0;
-             PeriodicWave   periodicWave;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>OscillatorOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="OscillatorOptions"
-            data-link-for="OscillatorOptions">
-              <dt>
-                <code><dfn>detune</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 0
-              </dt>
-              <dd>
-                The initial detune value for the
-                <a><code>OscillatorNode</code></a>.
-              </dd>
-              <dt>
-                <code><dfn>frequency</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code></span>, defaulting to 440
-              </dt>
-              <dd>
-                The initial frequency for the
-                <a><code>OscillatorNode</code></a>.
-              </dd>
-              <dt>
-                <code><dfn>periodicWave</dfn></code> of type <span class=
-                "idlAttrType"><code>PeriodicWave</code></span>
-              </dt>
-              <dd>
-                The <a><code>PeriodicWave</code></a> for the
-                <a><code>OscillatorNode</code></a>. If this is specified, then
-                any valid value for <a data-link-for=
-                "OscillatorOptions"><code>type</code></a> is ignored; it is
-                treated as if "custom" were specified.
-              </dd>
-              <dt>
-                <code><dfn>type</dfn></code> of type <span class=
-                "idlAttrType"><code>OscillatorType</code></span>, defaulting to
-                "sine"
-              </dt>
-              <dd>
-                The type of oscillator to be constructed. If this is set to
-                "custom" without also specifying a <a data-link-for=
-                "OscillatorOptions"><code>periodicWave</code></a>, then an
-                <span class="synchronous"><code>InvalidStateError</code>
-                exception MUST be thrown</span>. If <a data-link-for=
-                "OscillatorOptions"><code>periodicWave</code></a> is specified,
-                then any valid value for <a data-link-for=
-                "OscillatorOptions"><code>type</code></a> is ignored; it is
-                treated as if it were set to "custom".
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h2>
-            Basic Waveform Phase
-          </h2>
-          <p>
-            The idealized mathematical waveforms for the various oscillator
-            types are defined here. In summary, all waveforms are defined
-            mathematically to be an odd function with a positive slope at time
-            0. The actual waveforms produced by the oscillator may differ to
-            prevent aliasing affects.
-          </p>
-          <p>
-            The oscillator MUST produce the same result as if a PeriodicWave
-            with the appropriate <a href="#oscillator-coefficients">Fourier
-            series</a> and with normalization enabled were used to create these
-            basic waveforms.
-          </p>
-          <dl>
-            <dt>
-              "sine"
-            </dt>
-            <dd>
-              The waveform for sine oscillator is:
-              <pre class="nohighlight">
-                $$
-                  x(t) = \sin t
-                $$.
-
-</pre>
-            </dd>
-            <dt>
-              "square"
-            </dt>
-            <dd>
-              The waveform for the square wave oscillator is:
-              <pre class="nohighlight">
-                $$
-                  x(t) = \begin{cases}
-                         1 & \mbox{for } 0≤ t &lt; \pi \\
-                         -1 & \mbox{for } -\pi &lt; t &lt; 0.
-                         \end{cases}
-                $$
-              </pre>
-              <p>
-                This is extended to all \(t\) by using the fact that the
-                waveform is an odd function with period \(2\pi\).
-              </p>
-            </dd>
-            <dt>
-              "sawtooth"
-            </dt>
-            <dd>
-              The waveform for the sawtooth oscillator is the ramp:
-              <pre class="nohighlight">
-                $$
-                  x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi;
-                $$
-              </pre>
-              <p>
-                This is extended to all \(t\) by using the fact that the
-                waveform is an odd function with period \(2\pi\).
-              </p>
-            </dd>
-            <dt>
-              "triangle"
-            </dt>
-            <dd>
-              The waveform for the triangle oscillator is:
-              <pre class="nohighlight">
-                $$
-                  x(t) = \begin{cases}
-                           \frac{2}{\pi} t & \mbox{for } 0 ≤ t ≤ \frac{\pi}{2} \\
-                           1-\frac{2}{\pi} (t-\frac{\pi}{2}) & \mbox{for }
-                           \frac{\pi}{2} &lt; t ≤ \pi.
-                         \end{cases}
-                $$
-              </pre>
-              <p>
-                This is extended to all \(t\) by using the fact that the
-                waveform is an odd function with period \(2\pi\).
-              </p>
-            </dd>
-          </dl>
-        </section>
-      </section>
-      <section>
         <h2>
           The <dfn>PeriodicWave</dfn> Interface
         </h2>
@@ -18691,24 +18169,16 @@ dictionary PeriodicWaveOptions : PeriodicWaveConstraints {
           </dl>
         </section>
       </section>
-      <section>
-        <h2 id="MediaStreamAudioSourceNode">
-          The MediaStreamAudioSourceNode Interface
+      <section class="informative">
+        <h2>
+          The <dfn>ScriptProcessorNode</dfn> Interface - DEPRECATED
         </h2>
         <p>
-          This interface represents an audio source from a
-          <code>MediaStream</code>. The track that will be used as the source
-          of audio and will be output from this node is the first
-          <code>MediaStreamTrack</code> whose <code>kind</code> attribute has
-          the value <code>"audio"</code>, when alphabetically sorting the
-          tracks of this <code>MediaStream</code> by their <code>id</code>
-          attribute. Those interfaces are described in
-          [[!mediacapture-streams]].
-        </p>
-        <p class="note">
-          The behaviour for picking the track to output is weird for legacy
-          reasons. <a>MediaStreamTrackAudioSourceNode</a> should be used
-          instead.
+          This interface is an <a><code>AudioNode</code></a> which can
+          generate, process, or analyse audio directly using a script. This
+          node type is deprecated, to be replaced by the
+          <a>AudioWorkletNode</a>; this text is only here for informative
+          purposes until implementations remove this node type.
         </p>
         <div class="node-info">
           <table>
@@ -18728,7 +18198,7 @@ dictionary PeriodicWaveOptions : PeriodicWaveConstraints {
                 <a data-link-for="AudioNode">numberOfInputs</a>
               </td>
               <td>
-                0
+                1
               </td>
               <td></td>
             </tr>
@@ -18738,6 +18208,38 @@ dictionary PeriodicWaveOptions : PeriodicWaveConstraints {
               </td>
               <td>
                 1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                <a data-link-for="BaseAudioContext">numberOfInputChannels</a>
+              </td>
+              <td>
+                This is the number of channels specified when constructing this
+                node. There are <a>channelCount constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td>
+                Has <a>channelCountMode constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
               </td>
               <td></td>
             </tr>
@@ -18753,30 +18255,181 @@ dictionary PeriodicWaveOptions : PeriodicWaveConstraints {
           </table>
         </div>
         <p>
-          The number of channels of the output corresponds to the number of
-          channels of the <code>MediaStreamTrack</code>. If there is no valid
-          audio track, then the number of channels output will be one silent
-          channel.
+          The <a><code>ScriptProcessorNode</code></a> is constructed with a
+          <dfn>bufferSize</dfn> which MUST be one of the following values: 256,
+          512, 1024, 2048, 4096, 8192, 16384. This value controls how
+          frequently the <a data-link-for=
+          "ScriptProcessorNode">onaudioprocess</a> event is dispatched and how
+          many sample-frames need to be processed each call. <a data-link-for=
+          "ScriptProcessorNode"><code>onaudioprocess</code></a> events are only
+          dispatched if the <a><code>ScriptProcessorNode</code></a> has at
+          least one input or one output connected. Lower numbers for
+          <a data-link-for="ScriptProcessorNode">bufferSize</a> will result in
+          a lower (better) <a href="#latency">latency</a>. Higher numbers will
+          be necessary to avoid audio breakup and <a href=
+          "#audio-glitching">glitches</a>. This value will be picked by the
+          implementation if the bufferSize argument to
+          <code>createScriptProcessor</code> is not passed in, or is set to 0.
+        </p>
+        <p>
+          <a>numberOfInputChannels</a> and <a>numberOfOutputChannels</a>
+          determine the number of input and output channels. It is invalid for
+          both <a>numberOfInputChannels</a> and <a>numberOfOutputChannels</a>
+          to be zero.
+        </p>
+        <pre class="idl">
+[Exposed=Window]
+interface ScriptProcessorNode : AudioNode {
+                    attribute EventHandler onaudioprocess;
+    readonly        attribute long         bufferSize;
+};
+        </pre>
+        <section>
+          <h3>
+            Attributes
+          </h3>
+          <dl class="attributes" data-dfn-for="ScriptProcessorNode"
+          data-link-for="ScriptProcessorNode">
+            <dt>
+              <code><dfn>bufferSize</dfn></code> of type <span class=
+              "idlAttrType"><a><code>long</code></a></span>, readonly
+            </dt>
+            <dd>
+              The size of the buffer (in sample-frames) which needs to be
+              processed each time <a data-link-for=
+              "ScriptProcessorNode"><code>onaudioprocess</code></a> is called.
+              Legal values are (256, 512, 1024, 2048, 4096, 8192, 16384).
+            </dd>
+            <dt>
+              <code><dfn>onaudioprocess</dfn></code> of type <span class=
+              "idlAttrType"><code>EventHandler</code></span>
+            </dt>
+            <dd>
+              A property used to set the <code>EventHandler</code> (described
+              in <cite><a href=
+              "https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">
+              HTML</a></cite>[[!HTML]]) for the <a data-link-for=
+              "ScriptProcessorNode"><code>onaudioprocess</code></a> event that
+              is dispatched to <a><code>ScriptProcessorNode</code></a> node
+              types. An event of type <a><code>AudioProcessingEvent</code></a>
+              will be dispatched to the event handler.
+            </dd>
+          </dl>
+        </section>
+      </section>
+      <section>
+        <h2>
+          The StereoPannerNode Interface
+        </h2>
+        <p>
+          This interface represents a processing node which positions an
+          incoming audio stream in a stereo image using a low-cost <a href=
+          "#Spatialzation-equal-power-panning">equal-power panning
+          algorithm</a>. This panning effect is common in positioning audio
+          components in a stereo stream.
+        </p>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td>
+                Has <a>channelCount constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">clamped-max</a>"
+              </td>
+              <td>
+                Has <a>channelCountMode constraints</a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
+        <p>
+          The input of this node is stereo (2 channels) and cannot be
+          increased. Connections from nodes with fewer or more channels will be
+          <a href="#channel-up-mixing-and-down-mixing">up-mixed or down-mixed
+          appropriately</a>.
+        </p>
+        <p>
+          The output of this node is hard-coded to stereo (2 channels) and
+          cannot be configured.
         </p>
         <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, MediaStreamAudioSourceOptions options)]
-interface MediaStreamAudioSourceNode : AudioNode {
-    [SameObject] readonly        attribute MediaStream mediaStream;
+ Constructor (BaseAudioContext context, optional StereoPannerOptions options)]
+interface StereoPannerNode : AudioNode {
+    readonly        attribute AudioParam pan;
 };
         </pre>
         <section>
           <h3>
             Constructors
           </h3>
-          <dl class="methods" data-dfn-for="MediaStreamAudioSourceNode"
-          data-link-for="MediaStreamAudioSourceNode">
+          <dl class="methods" data-dfn-for="StereoPannerNode" data-link-for=
+          "StereoPannerNode">
             <dt>
-              <code><dfn>MediaStreamAudioSourceNode</dfn></code>
+              <code><dfn>StereoPannerNode</dfn></code>
             </dt>
             <dd>
               <p>
-                Let <var>node</var> be a new <a>MediaStreamAudioSourceNode</a>
+                Let <var>node</var> be a new <a>StereoStereoPannerNode</a>
                 object. <a href="#audionode-constructor-init">Initialize</a>
                 <var>node</var>, and return <var>node</var>.
               </p>
@@ -18813,7 +18466,7 @@ interface MediaStreamAudioSourceNode : AudioNode {
                   </td>
                   <td class="prmDesc">
                     The <a>BaseAudioContext</a> this new
-                    <a>MediaStreamAudioSourceNode</a> will be <a href=
+                    <a>StereoPannerNode</a> will be <a href=
                     "#associated">associated</a> with.
                   </td>
                 </tr>
@@ -18822,22 +18475,17 @@ interface MediaStreamAudioSourceNode : AudioNode {
                     options
                   </td>
                   <td class="prmType">
-                    <a><code>MediaStreamAudioSourceOptions</code></a>
+                    <a><code>StereoPannerOptions</code></a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
                   </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
+                  <td class="prmOptTrue">
+                    <span role="img" aria-label="True">✔</span>
                   </td>
                   <td class="prmDesc">
-                    Initial parameter values for this
-                    <a>MediaStreamAudioSourceNode</a>. If the
-                    <code>mediaStream</code> parameter does not reference a
-                    <code>MediaStream</code> whose <code>kind</code> attribute
-                    has the value <code>"audio"</code>, <span class=
-                    "synchronous">an <code>InvalidStateError</code> MUST be
-                    thrown</span>.
+                    Optional initial parameter value for this
+                    <a>StereoPannerNode</a>.
                   </td>
                 </tr>
               </table>
@@ -18848,230 +18496,131 @@ interface MediaStreamAudioSourceNode : AudioNode {
           <h3>
             Attributes
           </h3>
-          <dl class="attributes" data-dfn-for="MediaStreamAudioSourceNode"
-          data-link-for="MediaStreamAudioSourceNode">
+          <dl class="attributes" data-dfn-for="StereoPannerNode" data-link-for=
+          "StereoPannerNode">
             <dt>
-              <code><dfn>mediaStream</dfn></code> of type <span class=
-              "idlAttrType"><a><code>MediaStream</code></a></span>, readonly
-            </dt>
-            <dd>
-              The <code>MediaStream</code> used when constructing this
-              <a>MediaStreamAudioSourceNode</a>.
-            </dd>
-          </dl>
-        </section>
-        <section>
-          <h2>
-            <dfn>MediaStreamAudioSourceOptions</dfn>
-          </h2>
-          <p>
-            This specifies the options for constructing a
-            <a><code>MediaStreamAudioSourceNode</code></a>.
-          </p>
-          <pre class="idl">
-dictionary MediaStreamAudioSourceOptions {
-    required MediaStream mediaStream;
-};
-        </pre>
-          <section>
-            <h3>
-              Dictionary <a>MediaStreamAudioSourceOptions</a> Members
-            </h3>
-            <dl class="attributes" data-dfn-for="MediaStreamAudioSourceOptions"
-            data-link-for="MediaStreamAudioSourceOptions">
-              <dt>
-                <code><dfn>mediaStream</dfn></code> of type <span class=
-                "idlAttrType"><code>MediaStream</code></span>, required
-              </dt>
-              <dd>
-                The media stream that will act as a source. This MUST be
-                specified.
-              </dd>
-            </dl>
-          </section>
-        </section>
-      </section>
-      <section>
-        <h2 id="MediaStreamTrackAudioSourceNode">
-          The MediaStreamTrackAudioSourceNode Interface
-        </h2>
-        <p>
-          This interface represents an audio source from a
-          <code>MediaStreamTrack</code>.
-        </p>
-        <div class="node-info">
-          <table>
-            <tr>
-              <th>
-                Property
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Notes
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfInputs</a>
-              </td>
-              <td>
-                0
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a data-link-for="AudioNode">numberOfOutputs</a>
-              </td>
-              <td>
-                1
-              </td>
-              <td></td>
-            </tr>
-            <tr>
-              <td>
-                <a>tail-time</a> reference
-              </td>
-              <td>
-                No
-              </td>
-              <td></td>
-            </tr>
-          </table>
-        </div>
-        <p>
-          The number of channels of the output corresponds to the number of
-          channels of the <code>MediaStreamTrack</code>.
-        </p>
-        <pre class="idl">
-[Exposed=Window,
- Constructor (AudioContext context, MediaStreamTrackAudioSourceOptions options)]
-interface MediaStreamTrackAudioSourceNode : AudioNode {
-};
-        </pre>
-        <section>
-          <h3>
-            Constructors
-          </h3>
-          <dl class="methods" data-dfn-for="MediaStreamTrackAudioSourceNode"
-          data-link-for="MediaStreamTrackAudioSourceNode">
-            <dt>
-              <code><dfn>MediaStreamTrackAudioSourceNode</dfn></code>
+              <code><dfn>pan</dfn></code> of type <span class=
+              "idlAttrType"><a><code>AudioParam</code></a></span>, readonly
             </dt>
             <dd>
               <p>
-                Let <var>node</var> be a new
-                <a>MediaStreamTrackAudioSourceNode</a> object. <a href=
-                "#audionode-constructor-init">Initialize</a> <var>node</var>,
-                and return <var>node</var>.
+                The position of the input in the output's stereo image. -1
+                represents full left, +1 represents full right.
               </p>
-              <table class="parameters">
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    context
-                  </td>
-                  <td class="prmType">
-                    <a><code>BaseAudioContext</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>MediaStreamTrackAudioSourceNode</a> will be <a href=
-                    "#associated">associated</a> with.
-                  </td>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    options
-                  </td>
-                  <td class="prmType">
-                    <a><code>MediaStreamTrackAudioSourceOptions</code></a>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmDesc">
-                    Initial parameter value for this
-                    <a>MediaStreamTrackAudioSourceNode</a>.
-                  </td>
-                </tr>
-              </table>
+              <div class="audioparam-info">
+                <table>
+                  <tr>
+                    <th>
+                      Parameter
+                    </th>
+                    <th>
+                      Value
+                    </th>
+                    <th>
+                      Notes
+                    </th>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">defaultValue</a>
+                    </td>
+                    <td>
+                      0
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">minValue</a>
+                    </td>
+                    <td>
+                      -1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a data-link-for="AudioParam">maxValue</a>
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      Rate
+                    </td>
+                    <td>
+                      <a>a-rate</a>
+                    </td>
+                    <td></td>
+                  </tr>
+                </table>
+              </div>
             </dd>
           </dl>
         </section>
         <section>
           <h2>
-            <dfn>MediaStreamTrackAudioSourceOptions</dfn>
+            <dfn>StereoPannerOptions</dfn>
           </h2>
           <p>
-            This specifies the options for constructing a
-            <a><code>MediaStreamTrackAudioSourceNode</code></a>. This is
-            required.
+            This specifies the options to use in constructing a
+            <a><code>StereoPannerNode</code></a>. All members are optional; if
+            not specified, the normal default is used in constructing the node.
           </p>
           <pre class="idl">
-dictionary MediaStreamTrackAudioSourceOptions {
-    required MediaStreamTrack mediaStreamTrack;
+dictionary StereoPannerOptions : AudioNodeOptions {
+             float pan = 0;
 };
         </pre>
           <section>
             <h3>
-              Dictionary <a>MediaStreamTrackAudioSourceOptions</a> Members
+              Dictionary <a>StereoPannerOptions</a> Members
             </h3>
-            <dl class="attributes" data-dfn-for=
-            "MediaStreamTrackAudioSourceOptions" data-link-for=
-            "MediaStreamTrackAudioSourceOptions">
+            <dl class="attributes" data-dfn-for="StereoPannerOptions"
+            data-link-for="StereoPannerOptions">
               <dt>
-                <code><dfn>mediaStreamTrack</dfn></code> of type <span class=
-                "idlAttrType"><code>MediaStreamTrack</code></span>, readonly
+                <code><dfn>pan</dfn></code> of type <span class=
+                "idlAttrType"><code>float</code></span>, defaulting to 0
               </dt>
               <dd>
-                The audio media stream track that will act as a source.
+                The initial value for the <a data-link-for=
+                "StereoPannerNode"><code>pan</code></a> AudioParam.
               </dd>
             </dl>
           </section>
         </section>
+        <section class="informative">
+          <h3>
+            Channel Limitations
+          </h3>
+          <p>
+            Because its processing is constrained by the above definitions,
+            <a><code>StereoPannerNode</code></a> is limited to mixing no more
+            than 2 channels of audio, and producing exactly 2 channels. It is
+            possible to use a <a><code>ChannelSplitterNode</code></a>,
+            intermediate processing by a subgraph of
+            <a><code>GainNode</code></a>s and/or other nodes, and recombination
+            via a <a><code>ChannelMergerNode</code></a> to realize arbitrary
+            approaches to panning and mixing.
+          </p>
+        </section>
       </section>
       <section>
-        <h2>
-          The MediaStreamAudioDestinationNode Interface
+        <h2 id="WaveShaperNode">
+          The WaveShaperNode Interface
         </h2>
         <p>
-          This interface is an audio destination representing a
-          <code>MediaStream</code> with a single <code>MediaStreamTrack</code>
-          whose <code>kind</code> is <code>"audio"</code>. This MediaStream is
-          created when the node is created and is accessible via the
-          <dfn>stream</dfn> attribute. This stream can be used in a similar way
-          as a <code>MediaStream</code> obtained via
-          <code>getUserMedia()</code>, and can, for example, be sent to a
-          remote peer using the <code>RTCPeerConnection</code> (described in
-          [[!webrtc]]) <code>addStream()</code> method.
+          <a><code>WaveShaperNode</code></a> is an
+          <a><code>AudioNode</code></a> processor implementing non-linear
+          distortion effects.
+        </p>
+        <p>
+          Non-linear waveshaping distortion is commonly used for both subtle
+          non-linear warming, or more obvious distortion effects. Arbitrary
+          non-linear shaping curves may be specified.
         </p>
         <div class="node-info">
           <table>
@@ -19100,7 +18649,7 @@ dictionary MediaStreamTrackAudioSourceOptions {
                 <a data-link-for="AudioNode">numberOfOutputs</a>
               </td>
               <td>
-                0
+                1
               </td>
               <td></td>
             </tr>
@@ -19118,7 +18667,7 @@ dictionary MediaStreamTrackAudioSourceOptions {
                 <a data-link-for="AudioNode">channelCountMode</a>
               </td>
               <td>
-                "<a data-link-for="channelCountMode">explicit</a>"
+                "<a data-link-for="channelCountMode">max</a>"
               </td>
               <td></td>
             </tr>
@@ -19136,38 +18685,83 @@ dictionary MediaStreamTrackAudioSourceOptions {
                 <a>tail-time</a> reference
               </td>
               <td>
-                No
+                Maybe
               </td>
-              <td></td>
+              <td>
+                There is a <a>tail-time</a> reference only if the
+                <a data-link-for="WaveShaperNode">oversample</a> attribute is
+                set to "<a data-link-for="OverSampleType">2x</a>" or
+                "<a data-link-for="OverSampleType">4x</a>". The actual duration
+                of this <a>tail-time</a> depends on the implementation.
+              </td>
             </tr>
           </table>
         </div>
         <p>
-          The number of channels of the input is by default 2 (stereo).
+          The number of channels of the output always equals the number of
+          channels of the input.
+        </p>
+        <p>
+          <a>WaveShaperNode</a>s are created with an internal flag <code>curve
+          set</code>, initially set to false.
         </p>
         <pre class="idl">
+enum OverSampleType {
+    "none",
+    "2x",
+    "4x"
+};
+        </pre>
+        <table class="simple" data-dfn-for="OverSampleType" data-link-for=
+        "OverSampleType">
+          <tr>
+            <th colspan="2">
+              Enumeration description
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <dfn>none</dfn>
+            </td>
+            <td>
+              Don't oversample
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>2x</dfn>
+            </td>
+            <td>
+              Oversample two times
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <dfn>4x</dfn>
+            </td>
+            <td>
+              Oversample four times
+            </td>
+          </tr>
+        </table>
+        <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional AudioNodeOptions options)]
-interface MediaStreamAudioDestinationNode : AudioNode {
-    readonly        attribute MediaStream stream;
+ Constructor (BaseAudioContext context, optional WaveShaperOptions options)]
+interface WaveShaperNode : AudioNode {
+                    attribute Float32Array?  curve;
+                    attribute OverSampleType oversample;
 };
         </pre>
         <section>
           <h3>
             Constructors
           </h3>
-          <dl class="methods" data-dfn-for="MediaStreamAudioDestinationNode"
-          data-link-for="MediaStreamAudioDestinationNode">
+          <dl class="methods" data-dfn-for="WaveShaperNode" data-link-for=
+          "WaveShaperNode">
             <dt>
-              <code><dfn>MediaStreamAudioDestinationNode</dfn></code>
+              <code><dfn>WaveShaperNode</dfn></code>
             </dt>
             <dd>
-              <p>
-                Let <var>node</var> be a new
-                <a>MediaStreamAudioDestinationNode</a> object. <a href=
-                "#audionode-constructor-init">Initialize</a> <var>node</var>,
-                and return <var>node</var>.
-              </p>
               <table class="parameters">
                 <tr>
                   <th>
@@ -19200,9 +18794,8 @@ interface MediaStreamAudioDestinationNode : AudioNode {
                     <span role="img" aria-label="False">✘</span>
                   </td>
                   <td class="prmDesc">
-                    The <a>BaseAudioContext</a> this new
-                    <a>MediaStreamAudioDestinationNode</a> will be <a href=
-                    "#associated">associated</a> with.
+                    The <a>BaseAudioContext</a> this new <a>WaveShaperNode</a>
+                    will be <a href="#associated">associated</a> with.
                   </td>
                 </tr>
                 <tr>
@@ -19210,7 +18803,7 @@ interface MediaStreamAudioDestinationNode : AudioNode {
                     options
                   </td>
                   <td class="prmType">
-                    <a><code>AudioNodeOptions</code></a>
+                    <a><code>WaveShaperOptions</code></a>
                   </td>
                   <td class="prmNullFalse">
                     <span role="img" aria-label="False">✘</span>
@@ -19220,7 +18813,7 @@ interface MediaStreamAudioDestinationNode : AudioNode {
                   </td>
                   <td class="prmDesc">
                     Optional initial parameter value for this
-                    <a>MediaStreamAudioDestinationNode</a>.
+                    <a>WaveShaperNode</a>.
                   </td>
                 </tr>
               </table>
@@ -19231,18 +18824,152 @@ interface MediaStreamAudioDestinationNode : AudioNode {
           <h3>
             Attributes
           </h3>
-          <dl class="attributes" data-dfn-for="MediaStreamAudioDestinationNode"
-          data-link-for="MediaStreamAudioDestinationNode">
+          <dl class="attributes" data-dfn-for="WaveShaperNode" data-link-for=
+          "WaveShaperNode">
             <dt>
-              <code><dfn>stream</dfn></code> of type <span class=
-              "idlAttrType"><a><code>MediaStream</code></a></span>, readonly
+              <code><dfn>curve</dfn></code> of type <span class=
+              "idlAttrType"><a><code>Float32Array</code></a></span>, nullable
             </dt>
             <dd>
-              A MediaStream containing a single MediaStreamTrack with the same
-              number of channels as the node itself, and whose
-              <code>kind</code> attribute has the value <code>"audio"</code>.
+              <p>
+                The shaping curve used for the waveshaping effect. The input
+                signal is nominally within the range [-1; 1]. Each input sample
+                within this range will index into the shaping curve, with a
+                signal level of zero corresponding to the center value of the
+                curve array if there are an odd number of entries, or
+                interpolated between the two centermost values if there are an
+                even number of entries in the array. Any sample value less than
+                -1 will correspond to the first value in the curve array. Any
+                sample value greater than +1 will correspond to the last value
+                in the curve array.
+              </p>
+              <p>
+                The implementation MUST perform linear interpolation between
+                adjacent points in the curve. Initially the curve attribute is
+                null, which means that the WaveShaperNode will pass its input
+                to its output without modification.
+              </p>
+              <p>
+                Values of the curve are spread with equal spacing in the [-1;
+                1] range. This means that a <a><code>curve</code></a> with a
+                even number of value will not have a value for a signal at
+                zero, and a <a><code>curve</code></a> with an odd number of
+                value will have a value for a signal at zero.
+              </p>
+              <p>
+                A <code>InvalidStateError</code> MUST be thrown if this
+                attribute is set with a <code>Float32Array</code> that has a
+                <code>length</code> less than 2.
+              </p>
+              <p>
+                When this attribute is set, an internal copy of the curve is
+                created by the <a><code>WaveShaperNode</code></a>. Subsequent
+                modifications of the contents of the array used to set the
+                attribute therefore have no effect: the attribute MUST be set
+                again in order to change the curve.
+              </p>
+              <p>
+                To set the <code>curve</code> attribute, execute these steps:
+              </p>
+              <ol>
+                <li>Let <code>new curve</code> be the <code>Float32Array</code>
+                to be assigned to <code>curve</code>.
+                </li>
+                <li>If <code>new curve</code> is not <code>null</code> and
+                <code>curve set</code> is true, throw an
+                <code>InvalidStateError</code> and abort these steps.
+                </li>
+                <li>If <code>new curve</code> is not <code>null</code>, set
+                <code>curve set</code> to true.
+                </li>
+                <li>Assign <code>new curve</code> to the <code>curve</code>
+                attribute.
+                </li>
+              </ol>
+            </dd>
+            <dt>
+              <code><dfn>overSample</dfn></code> of type <span class=
+              "idlAttrType"><a><code>OverSampleType</code></a></span>
+            </dt>
+            <dd>
+              <p>
+                Specifies what type of oversampling (if any) should be used
+                when applying the shaping curve. The default value is "none",
+                meaning the curve will be applied directly to the input
+                samples. A value of "2x" or "4x" can improve the quality of the
+                processing by avoiding some aliasing, with the "4x" value
+                yielding the highest quality. For some applications, it's
+                better to use no oversampling in order to get a very precise
+                shaping curve.
+              </p>
+              <p>
+                A value of "2x" or "4x" means that the following steps MUST be
+                performed:
+              </p>
+              <ol>
+                <li>Up-sample the input samples to 2x or 4x the sample-rate of
+                the <a><code>AudioContext</code></a>. Thus for each <a>render
+                quantum</a>, generate 256 (for 2x) or 512 (for 4x) samples.
+                </li>
+                <li>Apply the shaping curve.
+                </li>
+                <li>Down-sample the result back to the sample-rate of the
+                <a><code>AudioContext</code></a>. Thus taking the 256 (or 512)
+                processed samples, generating 128 as the final result.
+                </li>
+              </ol>
+              <p>
+                The exact up-sampling and down-sampling filters are not
+                specified, and can be tuned for sound quality (low aliasing,
+                etc.), low latency, and performance.
+              </p>
+              <p class="note">
+                Use of oversampling introduces some degree of audio processing
+                latency due to the up-sampling and down-sampling filters. The
+                amount of this latency can vary from one implementation to
+                another.
+              </p>
             </dd>
           </dl>
+        </section>
+        <section>
+          <h2>
+            <dfn>WaveShaperOptions</dfn>
+          </h2>
+          <p>
+            This specifies the options for constructing a
+            <a><code>WaveShaperNode</code></a>. All members are optional; if
+            not specified, the normal default is used in constructing the node.
+          </p>
+          <pre class="idl">
+dictionary WaveShaperOptions : AudioNodeOptions {
+             sequence&lt;float&gt; curve;
+             OverSampleType  oversample = "none";
+};
+        </pre>
+          <section>
+            <h3>
+              Dictionary <a>WaveShaperOptions</a> Members
+            </h3>
+            <dl class="attributes" data-dfn-for="WaveShaperOptions"
+            data-link-for="WaveShaperOptions">
+              <dt>
+                <code><dfn>curve</dfn></code> of type <span class=
+                "idlAttrType"><code>sequence&lt;float&gt;</code></span>
+              </dt>
+              <dd>
+                The shaping curve for the waveshaping effect.
+              </dd>
+              <dt>
+                <code><dfn>oversample</dfn></code> of type <span class=
+                "idlAttrType"><a><code>OverSampleType</code></a></span>,
+                defaulting to "none"
+              </dt>
+              <dd>
+                The type of oversampling to use for the shaping curve.
+              </dd>
+            </dl>
+          </section>
         </section>
       </section>
     </section>


### PR DESCRIPTION
The sections in Section 2: The Audio API is reordered in the following
way:

BaseAudioContext
AudioContext
OfflineAudioContext
Audiobuffer
AudioNode
AudioParam
AudioScheduledSourceNode
[everything else in alphabetical order]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/973-reorder-sections.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/c9e39f3...rtoy:6d4300b.html)