### PR TITLE
Fix #1554: Throw InvalidStateError when setting rate to invalid value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3370,7 +3370,7 @@ Attributes</h4>
 			"{{AutomationRate/k-rate}}". <span
 			class="synchronous">An {{InvalidStateError}}
 			must be thrown if the rate is changed to
-			"{{AutomatinoRate/a-rate}}"</span>.
+			"{{AutomationRate/a-rate}}"</span>.
 
 		: {{DynamicsCompressorNode}}
 		::
@@ -3383,7 +3383,7 @@ Attributes</h4>
 			MUST be "{{AutomationRate/k-rate}}".  <span
 			class="synchronous">An {{InvalidStateError}}
 			must be thrown if the rate is changed to
-			"{{AutomatinoRate/a-rate}}"</span>.
+			"{{AutomationRate/a-rate}}"</span>.
 
 		: {{PannerNode}}
 		::

--- a/index.bs
+++ b/index.bs
@@ -3367,7 +3367,10 @@ Attributes</h4>
 			The {{AudioParam}}s
 			{{AudioBufferSourceNode/playbackRate}} and
 			{{AudioBufferSourceNode/detune}} MUST be
-			"{{AutomationRate/k-rate}}" and cannot be changed.
+			"{{AutomationRate/k-rate}}". <span
+			class="synchronous">An {{InvalidStateError}}
+			must be thrown if the rate is changed to
+			"{{AutomatinoRate/a-rate}}"</span>.
 
 		: {{DynamicsCompressorNode}}
 		::
@@ -3377,7 +3380,10 @@ Attributes</h4>
 			{{DynamicsCompressorNode/ratio}},
 			{{DynamicsCompressorNode/attack}}, and
 			{{DynamicsCompressorNode/release}}
-			MUST be "{{AutomationRate/k-rate}}" and cannot be changed.
+			MUST be "{{AutomationRate/k-rate}}".  <span
+			class="synchronous">An {{InvalidStateError}}
+			must be thrown if the rate is changed to
+			"{{AutomatinoRate/a-rate}}"</span>.
 
 		: {{PannerNode}}
 		::


### PR DESCRIPTION
The automation rates for the `AudioParam`s of a `AudioBufferSourceNode` and
a `DynamicsCompressorNode` are fixed.  Throw an `InvalidStateError`
when trying to change it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1555.html" title="Last updated on Apr 6, 2018, 2:52 PM GMT (703a275)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1555/55b069b...rtoy:703a275.html" title="Last updated on Apr 6, 2018, 2:52 PM GMT (703a275)">Diff</a>