### PR TITLE
Throw when the MST passed to the MediaStreamTrackAudioSourceNode's is not an audio track.

### DIFF
--- a/index.html
+++ b/index.html
@@ -14756,7 +14756,10 @@ dictionary MediaStreamTrackAudioSourceOptions {
                 "idlAttrType"><code>MediaStreamTrack</code></span>, readonly
               </dt>
               <dd>
-                The audio media stream track that will act as a source.
+                The media stream track that will act as a source. If this
+                <code>MediaStreamTrack</code> <code>kind</code> attribute is
+                not <code>"audio"</code>, an <code>InvalidStateError</code>
+                MUST be thrown.
               </dd>
             </dl>
           </section>


### PR DESCRIPTION
This fixes #1424.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/padenot/web-audio-api/1424-mstasn.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/8b7d14d...padenot:4bb42e3.html)