### PR TITLE
Fix #1505: Add parameter entry for AudioWorkletNode name

### DIFF
--- a/index.html
+++ b/index.html
@@ -18612,6 +18612,25 @@ interface AudioWorkletNode : AudioNode {
                   </tr>
                   <tr>
                     <td class="prmName">
+                      name
+                    </td>
+                    <td class="prmType">
+                      <a><code>BaseAudioContext</code></a>
+                    </td>
+                    <td class="prmNullFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmOptFalse">
+                      <span role="img" aria-label="False">✘</span>
+                    </td>
+                    <td class="prmDesc">
+                      A string that can be used as a key in the
+                      <a>BaseAudioContext</a>’s <a>node name to parameter
+                      descriptor map</a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="prmName">
                       options
                     </td>
                     <td class="prmType">

--- a/index.html
+++ b/index.html
@@ -18615,7 +18615,7 @@ interface AudioWorkletNode : AudioNode {
                       name
                     </td>
                     <td class="prmType">
-                      <a><code>BaseAudioContext</code></a>
+                      <a><code>DOMString</code></a>
                     </td>
                     <td class="prmNullFalse">
                       <span role="img" aria-label="False">✘</span>


### PR DESCRIPTION
Need to describe the `name` parameter of the `AudioWorkletNode`
constructor.

We inadvertently missed this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1510.html" title="Last updated on Feb 23, 2018, 8:55 PM GMT (f898ea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1510/e79e859...rtoy:f898ea2.html" title="Last updated on Feb 23, 2018, 8:55 PM GMT (f898ea2)">Diff</a>