### PR TITLE
Serialize AudioWorkletNode options dictionary to audio thread side.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18734,23 +18734,38 @@ interface AudioWorkletProcessor {
                 <code>AudioWorkletProcessor</code>
               </dt>
               <dd>
-                Initializes the <a>AudioWorkletProcessor</a> using the contents
-                of the <code>options</code> dictionary that was passed to the
-                constructor for <a>AudioWorkletNode</a>. The contents of this
-                dictionary will have been serialized and deserialized according
-                to the algorithm for <a href=
-                "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">instantiating
-                an AudioWorkletProcessor</a>.
+                When the constructor for <a>AudioWorkletProcessor</a> is
+                invoked, the following steps are performed:
+                <ol>
+                  <li>Compare the value of NewTarget with the <a href=
+                  "https://tc39.github.io/ecma262/#active-function-object">active
+                  function object</a>; if the two are equal, throw a
+                  <code>TypeError</code> is thrown.
+                    <div class="note">
+                      This check prevents the invocation of the constructor
+                      directly from JavaScript. The interface object may only
+                      be called internally by the UA.
+                    </div>
+                  </li>
+                  <li>Initialize the <a>AudioWorkletProcessor</a> using the
+                  contents of the <code>options</code> dictionary that was
+                  passed to the constructor for <a>AudioWorkletNode</a>. The
+                  contents of this dictionary will have been serialized and
+                  deserialized according to the algorithm for <a href=
+                  "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">
+                    instantiating an AudioWorkletProcessor</a>.
+                    <div class="note">
+                      The base implementation of <a>AudioWorkletProcessor</a>
+                      does not examine the values in the <code>options</code>
+                      dictionary. However, processor classes that extend
+                      <a>AudioWorkletProcessor</a> will use this dictionary to
+                      initialize themselves based on the options relevant to
+                      their specific node type.
+                    </div>
+                  </li>
+                </ol>
               </dd>
             </dl>
-            <div class="note">
-              The base implementation of <a>AudioWorkletProcessor</a> does not
-              examine the values in the <code>options</code> dictionary.
-              However, processor classes that extend
-              <a>AudioWorkletProcessor</a> will use this dictionary to
-              initialize themselves based on the options relevant to their
-              specific node type.
-            </div>
           </section>
           <section>
             <h3>

--- a/index.html
+++ b/index.html
@@ -19023,25 +19023,9 @@ dictionary AudioParamDescriptor {
               StructuredSerializeWithTransfer</a>(<var>processorPortOnThisSide</var>,
               « <var>processorPortOnThisSide</var> »).
             </li>
-            <li>Let <var>optionsTransferables</var> be an empty list.
-            </li>
-            <li>For each value <var>optionsValue</var> in a key/value pair
-            within <var>options</var>:
-            </li>
-            <ol>
-              <li>If <var>optionsValue</var> has either an [[ArrayBufferData]]
-              internal slot or is a <a href=
-              "https://heycam.github.io/webidl/#dfn-platform-object">platform
-              object</a> that is a <a href=
-              "https://html.spec.whatwg.org/multipage/structured-data.html#transferable-objects">
-                transferable object</a>, then append <var>optionsValue</var> to
-                <var>optionsTransferables</var>.
-              </li>
-            </ol>
             <li>Let <var>optionsSerialization</var> be <a href=
-            "https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserializewithtransfer">
-              StructuredSerializeWithTransfer</a>(<var>options</var>, «
-              <var>optionsTransferables</var> »).
+            "https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserialize">
+              StructuredSerialize</a>(<var>options</var>).
             </li>
             <li>Set <var>node</var>'s <a data-link-for=
             "AudioWorkletNode">port</a> to <var>nodePort</var>.
@@ -19126,8 +19110,8 @@ dictionary AudioParamDescriptor {
             </li>
             <li>Let <var>options</var> be <a href=
             "https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
-              StructuredDeserializeWithTransfer</a>(<var>optionsSerialization</var>,
-              the current Realm).
+              StructuredDeserialize</a>(<var>optionsSerialization</var>, the
+              current Realm).
             </li>
             <li>Let <var>processorConstructor</var> be the result of looking up
             <var>nodeName</var> on the <a>AudioWorkletGlobalScope</a>'s <a>node

--- a/index.html
+++ b/index.html
@@ -18718,11 +18718,40 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
             reference</dfn>, initially null.
           </p>
           <pre class="idl">
-[Exposed=AudioWorklet]
+[Exposed=AudioWorklet,
+ Constructor (optional AudioWorkletOptions options)]
 interface AudioWorkletProcessor {
     readonly        attribute MessagePort port;
 };
           </pre>
+          <section>
+            <h3>
+              Constructors
+            </h3>
+            <dl class="methods" data-dfn-for="AudioWorkletProcessor"
+            data-link-for="AudioWorkletProcessor">
+              <dt>
+                <code>AudioWorkletProcessor</code>
+              </dt>
+              <dd>
+                Initializes the <a>AudioWorkletProcessor</a> using the contents
+                of the <code>options</code> dictionary that was passed to the
+                constructor for <a>AudioWorkletNode</a>. The contents of this
+                dictionary will have been serialized and deserialized according
+                to the algorithm for <a href=
+                "#instantiation-of-AudioWorkletNode-and-AudioWorkletProcessor">instantiating
+                an AudioWorkletProcessor</a>.
+              </dd>
+            </dl>
+            <div class="note">
+              The base implementation of <a>AudioWorkletProcessor</a> does not
+              examine the values in the <code>options</code> dictionary.
+              However, processor classes that extend
+              <a>AudioWorkletProcessor</a> will use this dictionary to
+              initialize themselves based on the options relevant to their
+              specific node type.
+            </div>
+          </section>
           <section>
             <h3>
               Attributes

--- a/index.html
+++ b/index.html
@@ -19023,6 +19023,26 @@ dictionary AudioParamDescriptor {
               StructuredSerializeWithTransfer</a>(<var>processorPortOnThisSide</var>,
               « <var>processorPortOnThisSide</var> »).
             </li>
+            <li>Let <var>optionsTransferables</var> be an empty list.
+            </li>
+            <li>For each value <var>optionsValue</var> in a key/value pair
+            within <var>options</var>:
+            </li>
+            <ol>
+              <li>If <var>optionsValue</var> has either an [[ArrayBufferData]]
+              internal slot or is a <a href=
+              "https://heycam.github.io/webidl/#dfn-platform-object">platform
+              object</a> that is a <a href=
+              "https://html.spec.whatwg.org/multipage/structured-data.html#transferable-objects">
+                transferable object</a>, then append <var>optionsValue</var> to
+                <var>optionsTransferables</var>.
+              </li>
+            </ol>
+            <li>Let <var>optionsSerialization</var> be <a href=
+            "https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserializewithtransfer">
+              StructuredSerializeWithTransfer</a>(<var>options</var>, «
+              <var>optionsTransferables</var> »).
+            </li>
             <li>Set <var>node</var>'s <a data-link-for=
             "AudioWorkletNode">port</a> to <var>nodePort</var>.
             </li>
@@ -19080,7 +19100,8 @@ dictionary AudioParamDescriptor {
             <li>
               <a href="#queuing">Queue a control message</a> to create an
               <a>AudioWorkletProcessor</a>, given <var>nodeName</var>,
-              <var>processorPortSerialization</var>, and <var>node</var>.
+              <var>processorPortSerialization</var>,
+              <var>optionsSerialization</var> and <var>node</var>.
             </li>
             <li>Return <var>node</var>.
             </li>
@@ -19103,6 +19124,11 @@ dictionary AudioParamDescriptor {
               StructuredDeserializeWithTransfer</a>(<var>processorPortSerialization</var>,
               the current Realm).
             </li>
+            <li>Let <var>options</var> be <a href=
+            "https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
+              StructuredDeserializeWithTransfer</a>(<var>optionsSerialization</var>,
+              the current Realm).
+            </li>
             <li>Let <var>processorConstructor</var> be the result of looking up
             <var>nodeName</var> on the <a>AudioWorkletGlobalScope</a>'s <a>node
             name to processor definition map</a>.
@@ -19111,7 +19137,7 @@ dictionary AudioParamDescriptor {
             throw a <code>NotSupportedError</code> DOMException.
             </li>
             <li>Let <var>processor</var> be the result of
-            Construct(<var>processorConstructor</var>).
+            Construct(<var>processorConstructor</var>, « <var>options</var> »).
             </li>
             <li>If <var>processor</var> does not implement the
             <a>AudioWorkletProcessor</a> interface, throw an


### PR DESCRIPTION
Fix #1442


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/1442-bring-back-awp-options.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/b027c50...86eaf1c.html)