### PR TITLE
Fix #1478: Add note about WaveShaperNode outputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -17951,6 +17951,12 @@ interface WaveShaperNode : AudioNode {
                 attribute.
                 </li>
               </ol>
+              <p class="note">
+                The use of a curve that produces a non-zero output value for
+                zero input value will cause this node to produce a DC signal
+                even if there are no inputs connected to this node. This will
+                persist until the node is disconnected from downstream nodes.
+              </p>
             </dd>
             <dt>
               <code><dfn>overSample</dfn></code> of type <span class=


### PR DESCRIPTION
Add note that this node will output non-zero data forever if the curve
is such that there is a non-zero output value for zero input value.
This persists until the node is disconnected.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1497.html" title="Last updated on Feb 15, 2018, 11:01 PM GMT (724d992)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1497/af49d6c...rtoy:724d992.html" title="Last updated on Feb 15, 2018, 11:01 PM GMT (724d992)">Diff</a>