### PR TITLE
Unify enum description tables and styling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -173,6 +173,25 @@ div.audioparam-info > table > thead > tr > th {
 	color: #178217;
 	border-bottom: 1px solid #707070;
 }
+div.enum-description > table {
+	border-collapse: collapse;
+	border-top: 2px solid #707070;
+	border-bottom: 2px solid #707070;
+	width: 100%;
+	margin: 2em 0;
+}
+div.enum-description > table > tbody > tr > th,
+div.enum-description > table > tbody > tr > td {
+	padding: 0.2em 0.6em;
+	min-width: 150px;
+	border-top: 1px solid #ddd
+}
+div.enum-description > table > thead > tr > th {
+	line-height: 2em;
+	font-weight: 600;
+	color: #178217;
+	border-bottom: 1px solid #707070;
+}
 </style>
 
 <h2 id="introductory" class=no-num>
@@ -640,25 +659,27 @@ enum AudioContextState {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-for="AudioContextState" dfn-type="enum-value">
-	<tbody>
+	<thead>
 		<tr>
 			<th colspan="2">
 				Enumeration description
+	<tbody>
 		<tr>
 			<td>
-				<code><dfn>suspended</dfn></code>
+				"<dfn>suspended</dfn>"
 			<td>
 				This context is currently suspended (context time is not
 				proceeding, audio hardware may be powered down/released).
 		<tr>
 			<td>
-				<code><dfn>running</dfn></code>
+				"<dfn>running</dfn>"
 			<td>
 				Audio is being processed.
 		<tr>
 			<td>
-				<code><dfn>closed</dfn></code>
+				"<dfn>closed</dfn>"
 			<td>
 				This context has been released, and can no longer be used to
 				process audio. All system audio resources have been released.
@@ -669,6 +690,7 @@ enum AudioContextState {
 				{{BaseAudioContext/decodeAudioData()}},
 				or the {{AudioBuffer}} constructor.)
 </table>
+</div>
 
 <xmp class="idl">
 callback DecodeErrorCallback = void (DOMException error);
@@ -1338,29 +1360,32 @@ enum AudioContextLatencyCategory {
 		"playback"
 };
 </pre>
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="AudioContextLatencyCategory">
-	<tbody>
+	<thead>
 		<tr>
 			<th colspan="2">
 				Enumeration description
+	<tbody>
 		<tr>
 			<td>
-				<code><dfn>balanced</dfn></code>
+				"<dfn>balanced</dfn>"
 			<td>
 				Balance audio output latency and power consumption.
 		<tr>
 			<td>
-				<code><dfn>interactive</dfn></code>
+				"<dfn>interactive</dfn>"
 			<td>
 				Provide the lowest audio output latency possible without
 				glitching. This is the default.
 		<tr>
 			<td>
-				<code><dfn>playback</dfn></code>
+				"<dfn>playback</dfn>"
 			<td>
 				Prioritize sustained playback without interruption over audio
 				output latency. Lowest power consumption.
 </table>
+</div>
 
 <pre class="idl">
 [Exposed=Window,
@@ -2602,28 +2627,32 @@ node are to be mixed. The <a>computedNumberOfChannels</a> is
 determined as shown below. See <a href="#channel-up-mixing-and-down-mixing"></a> for more information on how
 mixing is to be done.
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="ChannelCountMode">
+	<thead>
 	<tr>
 		<th colspan="2">
 			Enumeration description
+	<tbody>
 	<tr>
-		<td><dfn>max</dfn>
+		<td>"<dfn>max</dfn>"
 		<td>
 			<a>computedNumberOfChannels</a> is the maximum of the number of
 			channels of all connections to an input. In this mode
 			{{AudioNode/channelCount}} is ignored.
 	<tr>
-		<td><dfn>clamped-max</dfn>
+		<td>"<dfn>clamped-max</dfn>"
 		<td>
 			<a>computedNumberOfChannels</a> is determined as for "{{ChannelCountMode/max}}"
 			and then clamped to a maximum value of the given
 			{{AudioNode/channelCount}}.
 	<tr>
-		<td><dfn>explicit</dfn>
+		<td>"<dfn>explicit</dfn>"
 		<td>
 			<a>computedNumberOfChannels</a> is the exact value as specified
 			by the {{AudioNode/channelCount}}.
 </table>
+</div>
 
 <pre class="idl">
 [Exposed=Window]
@@ -2633,23 +2662,27 @@ enum ChannelInterpretation {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="ChannelInterpretation">
+	<thead>
 	<tr>
 		<th colspan="2">
 			Enumeration description
+	<tbody>
 	<tr>
-		<td><dfn>speakers</dfn>
+		<td>"<dfn>speakers</dfn>"
 		<td>
 			use <a href="#UpMix-sub">up-mix equations</a> or <a href="#down-mix">down-mix equations</a>. In cases where the number of
 			channels do not match any of these basic speaker layouts, revert
 			to "{{ChannelInterpretation/discrete}}".
 	<tr>
-		<td><dfn>discrete</dfn>
+		<td>"<dfn>discrete</dfn>"
 		<td>
 			Up-mix by filling channels until they run out then zero out
 			remaining channels. Down-mix by filling as many channels as
 			possible, then dropping remaining channels.
 </table>
+</div>
 
 <h4 id="AudioNode-attributes">
 Attributes</h4>
@@ -5495,12 +5528,15 @@ enum BiquadFilterType {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="BiquadFilterType">
+	<thead>
 	<tr>
 		<th colspan="2">
 			Enumeration description
+	<tbody>
 	<tr>
-		<td><dfn>lowpass</dfn>
+		<td>"<dfn>lowpass</dfn>"
 		<td>
 			A <a href="https://en.wikipedia.org/wiki/Low-pass_filter">lowpass
 			filter</a> allows frequencies below the cutoff frequency to
@@ -5518,7 +5554,7 @@ enum BiquadFilterType {
 			: gain
 			:: Not used in this filter type
 	<tr>
-		<td><dfn>highpass</dfn>
+		<td>"<dfn>highpass</dfn>"
 		<td>
 			A <a href="https://en.wikipedia.org/wiki/High-pass_filter">highpass
 			filter</a> is the opposite of a lowpass filter. Frequencies
@@ -5537,7 +5573,7 @@ enum BiquadFilterType {
 			: gain
 			:: Not used in this filter type
 	<tr>
-		<td><dfn>bandpass</dfn>
+		<td>"<dfn>bandpass</dfn>"
 		<td>
 			A <a href="https://en.wikipedia.org/wiki/Band-pass_filter">bandpass
 			filter</a> allows a range of frequencies to pass through and
@@ -5552,7 +5588,7 @@ enum BiquadFilterType {
 			: gain
 			:: Not used in this filter type
 	<tr>
-		<td><dfn>lowshelf</dfn>
+		<td>"<dfn>lowshelf</dfn>"
 		<td>
 			The lowshelf filter allows all frequencies through, but adds a
 			boost (or attenuation) to the lower frequencies. It implements
@@ -5567,7 +5603,7 @@ enum BiquadFilterType {
 			:: The boost, in dB, to be applied. If the value is negative,
 				the frequencies are attenuated.
 	<tr>
-		<td><dfn>highshelf</dfn>
+		<td>"<dfn>highshelf</dfn>"
 		<td>
 			The highshelf filter is the opposite of the lowshelf filter and
 			allows all frequencies through, but adds a boost to the higher
@@ -5582,7 +5618,7 @@ enum BiquadFilterType {
 			:: The boost, in dB, to be applied. If the value is negative,
 				the frequencies are attenuated.
 	<tr>
-		<td><dfn>peaking</dfn>
+		<td>"<dfn>peaking</dfn>"
 		<td>
 			The peaking filter allows all frequencies through, but adds a
 			boost (or attenuation) to a range of frequencies.
@@ -5596,7 +5632,7 @@ enum BiquadFilterType {
 			:: The boost, in dB, to be applied. If the value is negative,
 				the frequencies are attenuated.
 	<tr>
-		<td><dfn>notch</dfn>
+		<td>"<dfn>notch</dfn>"
 		<td>
 			The notch filter (also known as a <a href="https://en.wikipedia.org/wiki/Band-stop_filter">band-stop or
 			band-rejection filter</a>) is the opposite of a bandpass
@@ -5611,7 +5647,7 @@ enum BiquadFilterType {
 			: gain
 			:: Not used in this filter type.
 	<tr>
-		<td><dfn>allpass</dfn>
+		<td>"<dfn>allpass</dfn>"
 		<td>
 			An <a href="https://en.wikipedia.org/wiki/All-pass_filter#Digital_Implementation">
 			allpass filter</a> allows all frequencies through, but changes
@@ -5630,7 +5666,8 @@ enum BiquadFilterType {
 			: gain
 			:: Not used in this filter type.
 </table>
-
+</div>
+	
 All attributes of the {{BiquadFilterNode}} are <a>a-rate</a> {{AudioParam}}s.
 
 <pre class="idl">
@@ -7833,16 +7870,18 @@ enum OscillatorType {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="OscillatorType">
 	<thead>
 		<tr><th colspan="2">Enumeration description
 	<tbody>
-		<tr><td><dfn>sine</dfn> <td>A sine wave
-		<tr><td><dfn>square</dfn> <td>A square wave of duty period 0.5
-		<tr><td><dfn>sawtooth</dfn> <td>A sawtooth wave
-		<tr><td><dfn>triangle</dfn> <td>A triangle wave
-		<tr><td><dfn>custom</dfn> <td>A custom periodic wave
+		<tr><td>"<dfn>sine</dfn>" <td>A sine wave
+		<tr><td>"<dfn>square</dfn>" <td>A square wave of duty period 0.5
+		<tr><td>"<dfn>sawtooth</dfn>" <td>A sawtooth wave
+		<tr><td>"<dfn>triangle</dfn>" <td>A triangle wave
+		<tr><td>"<dfn>custom</dfn>" <td>A custom periodic wave
 </table>
+</div>
 
 <pre class="idl">
 [Exposed=Window,
@@ -8097,11 +8136,12 @@ enum PanningModelType {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="PanningModelType">
 	<thead>
 		<tr><th colspan="2">Enumeration description
 	<tbody>
-		<tr><td><dfn>equalpower</dfn>
+		<tr><td>"<dfn>equalpower</dfn>"
 		<td>
 			A simple and efficient spatialization algorithm using equal-power
 			panning.
@@ -8109,7 +8149,7 @@ enum PanningModelType {
 			Note: When this panning model is used, all the {{AudioParam}}s
 			used to compute the output of this node are <a>a-rate</a>.
 
-		<tr><td><dfn>HRTF</dfn>
+		<tr><td>"<dfn>HRTF</dfn>"
 		<td>
 			A higher quality spatialization algorithm using a convolution
 			with measured impulse responses from human subjects. This panning
@@ -8118,6 +8158,7 @@ enum PanningModelType {
 			Note:When this panning model is used, all the {{AudioParam}}s
 			used to compute the output of this node are <a>k-rate</a>.
 </table>
+</div>
 
 The {{DistanceModelType}} enum determines which
 algorithm will be used to reduce the volume of an audio source as it
@@ -8137,12 +8178,13 @@ enum DistanceModelType {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="DistanceModelType">
 	<thead>
 		<tr><th colspan="2">Enumeration description
 	<tbody>
 		<tr>
-			<td><dfn>linear</dfn>
+			<td>"<dfn>linear</dfn>"
 			<td>
 				A linear distance model which calculates <em>distanceGain</em>
 				according to:
@@ -8162,7 +8204,7 @@ enum DistanceModelType {
 				d'_{max}]\).
 
 		<tr>
-			<td><dfn>inverse</dfn>
+			<td>"<dfn>inverse</dfn>"
 			<td>
 				An inverse distance model which calculates
 				<em>distanceGain</em> according to:
@@ -8178,7 +8220,7 @@ enum DistanceModelType {
 				is taken to be 0, independent of the value of \(d\) and \(f\).
 
 		<tr>
-			<td><dfn>exponential</dfn>
+			<td>"<dfn>exponential</dfn>"
 			<td>
 				An exponential distance model which calculates
 				<em>distanceGain</em> according to:
@@ -8193,6 +8235,7 @@ enum DistanceModelType {
 				\infty)\). If \(d_{ref} = 0\), the value of the exponential
 				model is taken to be 0, independent of \(d\) and \(f\).
 </table>
+</div>
 
 <pre class="idl">
 [Exposed=Window,
@@ -9043,19 +9086,21 @@ enum OverSampleType {
 };
 </pre>
 
+<div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="OverSampleType">
 	<thead>
 		<tr><th colspan="2">Enumeration description
 	<tbody>
-		<tr><td><dfn>none</dfn>
+		<tr><td>"<dfn>none</dfn>"
 			<td>Don't oversample
 
-		<tr><td><dfn>2x</dfn>
+		<tr><td>"<dfn>2x</dfn>"
 			<td>Oversample two times
 
-		<tr><td><dfn>4x</dfn>
+		<tr><td>"<dfn>4x</dfn>"
 			<td>Oversample four times
 </table>
+</div>
 
 <pre class="idl">
 [Exposed=Window,


### PR DESCRIPTION
This consists of several changes:
- Use the same table structure for all enum description tables
- Add CSS styling to add thin lines between rows (especially effective for the biquad filter types)
- Add quotes around the enum values.  They previously didn't include quotes but the enum values are strings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1547.html" title="Last updated on Mar 29, 2018, 7:03 PM GMT (72cdf9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1547/1221c3a...rtoy:72cdf9c.html" title="Last updated on Mar 29, 2018, 7:03 PM GMT (72cdf9c)">Diff</a>