### PR TITLE
Fix #1538: fix link checker failures and add new audio eq cookbook link

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5819,7 +5819,7 @@ having very different characteristics. The formulas in this section
 describe the filters that a <a>conforming implementation</a> MUST
 implement, as they determine the characteristics of the different
 filter types. They are inspired by formulas found in the
-<a href="http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt">Audio EQ Cookbook</a>.
+<a href="https://www.w3.org/2011/audio/audio-eq-cookbook.html">Audio EQ Cookbook</a>.
 
 The transfer function for the filters implemented by the
 {{BiquadFilterNode}} is:

--- a/index.bs
+++ b/index.bs
@@ -10600,11 +10600,11 @@ can restart executing this algoritm if needed.
 			it to match if number of input channels of this
 			{{AudioNode}}.
 
-		3. If this {{AudioNode}} is a <a>source node</a>, <a href="computing">compute a block of audio</a>,
+		3. If this {{AudioNode}} is a <a>source node</a>, [=Computing a block of audio|compute a block of audio=],
 			and <a href="#available">make it available for reading</a>.
 
 		4. Else, if this {{AudioNode}} is a <a>destination node</a>,
-			<a href="record">record the input</a> of this {{AudioNode}}.
+			[=Recording the input|record the input=] of this {{AudioNode}}.
 
 		5. Else, <a>process</a> the <a>input buffer</a>,
 			and <a href="#available">make available for reading</a> the resulting buffer.
@@ -10626,11 +10626,11 @@ Note: For example, implementations can choose to allocate a new buffer,
 or have a more elaborate mechanism, reusing an existing buffer
 that is now unused.
 
-<dfn id="record">Recording the input</dfn> of an {{AudioNode}}
+<dfn>Recording the input</dfn> of an {{AudioNode}}
 means copying the input data of this {{AudioNode}} for future
 usage.
 
-<dfn id="computing">Computing a block of audio</dfn> means
+<dfn>Computing a block of audio</dfn> means
 running the algorithm for this {{AudioNode}} to produce 128
 sample-frames.
 


### PR DESCRIPTION
Fix up the two bad links (why didn't bikeshed catch this?)

While I'm at it, I updated the Audio EQ Cookbook to point to the MathJax'ed version of the original cookbook page.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1542.html" title="Last updated on Mar 28, 2018, 4:38 PM GMT (01b14c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1542/b6b9369...rtoy:01b14c7.html" title="Last updated on Mar 28, 2018, 4:38 PM GMT (01b14c7)">Diff</a>