### PR TITLE
Fix #1426: ChannelMerger channelCountMode is "explicit"

### DIFF
--- a/index.html
+++ b/index.html
@@ -11092,7 +11092,7 @@ $$
                 <a data-link-for="AudioNode">channelCountMode</a>
               </td>
               <td>
-                "<a data-link-for="channelCountMode">max</a>"
+                "<a data-link-for="channelCountMode">explicit</a>"
               </td>
               <td>
                 Has <a>channelCountMode constraints</a>


### PR DESCRIPTION
In the node property table, set the mode to "explicit" instead of
"max"; it should be explicit, as mentioned in the channelCountMode
constraints section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1426-set-channel-merger-mode-correctly.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/543e3f9...rtoy:43f2376.html)