### PR TITLE
Fix #1560: AudioParam tables link to automationRate

### DIFF
--- a/audioparam.include
+++ b/audioparam.include
@@ -19,7 +19,7 @@
 			<td>[MAX]
 			<td>[MAX-NOTES?]
 		<tr>
-			<td>Rate
+			<td>{{AudioParam/automationRate}}
 			<td>[RATE]
 			<td>[RATE-NOTES?]
 </table>

--- a/index.bs
+++ b/index.bs
@@ -5759,7 +5759,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
 	: <dfn>detune</dfn>
@@ -5775,7 +5775,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
 	: <dfn>frequency</dfn>
@@ -5792,7 +5792,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
 	: <dfn>gain</dfn>
@@ -5810,7 +5810,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
 	: <dfn>type</dfn>
@@ -6366,7 +6366,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 </dl>
 
@@ -6753,7 +6753,7 @@ Attributes</h4>
 			default: 0
 			min: 0
 			max: <l>{{DelayOptions/maxDelayTime}}</l>
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 </dl>
 
@@ -7318,7 +7318,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 </dl>
 
@@ -7978,7 +7978,7 @@ Attributes</h4>
 			min-notes: Approximately -3.4028235e38
 			max: <a>most-positive-single-float</a>
 			max-notes: Approximately 3.4028235e38
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
 	: <dfn>frequency</dfn>
@@ -7995,7 +7995,7 @@ Attributes</h4>
 			default: 440
 			min: -<a>Nyquist frequency</a>
 			max: <a>Nyquist frequency</a>
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
 	: <dfn>type</dfn>
@@ -9065,7 +9065,7 @@ Attributes</h4>
 			default: 0
 			min: -1
 			max: 1
-			rate: <a>a-rate</a>
+			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 </dl>
 


### PR DESCRIPTION
The `AudioParam` tables should have a link to `automationRate` instead
of just saying "Rate" since `AudioParam`s now have such an attribute.

Also fixed up a few places so that the specified rate points to the
`AutomationRate` enum instead of the definition of `a-rate` or
`k-rate`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1561.html" title="Last updated on Apr 10, 2018, 9:28 PM GMT (ec50cf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1561/607a107...rtoy:ec50cf1.html" title="Last updated on Apr 10, 2018, 9:28 PM GMT (ec50cf1)">Diff</a>