### PR TITLE
Fix #1448: Be explicit about node properties for source nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4504,7 +4504,9 @@ interface AudioNode : EventTarget {
               <p>
                 <a>channelCountMode</a> determines how channels will be counted
                 when up-mixing and down-mixing connections to any inputs to the
-                node. This attribute has no effect for nodes with no inputs.
+                node. The default value is "<a data-link-for=
+                "channelCountMode">max</a>". This attribute has no effect for
+                nodes with no inputs.
               </p>
               <p>
                 In addition, some nodes have additional <dfn>channelCountMode
@@ -4600,8 +4602,9 @@ interface AudioNode : EventTarget {
               <p>
                 <a>channelInterpretation</a> determines how individual channels
                 will be treated when up-mixing and down-mixing connections to
-                any inputs to the node. This attribute has no effect for nodes
-                with no inputs.
+                any inputs to the node. The default value is "<a data-link-for=
+                "channelInterpretation">speakers</a>". This attribute has no
+                effect for nodes with no inputs.
               </p>
               <p>
                 In addition, some nodes have additional
@@ -7715,6 +7718,33 @@ dictionary AnalyserOptions : AudioNodeOptions {
               </td>
               <td>
                 1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
               </td>
               <td></td>
             </tr>
@@ -11706,6 +11736,33 @@ dictionary ChannelSplitterOptions : AudioNodeOptions {
             </tr>
             <tr>
               <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
                 <a>tail-time</a> reference
               </td>
               <td>
@@ -15016,6 +15073,33 @@ dictionary MediaStreamTrackAudioSourceOptions {
               </td>
               <td>
                 1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">max</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
               </td>
               <td></td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -8760,11 +8760,6 @@ function process(numberOfFrames) {
           example, a <a><code>MediaStreamAudioDestinationNode</code></a>, or a
           <code>MediaRecorder</code> (described in [[mediastream-recording]]).
         </p>
-        <pre>
-      numberOfInputs  : 1
-      numberOfOutputs : 1
-
-</pre>
         <p>
           The <a>AudioDestinationNode</a> can be either the destination of an
           <a>AudioContext</a> or <a>OfflineAudioContext</a>, and the channel
@@ -8773,11 +8768,75 @@ function process(numberOfFrames) {
         <p>
           For an <a>AudioContext</a>, the defaults are
         </p>
-        <pre>
-      channelCount = 2
-      channelCountMode = "explicit"
-      channelInterpretation = "speakers"
-</pre>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                2
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
         <p>
           The <a data-link-for="AudioNode">channelCount</a> can be set to any
           value less than or equal to <a data-link-for=
@@ -8791,11 +8850,75 @@ function process(numberOfFrames) {
         <p>
           For an <a>OfflineAudioContext</a>, the defaults are
         </p>
-        <pre>
-      channelCount = numberOfChannels
-      channelCountMode = "explicit"
-      channelInterpretation = "speakers"
-</pre>
+        <div class="node-info">
+          <table>
+            <tr>
+              <th>
+                Property
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfInputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">numberOfOutputs</a>
+              </td>
+              <td>
+                1
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCount</a>
+              </td>
+              <td>
+                <code>numberOfChannels</code>
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelCountMode</a>
+              </td>
+              <td>
+                "<a data-link-for="channelCountMode">explicit</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a data-link-for="AudioNode">channelInterpretation</a>
+              </td>
+              <td>
+                "<a data-link-for="channelInterpretation">speakers</a>"
+              </td>
+              <td></td>
+            </tr>
+            <tr>
+              <td>
+                <a>tail-time</a> reference
+              </td>
+              <td>
+                No
+              </td>
+              <td></td>
+            </tr>
+          </table>
+        </div>
         <p>
           where <code>numberOfChannels</code> is the number of channels
           specified when constructing the <a>OfflineAudioContext</a>. This


### PR DESCRIPTION
Explicitly say what the channel count, mode, and interpretation values
are for source nodes.  Also specify default values mode and
interpretation in the definition of these attributes in `AudioNode`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/rtoy/web-audio-api/1448-explicit-node-props-for-sources.html) | [Diff](https://s3.amazonaws.com/pr-preview/WebAudio/web-audio-api/b027c50...rtoy:3eb8dd7.html)