### PR TITLE
Fix #1437: Add node property tables for AudioDestinationNode

### DIFF
--- a/index.html
+++ b/index.html
@@ -8716,11 +8716,6 @@ function process(numberOfFrames) {
           example, a <a><code>MediaStreamAudioDestinationNode</code></a>, or a
           <code>MediaRecorder</code> (described in [[mediastream-recording]]).
         </p>
-        <pre>
-      numberOfInputs  : 1
-      numberOfOutputs : 1
-
-</pre>
         <p>
           The <a>AudioDestinationNode</a> can be either the destination of an
           <a>AudioContext</a> or <a>OfflineAudioContext</a>, and the channel
@@ -8729,11 +8724,75 @@ function process(numberOfFrames) {
         <p>
           For an <a>AudioContext</a>, the defaults are
         </p>
-        <pre>
-      channelCount = 2
-      channelCountMode = "explicit"
-      channelInterpretation = "speakers"
-</pre>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
         <p>
           The <a data-link-for="AudioNode">channelCount</a> can be set to any
           value less than or equal to <a data-link-for=
@@ -8747,11 +8806,75 @@ function process(numberOfFrames) {
         <p>
           For an <a>OfflineAudioContext</a>, the defaults are
         </p>
-        <pre>
-      channelCount = numberOfChannels
-      channelCountMode = "explicit"
-      channelInterpretation = "speakers"
-</pre>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                <code>numberOfChannels</code>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
         <p>
           where <code>numberOfChannels</code> is the number of channels
           specified when constructing the <a>OfflineAudioContext</a>. This


### PR DESCRIPTION
Add node property tables for the AudioDestinationNode.  This makes
this node match how other audio nodes are described in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1437-audio-dest-node-tables.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/0e15b53...rtoy:a5de046.html)