### PR TITLE
Spec document unloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -2243,7 +2243,10 @@ interface AudioContext : BaseAudioContext {
             </dt>
             <dd>
               <p>
-                If the <a>relevant settings object</a>'s <a>responsible
+                If the <a href=
+                "https://html.spec.whatwg.org/#concept-current-everything">current
+                settings object</a>'s <a href=
+                "https://html.spec.whatwg.org/#responsible-document">responsible
                 document</a> is NOT <a href=
                 "https://html.spec.whatwg.org/multipage/browsers.html#fully-active">
                 fully active</a>, throw an <code>InvalidStateError</code> and
@@ -2485,8 +2488,8 @@ interface AudioContext : BaseAudioContext {
                     This will stop rendering.
                   </div>
                 </li>
-                <li>If this <a>control message</a> is being run because the
-                document is being unloaded, abort this algorithm
+                <li>If this <a>control message</a> is being run in reaction to
+                the document is being unloaded, abort this algorithm
                 </li>
                 <div class="note">
                   We don't have to notify the control thread in this case.
@@ -3024,8 +3027,11 @@ interface OfflineAudioContext : BaseAudioContext {
             </dt>
             <dd>
               <p>
-                If the <a>relevant settings object</a>'s <a>responsible +
-                document</a> is NOT <a href=
+                If the <a href=
+                "https://html.spec.whatwg.org/#concept-current-everything">current
+                settings object</a>'s <a href=
+                "https://html.spec.whatwg.org/#responsible-document">responsible
+                + document</a> is NOT <a href=
                 "https://html.spec.whatwg.org/multipage/browsers.html#fully-active">
                 fully active</a>, throw an <code>InvalidStateError</code> and
                 abort these steps.
@@ -3264,11 +3270,9 @@ interface OfflineAudioContext : BaseAudioContext {
                 <li>Otherwise, in the case that the buffer was successfully
                 constructed, <a>begin offline rendering</a>.
                 </li>
-                <li>Append <var>promises</var> to <a>pendingPromises</a>.
+                <li>Append <var>promise</var> to <a>pendingPromises</a>.
                 </li>
                 <li>Return <var>promise</var>.
-                </li>
-                <li>Append <em>promise</em> to <a>pendingPromises</a>.
                 </li>
               </ol>
               <p>
@@ -19678,12 +19682,15 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
           Unloading a document
         </h2>
         <p>
-          When unloading a document with <a>BaseAudioContext</a>s, the
-          following steps MUST be executed:
+          Additional <a href=
+          "https://html.spec.whatwg.org/#unloading-document-cleanup-steps">unloading
+          document cleanup steps</a> are defined for document that uses
+          <a>BaseAudioContext</a>:
         </p>
         <ul>
-          <li>Reject all the promises of <a>pendingPromises</a>, for each
-          <a>AudioContext</a> and <a>OfflineAudioContext</a> of this document.
+          <li>Reject all the promises of <a>pendingPromises</a> with
+          <code>InvalidStateError</code>, for each <a>AudioContext</a> and <a>
+            OfflineAudioContext</a> of this document.
           </li>
           <li>Stop all <a>decoding thread</a>s
           </li>

--- a/index.html
+++ b/index.html
@@ -3031,7 +3031,7 @@ interface OfflineAudioContext : BaseAudioContext {
                 "https://html.spec.whatwg.org/#concept-current-everything">current
                 settings object</a>'s <a href=
                 "https://html.spec.whatwg.org/#responsible-document">responsible
-                + document</a> is NOT <a href=
+                document</a> is NOT <a href=
                 "https://html.spec.whatwg.org/multipage/browsers.html#fully-active">
                 fully active</a>, throw an <code>InvalidStateError</code> and
                 abort these steps.
@@ -19690,7 +19690,8 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
         <ul>
           <li>Reject all the promises of <a>pendingPromises</a> with
           <code>InvalidStateError</code>, for each <a>AudioContext</a> and <a>
-            OfflineAudioContext</a> of this document.
+            OfflineAudioContext</a> whose relevant global object is the same as
+            the document's associated Window.
           </li>
           <li>Stop all <a>decoding thread</a>s
           </li>

--- a/index.html
+++ b/index.html
@@ -1786,6 +1786,8 @@ interface BaseAudioContext : EventTarget {
                 (described in [[!ECMASCRIPT]]) on <a>audioData</a> is
                 <code>false</code>, execute the following steps:
                   <ol>
+                    <li>Append <var>promise</var> to <a>pendingPromises</a>.
+                    </li>
                     <li>
                       <a href=
                       "https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
@@ -1815,7 +1817,7 @@ interface BaseAudioContext : EventTarget {
                 When queuing a decoding operation to be performed on another
                 thread, the following steps MUST happen on a thread that is not
                 the <a>control thread</a> nor the <a>rendering thread</a>,
-                called the <em>decoding thread</em>.
+                called the <dfn>decoding thread</dfn>.
               </p>
               <div class="note">
                 Multiple <em>decoding threads</em> can run in parallel to
@@ -1970,8 +1972,8 @@ interface BaseAudioContext : EventTarget {
                 </li>
                 <li>If the <a>BaseAudioContext</a> is not <a>allowed to
                 start</a>, append <em>promise</em> to
-                <a>pendingResumePromises</a> and abort these steps, returning
-                <em>promise</em>.
+                <a>pendingResumePromises</a> and <a>pendingPromises</a> and
+                abort these steps, returning <em>promise</em>.
                 </li>
                 <li>Set the <em>control thread state</em> flag on the
                 <a>BaseAudioContext</a> to <code>running</code>.
@@ -2002,7 +2004,9 @@ interface BaseAudioContext : EventTarget {
                 thread</a> to execute the following, and abort these steps
                   <ol>
                     <li>Reject all promises from <a>pendingResumePromises</a>
-                    in order, then clear <a>pendingResumePromises</a>.
+                    in order, then clear <a>pendingResumePromises</a>
+                    Additionally, remove those promises from
+                    <a>pendingPromises</a>.
                     </li>
                     <li>Reject <em>promise</em>.
                     </li>
@@ -2013,6 +2017,8 @@ interface BaseAudioContext : EventTarget {
                   <ol>
                     <li>Resolve all promises from <a>pendingResumePromises</a>
                     in order, then clear <a>pendingResumePromises</a>.
+                    Additionally, remove those promises from
+                    <a>pendingPromises</a>.
                     </li>
                     <li>Resolve <em>promise</em>.
                     </li>
@@ -2237,6 +2243,13 @@ interface AudioContext : BaseAudioContext {
             </dt>
             <dd>
               <p>
+                If the <a>relevant settings object</a>'s <a>responsible
+                document</a> is NOT <a href=
+                "https://html.spec.whatwg.org/multipage/browsers.html#fully-active">
+                fully active</a>, throw an <code>InvalidStateError</code> and
+                abort these steps.
+              </p>
+              <p>
                 <span class="synchronous">When creating an <a>AudioContext</a>,
                 execute these steps:</span>
               </p>
@@ -2249,6 +2262,9 @@ interface AudioContext : BaseAudioContext {
                 </li>
                 <li>Let <dfn>pendingResumePromises</dfn> be an empty ordered
                 list of promises.
+                </li>
+                <li>Let <dfn>pendingPromises</dfn> be an empty ordered list of
+                promises.
                 </li>
                 <li>If <code>contextOptions</code> is given, apply the options:
                   <ol>
@@ -2443,11 +2459,13 @@ interface AudioContext : BaseAudioContext {
                 of the <a>AudioContext</a> is already <code>closed</code>,
                 resolve <em>promise</em>, return it, and abort these steps.
                 </li>
+                <li>Append <em>promise</em> to <a>pendingPromises</a>.
+                </li>
                 <li>Set the <em>control thread state</em> flag on the
                 <a>AudioContext</a> to <code>closed</code>.
                 </li>
                 <li>
-                  <a href="#queue">Queue a control message</a> to the
+                  <a href="#queue">Queue a control message</a> to close the
                   <a>AudioContext</a>.
                 </li>
                 <li>Return <em>promise</em>.
@@ -2463,7 +2481,16 @@ interface AudioContext : BaseAudioContext {
                 </li>
                 <li>Set the <a>rendering thread state</a> to
                 <code>suspended</code>.
+                  <div class="note">
+                    This will stop rendering.
+                  </div>
                 </li>
+                <li>If this <a>control message</a> is being run because the
+                document is being unloaded, abort this algorithm
+                </li>
+                <div class="note">
+                  We don't have to notify the control thread in this case.
+                </div>
                 <li>Queue a task on the <a>control thread</a>'s event loop, to
                 execute these steps:
                   <ol>
@@ -2788,6 +2815,8 @@ interface AudioContext : BaseAudioContext {
                 of the <a>AudioContext</a> is already <code>suspended</code>,
                 resolve <em>promise</em>, return it, and abort these steps.
                 </li>
+                <li>Append <em>promise</em> to <a>pendingPromises</a>.
+                </li>
                 <li>Set the <em>control thread state</em> flag on the
                 <a>AudioContext</a> to <code>suspended</code>.
                 </li>
@@ -2994,6 +3023,13 @@ interface OfflineAudioContext : BaseAudioContext {
               <code><dfn>OfflineAudioContext</dfn></code>
             </dt>
             <dd>
+              <p>
+                If the <a>relevant settings object</a>'s <a>responsible +
+                document</a> is NOT <a href=
+                "https://html.spec.whatwg.org/multipage/browsers.html#fully-active">
+                fully active</a>, throw an <code>InvalidStateError</code> and
+                abort these steps.
+              </p>
               <p>
                 Let <var>c</var> be a new <a>OfflineAudioContext</a> object.
                 Initialize <var>c</var> as follows:
@@ -3228,7 +3264,11 @@ interface OfflineAudioContext : BaseAudioContext {
                 <li>Otherwise, in the case that the buffer was successfully
                 constructed, <a>begin offline rendering</a>.
                 </li>
+                <li>Append <var>promises</var> to <a>pendingPromises</a>.
+                </li>
                 <li>Return <var>promise</var>.
+                </li>
+                <li>Append <em>promise</em> to <a>pendingPromises</a>.
                 </li>
               </ol>
               <p>
@@ -19630,6 +19670,26 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
               buffer</a> and the value(s) of the <a>AudioParam</a>(s) of this
               <a>AudioNode</a> as the input for this algorithm.
             </p>
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h2>
+          Unloading a document
+        </h2>
+        <p>
+          When unloading a document with <a>BaseAudioContext</a>s, the
+          following steps MUST be executed:
+        </p>
+        <ul>
+          <li>Reject all the promises of <a>pendingPromises</a>, for each
+          <a>AudioContext</a> and <a>OfflineAudioContext</a> of this document.
+          </li>
+          <li>Stop all <a>decoding thread</a>s
+          </li>
+          <li>
+            <a href="#queue">Queue a control message</a> to close the
+            <a>AudioContext</a>.
           </li>
         </ul>
       </section>


### PR DESCRIPTION
This does the following:
- Keep all promises around, so we can deal with them on unload
- Spec what to do when unloading a document: very similar to calling `close()` on all audiocontext
- This stops the rendering of AudioContext, stops decoding of decodeAudioData tasks, stop the rendering of OfflineAudioContext.
- A consequence of this is that there won't be any audio output anymore.
- Another consequence of this (because the rendering loop does not running anymore) is that any control message sent by Web Audio API objects are never going to be executed. We don't have to check for "active document" everywhere.

This deals with #1139.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/padenot/web-audio-api/unload.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/8b7d14d...padenot:47a8e9d.html)