### PR TITLE
Fix typo in bypass code example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9272,7 +9272,7 @@ instances created from the definition.
 class BypassProcessor extends AudioWorkletProcessor {
 	process (inputs, outputs) {
 		// Single input, single channel.
-		let input = inputs[
+		let input = inputs[0];
 		let output = outputs[0];
 		output[0].set(input[0]);
 	}


### PR DESCRIPTION
I wanted to generate index.html too, but this didn't work.
I believe it could be useful to add a note about how to do this on the contribute page.
Looking at the travis info, I thought the following would work:
curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 -F output=err -o err
but it failed.
With bikeshed installed locally, it didn't worked either.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ArnaudBienner/web-audio-api/pull/1525.html" title="Last updated on Mar 23, 2018, 4:04 PM GMT (6707efc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1525/5db4a60...ArnaudBienner:6707efc.html" title="Last updated on Mar 23, 2018, 4:04 PM GMT (6707efc)">Diff</a>