### PR TITLE
Fix #1553: Add automationRate to AudioParamDescriptor dict

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3383,13 +3383,13 @@ Attributes</h4>
 		::
 			If the {{PannerNode/panningModel}} is
 			"{{PanningModelType/HRTF}}", the setting of
-			the {{automationRate}} for any
+			the {{AudioParam/automationRate}} for any
 			{{AudioParam}} of the {{PannerNode}} is ignored.
 			Likewise, the setting of the
-			{{automationRate}} for any {{AudioParam}}
+			{{AudioParam/automationRate}} for any {{AudioParam}}
 			of the {{AudioListener}} is ignored.  In this
 			case, the {{AudioParam}} behaves as if the
-			{{automationRate}} were set to
+			{{AudioParam/automationRate}} were set to
 			"{{AutomationRate/k-rate}}".
 
 	: <dfn>defaultValue</dfn>

--- a/index.bs
+++ b/index.bs
@@ -9845,7 +9845,8 @@ class MyProcessor extends AudioWorkletProcessor {
 			name: 'myParam',
 			defaultValue: 0.5,
 			minValue: 0,
-			maxValue: 1
+			maxValue: 1,
+			automationRate: "k-rate"
 		}];
 	}
 
@@ -9858,7 +9859,7 @@ class MyProcessor extends AudioWorkletProcessor {
 		// A simple amplifier for single input and output.
 		for (let channel = 0; channel &lt; output.length; ++channel) {
 			for (let i = 0; i &lt; output[channel].length; ++i) {
-				output[channel][i] = input[channel][i] * myParam[i];
+				output[channel][i] = input[channel][i] * myParam[0];
 			}
 		}
 	}
@@ -9980,6 +9981,7 @@ dictionary AudioParamDescriptor {
 	float defaultValue = 0;
 	float minValue = -3.4028235e38;
 	float maxValue = 3.4028235e38;
+	AutomationRate automationRate = "a-rate";
 };
 </pre>
 
@@ -9987,6 +9989,10 @@ dictionary AudioParamDescriptor {
 Dictionary {{AudioParamDescriptor}} Members</h6>
 
 <dl dfn-type=dict-member dfn-for="AudioParamDescriptor">
+	: <dfn>automationRate</dfn>
+	::
+		Represents the default automation rate.
+
 	: <dfn>defaultValue</dfn>
 	::
 		Represents the default value of the parameter. If this value


### PR DESCRIPTION
Also update example to set the automationRate to "k-rate".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1556.html" title="Last updated on Apr 6, 2018, 3:21 PM GMT (d9157d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1556/55b069b...rtoy:d9157d3.html" title="Last updated on Apr 6, 2018, 3:21 PM GMT (d9157d3)">Diff</a>