### PR TITLE
Fix link for CORS-cross-origin

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -50,8 +50,6 @@ LINK ERROR: No 'method' refs found for 'DynamicsCompressorNode()'.
 LINK ERROR: No 'method' refs found for 'GainNode()'.
 LINK ERROR: No 'method' refs found for 'IIRFilterNode()'.
 LINK ERROR: No 'method' refs found for 'MediaElementAudioSourceNode()'.
-LINK ERROR: No 'dfn' refs found for 'cors-cross-origin' that are marked for export.
-&lt;a data-link-type="dfn" data-lt="CORS-cross-origin">CORS-cross-origin&lt;/a>
 LINK ERROR: No 'method' refs found for 'MediaStreamAudioDestinationNode()'.
 LINK ERROR: No 'idl-name' refs found for 'MediaStream'.
 &lt;a data-link-type="idl-name" data-lt="MediaStream">MediaStream&lt;/a>

--- a/index.bs
+++ b/index.bs
@@ -7544,7 +7544,7 @@ To prevent this, a {{MediaElementAudioSourceNode}} MUST output
 {{HTMLMediaElement}} for which the execution of the
 <a href="https://fetch.spec.whatwg.org/#fetching">fetch
 algorithm</a> labeled the resource as
-<a>CORS-cross-origin</a>.
+<a href="https://html.spec.whatwg.org/#cors-cross-origin">CORS-cross-origin</a>.
 
 
 <!-- Big Text: MediaStream -->

--- a/index.bs
+++ b/index.bs
@@ -11662,7 +11662,7 @@ to Consider</a>
 
 	Research by Princeton CITP's <a href="https://audiofingerprint.openwpm.com/"></a>
 	Web Transparency and Accountability Project</a>
-	has shown that {{DynamicsCompressor}} and {{OscillatorNode}} can
+	has shown that {{DynamicsCompressorNode}} and {{OscillatorNode}} can
 	be used to gather entropy from a client to fingerprint a device.
 	This is due to small, and normally inaudible, differences in DSP
 	architecture, resampling strategies and rounding trade-offs between


### PR DESCRIPTION
This is the correct link.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1532.html" title="Last updated on Mar 26, 2018, 8:58 PM GMT (5102449)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1532/5c3bd32...padenot:5102449.html" title="Last updated on Mar 26, 2018, 8:58 PM GMT (5102449)">Diff</a>