### PR TITLE
A few minor editorial fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4453,7 +4453,7 @@ interface AudioNode : EventTarget {
                 <dd>
                   The channel count cannot changed from two, and a <span class=
                   "synchronous"><code>NotSupportedError</code> exception MUST
-                  be thrown for any attempt to change the value..</span>
+                  be thrown for any attempt to change the value.</span>
                 </dd>
                 <dt>
                   <a>DynamicsCompressorNode</a>
@@ -5515,9 +5515,9 @@ dictionary AudioNodeOptions {
         </p>
         <p>
           Some synthesis and processing <a><code>AudioNode</code></a>s have
-          <code>AudioParams</code> as attributes whose values MUST be taken
+          <code>AudioParam</code>s as attributes whose values MUST be taken
           into account on a per-audio-sample basis. For other
-          <code>AudioParams</code>, sample-accuracy is not important and the
+          <code>AudioParam</code>s, sample-accuracy is not important and the
           value changes can be sampled more coarsely. Each individual
           <code>AudioParam</code> will specify that it is either an
           <a>a-rate</a> parameter which means that its values MUST be taken
@@ -5551,13 +5551,13 @@ dictionary AudioNodeOptions {
           possible range. In this case, <a data-link-for=
           "AudioParam">maxValue</a> should be set to the
           <dfn>most-positive-single-float</dfn> value, which is 3.4028235e38.
-          (However, in Javascript which only supports IEEE-754 double precision
+          (However, in JavaScript which only supports IEEE-754 double precision
           float values, this must be written as 3.4028234663852886e38.)
           Similarly, <a data-link-for="AudioParam">minValue</a> should be set
           to the <dfn>most-negative-single-float</dfn> value, which is the
           negative of the <a>most-positive-single-float</a>: -3.4028235e38.
-          (Similarly, this must be written in Javascript as
-          -3.4028234663852886e38)
+          (Similarly, this must be written in JavaScript as
+          -3.4028234663852886e38.)
         </p>
         <p>
           An <code>AudioParam</code> maintains a list of zero or more <dfn id=
@@ -5974,8 +5974,9 @@ interface AudioParam {
                 time constant.
               </p>
               <p>
-                If there are no more events after this ExponentialRampToValue
-                event then for \(t \geq T_1\), \(v(t) = V_1\).
+                If there are no more events after this
+                <em>ExponentialRampToValue</em> event then for \(t \geq T_1\),
+                \(v(t) = V_1\).
               </p>
               <p>
                 If there is no event preceding this event, the exponential ramp
@@ -6091,8 +6092,9 @@ interface AudioParam {
                 the <code>value</code> parameter passed into this method.
               </p>
               <p>
-                If there are no more events after this LinearRampToValue event
-                then for \(t \geq T_1\), \(v(t) = V_1\).
+                If there are no more events after this
+                <em>LinearRampToValue</em> event then for \(t \geq T_1\),
+                \(v(t) = V_1\).
               </p>
               <p>
                 If there is no event preceding this event, the linear ramp
@@ -6529,7 +6531,7 @@ interface AudioParam {
                     value curve will be applied. <span class="synchronous">A
                     RangeError exception MUST be thrown if
                     <code>startTime</code> is negative or is not a finite
-                    number.</span>. If <var>startTime</var> is less than
+                    number</span>. If <var>startTime</var> is less than
                     <a data-link-for="BaseAudioContext">currentTime</a>, it is
                     clamped to <a data-link-for=
                     "BaseAudioContext">currentTime</a>.
@@ -6628,7 +6630,7 @@ interface AudioParam {
           <pre class="example">
             N.p.setValueAtTime(0, 0);
             N.p.linearRampToValueAtTime(4, 1);
-            N.p.linearRampToValueAtTime(0, 2)
+            N.p.linearRampToValueAtTime(0, 2);
 </pre>
           <p>
             The initial slope of the curve is 4, until it reaches the maximum
@@ -8330,7 +8332,7 @@ dictionary AudioBufferSourceOptions {
               </dd>
               <dt>
                 <code><dfn>detune</dfn></code> of type <span class=
-                "idlAttrType"><code>float</code>&gt;</span>, defaulting to 0
+                "idlAttrType"><code>float</code></span>, defaulting to 0
               </dt>
               <dd>
                 The initial value for the <a data-link-for=
@@ -8589,7 +8591,7 @@ function process(numberOfFrames) {
   if (buffer == null) {
     stop = currentTime; // force zero output for all time
   }
-}
+
   // Render each sample frame in the quantum
   for (let index = 0; index &lt; numberOfFrames; index++) {
     // Check that currentTime is within allowable range for playback

--- a/index.html
+++ b/index.html
@@ -5515,8 +5515,8 @@ dictionary AudioNodeOptions {
         </p>
         <p>
           Some synthesis and processing <a><code>AudioNode</code></a>s have
-          <code>AudioParam</code>s as attributes whose values MUST be taken
-          into account on a per-audio-sample basis. For other
+          <a><code>AudioParam</code></a>s as attributes whose values MUST be
+          taken into account on a per-audio-sample basis. For other
           <code>AudioParam</code>s, sample-accuracy is not important and the
           value changes can be sampled more coarsely. Each individual
           <code>AudioParam</code> will specify that it is either an


### PR DESCRIPTION
This PR contains a few very minor editorial fixes I found while reading through the spec:

- Formatting of plural AudioParams
- Capitalisation of JavaScript
- Use `<em>` for event names
- Removed extra `}` in example code
- Punctuation


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/web-audio-api/pull/1455.html" title="Last updated on Nov 28, 2017, 9:04 AM GMT">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/b027c50...chrisn:28e5a79.html" title="Last updated on Nov 28, 2017, 9:04 AM GMT">Diff</a>