### PR TITLE
Fix #1461: AudioWorkletNode/Processor IDL: incorrect constructor argument

### DIFF
--- a/index.html
+++ b/index.html
@@ -18538,7 +18538,7 @@ enum AudioWorkletProcessorState {
           </table>
           <pre class="idl">
 [Exposed=Window, SecureContext,
- Constructor (BaseAudioContext context, optional AudioWorkletNodeOptions options)]
+ Constructor (BaseAudioContext context, DOMString name, optional AudioWorkletNodeOptions options)]
 interface AudioWorkletNode : AudioNode {
     readonly        attribute AudioParamMap              parameters;
     readonly        attribute MessagePort                port;
@@ -18820,7 +18820,7 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
           </p>
           <pre class="idl">
 [Exposed=AudioWorklet,
- Constructor (optional AudioWorkletOptions options)]
+ Constructor (optional AudioWorkletNodeOptions options)]
 interface AudioWorkletProcessor {
     readonly        attribute MessagePort port;
 };

--- a/index.html
+++ b/index.html
@@ -18538,7 +18538,7 @@ enum AudioWorkletProcessorState {
           </table>
           <pre class="idl">
 [Exposed=Window, SecureContext,
- Constructor (BaseAudioContext context, optional AudioWorkletOptions options)]
+ Constructor (BaseAudioContext context, optional AudioWorkletNodeOptions options)]
 interface AudioWorkletNode : AudioNode {
     readonly        attribute AudioParamMap              parameters;
     readonly        attribute MessagePort                port;
@@ -18608,7 +18608,7 @@ interface AudioWorkletNode : AudioNode {
                       options
                     </td>
                     <td class="prmType">
-                      <a><code>AudioWorkletOptions</code></a>
+                      <a><code>AudioWorkletNodeOptions</code></a>
                     </td>
                     <td class="prmNullFalse">
                       <span role="img" aria-label="False">✘</span>


### PR DESCRIPTION
- Rename AudioWorkletOptions to AudioWorkletNodeOptions
- Add name parameter to AudioWorkletNode constructor.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1476.html" title="Last updated on Jan 23, 2018, 5:44 PM GMT (b323292)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1476/2e75c34...rtoy:b323292.html" title="Last updated on Jan 23, 2018, 5:44 PM GMT (b323292)">Diff</a>