### PR TITLE
Change order of diff files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   # If expected-errs.txt ever needs to be updated, run the following
   # commands, but save the output from sed to expected-errs.txt and
   # check in the file.
-  - cat err | sed -E 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u - expected-errs.txt
+  - cat err | sed -E 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u expected-errs.txt -
 
 branches:
   only:


### PR DESCRIPTION
The order of the files for diff was reversed so that it looked like
new errors in the current version were removed from the expected
file.  It should have been the other way so that new errors are
additions.