### PR TITLE
Fix #1647: Cycles include connecting to an AudioParam

### DIFF
--- a/index.html
+++ b/index.html
@@ -4793,11 +4793,10 @@ interface AudioNode : EventTarget {
                     <a><code>AudioNode</code></a> which creates a
                     <dfn>cycle</dfn>: an <a><code>AudioNode</code></a> may
                     connect to another <a><code>AudioNode</code></a>, which in
-                    turn connects back to the first
-                    <a><code>AudioNode</code></a> connecting to an input or an
-                    <a>AudioParam</a>. This is allowed only if there is at
-                    least one <a><code>DelayNode</code></a> in the
-                    <em>cycle</em> <span class="synchronous">or a
+                    turn connects back to the input or <a>AudioParam</a> of the
+                    first <a><code>AudioNode</code></a>. This is allowed only
+                    if there is at least one <a><code>DelayNode</code></a> in
+                    the <em>cycle</em> <span class="synchronous">or a
                     <code>NotSupportedError</code> exception MUST be
                     thrown.</span>
                   </td>

--- a/index.html
+++ b/index.html
@@ -4794,8 +4794,9 @@ interface AudioNode : EventTarget {
                     <dfn>cycle</dfn>: an <a><code>AudioNode</code></a> may
                     connect to another <a><code>AudioNode</code></a>, which in
                     turn connects back to the first
-                    <a><code>AudioNode</code></a>. This is allowed only if
-                    there is at least one <a><code>DelayNode</code></a> in the
+                    <a><code>AudioNode</code></a> connecting to an input or an
+                    <a>AudioParam</a>. This is allowed only if there is at
+                    least one <a><code>DelayNode</code></a> in the
                     <em>cycle</em> <span class="synchronous">or a
                     <code>NotSupportedError</code> exception MUST be
                     thrown.</span>


### PR DESCRIPTION
Update definition of cycle to mention that connections to an
AudioParam also creates a cycle, just like connecting to an input.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1477.html" title="Last updated on Jan 31, 2018, 9:50 PM GMT (d963e55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1477/2e75c34...rtoy:d963e55.html" title="Last updated on Jan 31, 2018, 9:50 PM GMT (d963e55)">Diff</a>