### PR TITLE
Use -E instead of -r for sed command, since it is recommended for por…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   # If expected-errs.txt ever needs to be updated, run the following
   # commands, but save the output from sed to expected-errs.txt and
   # check in the file.
-  - cat err | sed -r 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u - expected-errs.txt
+  - cat err | sed -E 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u - expected-errs.txt
 
 branches:
   only:


### PR DESCRIPTION
…tability

See https://www.gnu.org/software/sed/manual/sed.html#Command_002dLine-Options

@rtoy This is the issue I had I mentioned in #1525.
The command failed because -r wasn't supported for me (on macOS). Strangely, the sed command didn't failed because of unrecognized option when piped to diff.
Looking at the sed documentation, seems like -E is the preferred option.
I've submitted another pull request #1530 to complete CONTRIBUTING.md, with the sed command using -E, but I believe it would be nice to have this script updated as well, since contributors might be likely to look at .travis.yml directly (like I did).
