### PR TITLE
Fix #1490: Update bitcrusher example for constant AudioParam values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10174,36 +10174,43 @@ registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
 	process (inputs, outputs, parameters) {
 		let input = inputs[0];
 		let output = outputs[0];
+		let bitDepthLength = parameters.bitDepth.length;
+		let reductionLength = parameters.frequencyReduction.length;
 
-		// Handle the case where the AudioParam has a constant
-		// value, indicated by the fact that the array has length
-		// 1.  This can be done in multiple ways.
+		if (bitDepthLength > 1) {
+			// General case
+			for (let channel = 0; channel &lt; output.length; ++channel) {
+				for (let i = 0; i &lt; output[channel].length; ++i) {
+					let step = Math.pow(0.5, bitDepth[i]);
 
-		let bitDepth = parameters.bitDepth;
-		if (parameters.bitDepth.length === 1) {
-			bitDepth = new Float32Array(output[0].length);
-			bitDepth.fill(bitDepth[0]);
-		}
-
-		let frequencyReduction = parameters.frequencyReduction;
-		if (parameters.frequencyReduction.length === 1) {
-			frequencyReduction = new Float32Array(output[0].length);
-			frequencyReduction.fill(bitDepth[0]);
-		}
-
-		for (let channel = 0; channel &lt; output.length; ++channel) {
-			for (let i = 0; i &lt; output[channel].length; ++i) {
-				let step = Math.pow(0.5, bitDepth[i]);
-				this._phase += frequencyReduction[i];
-				if (this._phase >= 1.0) {
-					this._phase -= 1.0;
-					this._lastSampleValue =
-						step * Math.floor(input[channel][i] / step + 0.5);
+					// Use modulo for indexing to handle the case where
+					// the length of the frequencyReduction array is 1.
+					this._phase += frequencyReduction[i % reductionLength];
+					if (this._phase >= 1.0) {
+						this._phase -= 1.0;
+						this._lastSampleValue =
+							step * Math.floor(input[channel][i] / step + 0.5);
+					}
+					output[channel][i] = this._lastSampleValue;
 				}
-				output[channel][i] = this._lastSampleValue;
+			}
+		} else {
+			// Because we know bitDepth is constant for this call,
+			// we can lift the computation of step outside the loop,
+			// saving many operations.
+			let step = Math.pow(0.5, bitDepth[0]);
+			for (let channel = 0; channel &lt; output.length; ++channel) {
+				for (let i = 0; i &lt; output[channel].length; ++i) {
+					this._phase += frequencyReduction[i % reductionLength];
+					if (this._phase >= 1.0) {
+						this._phase -= 1.0;
+						this._lastSampleValue =
+							step * Math.floor(input[channel][i] / step + 0.5);
+					}
+					output[channel][i] = this._lastSampleValue;
+				}
 			}
 		}
-
 		// No need to return a value; this node's lifetime is dependent only on its
 		// input connections.
 	}

--- a/index.bs
+++ b/index.bs
@@ -10174,8 +10174,22 @@ registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
 	process (inputs, outputs, parameters) {
 		let input = inputs[0];
 		let output = outputs[0];
+
+		// Handle the case where the AudioParam has a constant
+		// value, indicated by the fact that the array has length
+		// 1.  This can be done in multiple ways.
+
 		let bitDepth = parameters.bitDepth;
+		if (parameters.bitDepth.length === 1) {
+			bitDepth = new Float32Array(output[0].length);
+			bitDepth.fill(bitDepth[0]);
+		}
+
 		let frequencyReduction = parameters.frequencyReduction;
+		if (parameters.frequencyReduction.length === 1) {
+			frequencyReduction = new Float32Array(output[0].length);
+			frequencyReduction.fill(bitDepth[0]);
+		}
 
 		for (let channel = 0; channel &lt; output.length; ++channel) {
 			for (let i = 0; i &lt; output[channel].length; ++i) {


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1550.html" title="Last updated on Mar 30, 2018, 11:18 PM GMT (728c808)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1550/fc74f42...rtoy:728c808.html" title="Last updated on Mar 30, 2018, 11:18 PM GMT (728c808)">Diff</a>