### PR TITLE
Fix single-use vars in algorithm to process control message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ script:
   # the ANSI color codes from the output to make it easier to read.
   # If expected-errs.txt ever needs to be updated, run the following
   # commands, but save the output from sed to expected-errs.txt and
-  # check in the file.
-  - cat err | sed -E 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u expected-errs.txt -
+  # check in the file.  The first sed makes sure there's a newline
+  # character at the end of the file.
+  - sed -e '$a\'  err | sed -E 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u expected-errs.txt -
 
 branches:
   only:

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -7,15 +7,12 @@ FATAL ERROR: Couldn't find include file 'audionode-noinput.include'. Error was:
 WARNING: The following &lt;var>s were only used once in the document:
   'target gain', in algorithm 'reduction-gain'
   'attack', in algorithm 'reduction-gain'
-  'nodeName', in algorithm 'process control message'
   'release', in algorithm 'reduction-gain'
-  'nodeName'
   'threshold', in algorithm 'reduction-gain'
   'final gain', in algorithm 'reduction-gain'
   'ratio', in algorithm 'reduction-gain'
   'this', in algorithm 'audioworklet construction'
   'knee', in algorithm 'reduction-gain'
-  'processorPortSerialization'
 If these are not typos, please add an ignore='' attribute to the &lt;var>.
 WARNING: Multiple elements have the same ID 'dom-decodeerrorcallback-error'.
 Deduping, but this ID may not be stable across revisions.

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -7,8 +7,8 @@ FATAL ERROR: Couldn't find include file 'audionode-noinput.include'. Error was:
 WARNING: The following &lt;var>s were only used once in the document:
   'target gain', in algorithm 'reduction-gain'
   'attack', in algorithm 'reduction-gain'
-  'release', in algorithm 'reduction-gain'
   'threshold', in algorithm 'reduction-gain'
+  'release', in algorithm 'reduction-gain'
   'final gain', in algorithm 'reduction-gain'
   'ratio', in algorithm 'reduction-gain'
   'this', in algorithm 'audioworklet construction'

--- a/index.bs
+++ b/index.bs
@@ -9971,20 +9971,20 @@ thread and the rendering thread.
 	11. Return <var>node</var>.
 </div>
 
-In order to process a control message for the construction of an
-{{AudioWorkletProcessor}}, given a string <var>nodeName</var>, a
-serialization record <var>processorPortSerialization</var>, and an
-{{AudioWorkletNode}} <var>node</var>, perform the following
-steps on the <a>rendering thread</a>. If any of these steps throws
-an exception (either explicitly or implicitly), abort the rest of
-steps and queue a task on the <a>control thread</a> to fire
-{{AudioWorkletNode/onprocessorerror}} event to
-<var>node</var>.
-
 <div algorithm="process control message">
+	In order to process a control message for the construction of an
+	{{AudioWorkletProcessor}}, given a string <var>nodeName</var>, a
+	serialization record <var>processorPortSerialization</var>, and an
+	{{AudioWorkletNode}} <var>node</var>, perform the following
+	steps on the <a>rendering thread</a>. If any of these steps throws
+	an exception (either explicitly or implicitly), abort the rest of
+	steps and queue a task on the <a>control thread</a> to fire
+	{{AudioWorkletNode/onprocessorerror}} event to
+	<var>node</var>.
+
 	1. Let <var>processorPort</var> be
 		<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
-		StructuredDeserializeWithTransfer</a>(<code>processorPortSerialization</code>,
+		StructuredDeserializeWithTransfer</a>(<var>processorPortSerialization</var>,
 		the current Realm).
 
 	1. Let <var>options</var> be <a href=


### PR DESCRIPTION
Fixes `nodeName` and `processorPortSerialization` by moving the intro
paragraph into the algorithm block.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1544.html" title="Last updated on Mar 28, 2018, 11:01 PM GMT (3413d2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1544/34fc87c...rtoy:3413d2d.html" title="Last updated on Mar 28, 2018, 11:01 PM GMT (3413d2d)">Diff</a>