### PR TITLE
Fix #1536: Unify AudioScheduledsource and ABSN stop methods

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4600,7 +4600,7 @@ any part of the looped region has been played. While
 {{AudioBufferSourceNode/loop}} remains true,
 looped playback will continue until one of the following occurs:
 
-* {{AudioBufferSourceNode/stop()}} is called,
+* {{AudioScheduledSourceNode/stop()}} is called,
 
 * the scheduled stop time has been reached,
 

--- a/index.bs
+++ b/index.bs
@@ -3893,6 +3893,13 @@ Methods</h4>
 				values in the messsage.
 		</div>
 
+		<div algorithm="run a control message to stop the AudioBufferSourceNode">
+			If the node is an {{AudioBufferSourceNode}},
+			running a <a>control message</a> to stop the
+			{{AudioBufferSourceNode}} means invoking the
+			<code>handleStop()</code> function in the <a href="#playback-AudioBufferSourceNode">playback algorithm</a>.
+		</div>
+
 		<pre class=argumentdef for="AudioScheduledSourceNode/stop(when)">
 			when: The {{AudioScheduledSourceNode/stop(when)/when}} parameter describes at what time (in seconds) the source should stop playing. It is in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. If 0 is passed in for this value or if the value is less than {{BaseAudioContext/currentTime}}, then the sound will stop playing immediately. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>when</code> is negative</span>.
 		</pre>
@@ -4378,7 +4385,6 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
 	void start (optional double when = 0,
 	            optional double offset,
 	            optional double duration);
-	void stop (optional double when = 0);
 };
 </pre>
 
@@ -4529,47 +4535,6 @@ Methods</h4>
 			<em>Return type:</em> {{void}}
 		</div>
 
-	: <dfn>stop(when)</dfn>
-	::
-		Schedules a sound to stop playback at an exact time. If
-		<code>stop</code> is called again after already having been
-		called, the last invocation will be the only one applied; stop
-		times set by previous calls will not be applied, unless the
-		buffer has already stopped prior to any subsequent calls. If
-		the buffer has already stopped, further calls to
-		<code>stop</code> will have no effect. If a stop time is
-		reached prior to the scheduled start time, the sound will not
-		play.
-
-		<div algorithm="AudioBufferSourceNode.stop()">
-			<span class="synchronous">When this method is called, execute these steps:</span>
-
-			1. If an earlier call to <code>start</code> has not already
-				occurred, an {{InvalidStateError}} exception MUST be
-				thrown.
-
-			2. Check for any errors that must be thrown due to parameter
-				constraints described below.
-
-			3. <a>Queue a control message</a> to stop the
-				{{AudioBufferSourceNode}}, including the parameter values
-				in the messsage.
-		</div>
-
-		<div algorithm="run a control message to stop the AudioBufferSourceNode">
-			Running a <a>control message</a> to stop the
-			{{AudioBufferSourceNode}} means invoking the
-			<code>handleStop()</code> function in the <a href="#playback-AudioBufferSourceNode">playback algorithm</a> which
-			follows.
-		</div>
-
-		<pre class=argumentdef for="AudioBufferSourceNode/stop(when)">
-			when: The {{AudioBufferSourceNode/stop(when)/when}} parameter describes at what time (in seconds) the source should stop playing. It is in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. If 0 is passed in for this value or if the value is less than {{BaseAudioContext/currentTime}}, then the sound will stop playing immediately. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>when</code> is negative</span>.
-		</pre>
-
-		<div>
-			<em>Return type:</em> {{void}}
-		</div>
 </dl>
 
 <h4 dictionary lt="AudioBufferSourceOptions">


### PR DESCRIPTION
Remove stop method from ABSN IDL so that it can inherit from
AudioScheduledSourceNode.  This means moving the bit of text saying
the handleStop() method must be invoked from ABSN to
AudioScheduledSourceNode and removing the method description from
ABSN.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1546.html" title="Last updated on Mar 29, 2018, 5:06 PM GMT (7cf1ed2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1546/1221c3a...rtoy:7cf1ed2.html" title="Last updated on Mar 29, 2018, 5:06 PM GMT (7cf1ed2)">Diff</a>