### PR TITLE
Fix #1483: rolloffFactor throws errors when invalid

### DIFF
--- a/index.html
+++ b/index.html
@@ -16458,7 +16458,8 @@ interface PannerNode : AudioNode {
             <dd>
               <p>
                 Describes how quickly the volume is reduced as source moves
-                away from listener. The default value is 1.
+                away from listener. The default value is 1. A RangeError
+                exception MUST be thrown if this is set to a negative value.
               </p>
               <p>
                 The nominal range for the <code>rolloffFactor</code> specifies


### PR DESCRIPTION
To be consistent with `refDistance` and `maxDistance,` specify that
setting `rolloffFactor` to a negative value should throe an error.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1494.html" title="Last updated on Feb 13, 2018, 5:24 PM GMT (4227d00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1494/bc49e55...rtoy:4227d00.html" title="Last updated on Feb 13, 2018, 5:24 PM GMT (4227d00)">Diff</a>