### PR TITLE
Fix #1484: refDistance should be non-negative (or zero)

### DIFF
--- a/index.html
+++ b/index.html
@@ -16449,7 +16449,7 @@ interface PannerNode : AudioNode {
               A reference distance for reducing volume as source moves further
               from the listener. The default value is 1. A
               <code>RangeError</code> exception MUST be thrown if this is set
-              to a non-negative value.
+              to a non-positive value.
             </dd>
             <dt>
               <code><dfn>rolloffFactor</dfn></code> of type <span class=


### PR DESCRIPTION
Fix typo.  An error should be thrown for non-positive values.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1485.html" title="Last updated on Feb 6, 2018, 4:33 PM GMT (8373a2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1485/eb1cecc...rtoy:8373a2e.html" title="Last updated on Feb 6, 2018, 4:33 PM GMT (8373a2e)">Diff</a>