### PR TITLE
Fix #1450: Odd text in VuMeter example

### DIFF
--- a/index.html
+++ b/index.html
@@ -19453,7 +19453,7 @@ registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
               communication (asynchronous) between
               <a><code>AudioWorkletNode</code></a> and
               <a><code>AudioWorkletProcessor</code></a>. This node does not
-              produce use any output.
+              produce any output.
             </p>
             <pre class="example" title=
             "VUMeterNode - Global Scope (vumeternode.js)">

--- a/index.html
+++ b/index.html
@@ -19452,8 +19452,8 @@ registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
               constructor options and encapsulating the inter-thread
               communication (asynchronous) between
               <a><code>AudioWorkletNode</code></a> and
-              <a><code>AudioWorkletProcessor</code></a> in clean method calls
-              and attribute accesses. This node does not use any output.
+              <a><code>AudioWorkletProcessor</code></a>. This node does not
+              produce use any output.
             </p>
             <pre class="example" title=
             "VUMeterNode - Global Scope (vumeternode.js)">


### PR DESCRIPTION
Remove unclear text and correct typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1482.html" title="Last updated on Feb 5, 2018, 6:36 PM GMT (730d304)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1482/2e75c34...rtoy:730d304.html" title="Last updated on Feb 5, 2018, 6:36 PM GMT (730d304)">Diff</a>