### PR TITLE
Fix #1459: Add processorOptions to AudioWorkletNodeOptions dictionary

### DIFF
--- a/index.html
+++ b/index.html
@@ -18697,6 +18697,7 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
              unsigned long             numberOfOutputs = 1;
              sequence&lt;unsigned long&gt;    outputChannelCount;
              record&lt;DOMString, double&gt;  parameterData;
+             Object processorOptions = null;
 };
             </pre>
             <section>
@@ -18752,6 +18753,15 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
                   <a>AudioWorkletNode</a>. If the string key of an entry in the
                   list does not match any name of <a>AudioParam</a> objects in
                   the node, it is ignored.
+                </dd>
+                <dt>
+                  <code><dfn>processorOptions</dfn></code> of type
+                  <code>Object</code>.
+                </dt>
+                <dd>
+                  This holds any additional user-defined data that may be used
+                  to initialize the corresponding <a>AudioWorkletProcessor</a>
+                  for this <a>AudioWorkletNode</a>.
                 </dd>
               </dl>
             </section>


### PR DESCRIPTION
Add another member to `AudioWorkletNodeOptions` dictionary that is
passed to the corresponding `AudioWorkletProcessor` to allow
initialization of the processor with user-defined data.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1492.html" title="Last updated on Feb 12, 2018, 5:20 PM GMT (0de84b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1492/bc49e55...rtoy:0de84b1.html" title="Last updated on Feb 12, 2018, 5:20 PM GMT (0de84b1)">Diff</a>