### PR TITLE
Revise AudioWorkletNode IDL: `AudioWorkletProcessorState` and `onprocessorerror`

### DIFF
--- a/index.html
+++ b/index.html
@@ -18578,17 +18578,16 @@ interface AudioWorkletNode : AudioNode {
             <dl class="attributes" data-dfn-for="AudioWorkletNode"
             data-link-for="AudioWorkletNode">
               <dt>
-                <code><dfn>onprocessorerror</dfn></code> of type
-                <span class=
+                <code><dfn>onprocessorerror</dfn></code> of type <span class=
                 "idlAttrType"><a><code>EventHandler</code></a></span>
               </dt>
               <dd>
                 When an exception is thrown from the processor's
                 <code>constructor</code>, <code>process</code> method, or any
                 user-defined class method, the processor will queue a task on
-                the control thread to fire <a>onprocessorerror</a> event
-                to the node. Note that once an exception is thrown, the
-                processor will output silence throughout its lifetime.
+                the control thread to fire <a>onprocessorerror</a> event to the
+                node. Note that once an exception is thrown, the processor will
+                output silence throughout its lifetime.
               </dd>
               <dt>
                 <code><dfn>parameters</dfn></code> of type <span class=

--- a/index.html
+++ b/index.html
@@ -5433,10 +5433,6 @@ dictionary AudioNodeOptions {
             <em>playing</em> reference to themselves while they are currently
             playing.
             </li>
-            <li>An <dfn>active reference</dfn> for <a>AudioWorkletNode</a>s
-            whose <a data-link-for="AudioWorkletNode">processorState</a>
-            property is set to <code>running</code>.
-            </li>
             <li>A <em>connection</em> reference which occurs if another
             <a>AudioNode</a> is connected to one or more of its inputs.
             Connections to a node's <a>AudioParam</a>s do not imply a
@@ -18590,7 +18586,7 @@ interface AudioWorkletNode : AudioNode {
                 When an exception is thrown from the processor's
                 <code>constructor</code>, <code>process</code> method, or any
                 user-defined class method, the processor will queue a task on
-                the control thread to fire <a>onprocessorstatechange</a> event
+                the control thread to fire <a>onprocessorerror</a> event
                 to the node. Note that once an exception is thrown, the
                 processor will output silence throughout its lifetime.
               </dd>
@@ -19198,8 +19194,8 @@ dictionary AudioParamDescriptor {
             an exception (either explicitly or implicitly), abort the rest of
             steps and queue a task on the <a>control thread</a> to fire
             <a data-link-for=
-            "AudioWorkletNode"><code>onprocessorstatechange</code></a> event to
-            <var>node</var> with <code>error</code> state.
+            "AudioWorkletNode"><code>onprocessorerror</code></a> event to
+            <var>node</var>.
           </p>
           <ol>
             <li>Let <var>processorPort</var> be <a href=

--- a/index.html
+++ b/index.html
@@ -18488,69 +18488,12 @@ interface AudioParamMap {
             <code>readonly maplike</code>.
           </p>
           <pre class="idl">
-enum AudioWorkletProcessorState {
-    "pending",
-    "running",
-    "stopped",
-    "error"
-};
-          </pre>
-          <table class="simple" data-dfn-for="AudioWorkletProcessorState"
-          data-link-for="AudioWorkletProcessorState">
-            <tr>
-              <th colspan="2">
-                Enumeration description
-              </th>
-            </tr>
-            <tr>
-              <td>
-                <dfn>pending</dfn>
-              </td>
-              <td>
-                The construction of associated processor has not been
-                completed. In this state, no audio processing can happen and
-                all messages to the processor will be queued.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <dfn>running</dfn>
-              </td>
-              <td>
-                Indicates that the <a>active source</a> flag on the
-                corresponding processor is <code>true</code>.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <dfn>stopped</dfn>
-              </td>
-              <td>
-                Indicates that the <a>active source</a> flag on the
-                corresponding processor is <code>false</code>.
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <dfn>error</dfn>
-              </td>
-              <td>
-                When an exception is thrown from the processor's
-                <code>constructor</code>, <code>process</code> method, or any
-                user-defined class method throws an exception. Note that once
-                an <a>AudioWorkletNode</a> reaches to this state, the processor
-                will output silence throughout its lifetime.
-              </td>
-            </tr>
-          </table>
-          <pre class="idl">
 [Exposed=Window, SecureContext,
  Constructor (BaseAudioContext context, DOMString name, optional AudioWorkletNodeOptions options)]
 interface AudioWorkletNode : AudioNode {
     readonly        attribute AudioParamMap              parameters;
     readonly        attribute MessagePort                port;
-    readonly        attribute AudioWorkletProcessorState processorState;
-                    attribute EventHandler               onprocessorstatechange;
+                    attribute EventHandler               onprocessorerror;
 };
           </pre>
           <section>
@@ -18639,14 +18582,17 @@ interface AudioWorkletNode : AudioNode {
             <dl class="attributes" data-dfn-for="AudioWorkletNode"
             data-link-for="AudioWorkletNode">
               <dt>
-                <code><dfn>onprocessorstatechange</dfn></code> of type
+                <code><dfn>onprocessorerror</dfn></code> of type
                 <span class=
                 "idlAttrType"><a><code>EventHandler</code></a></span>
               </dt>
               <dd>
-                Any state change on the processor will queue a task on the
-                control thread to fire <a>onprocessorstatechange</a> event to
-                the node.
+                When an exception is thrown from the processor's
+                <code>constructor</code>, <code>process</code> method, or any
+                user-defined class method, the processor will queue a task on
+                the control thread to fire <a>onprocessorstatechange</a> event
+                to the node. Note that once an exception is thrown, the
+                processor will output silence throughout its lifetime.
               </dd>
               <dt>
                 <code><dfn>parameters</dfn></code> of type <span class=
@@ -18672,16 +18618,6 @@ interface AudioWorkletNode : AudioNode {
                 corresponding <a>AudioWorkletProcessor</a> object allowing
                 bidirectional communication between a pair of
                 <a>AudioWorkletNode</a> and <a>AudioWorkletProcessor</a>.
-              </dd>
-              <dt>
-                <code><dfn>processorState</dfn></code> of type <span class=
-                "idlAttrType"><a><code>AudioWorkletProcessorState</code></a></span>,
-                readonly
-              </dt>
-              <dd>
-                Indicates the state of the associated processor. The
-                propagation from the actual processor's <a>active source</a>
-                flag to this property is done by queueing a task.
               </dd>
             </dl>
           </section>


### PR DESCRIPTION
Fixes #1451.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1509.html" title="Last updated on Feb 23, 2018, 8:49 PM GMT (1a90eb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1509/e79e859...hoch:1a90eb5.html" title="Last updated on Feb 23, 2018, 8:49 PM GMT (1a90eb5)">Diff</a>