### PR TITLE
Fix incorrect markup definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7231,7 +7231,7 @@ of the same shape.
 
 <div algorithm="convert linear to db">
 	Converting a value \(v\) in <dfn id="linear-to-decibel">linear gain
-	unit to decibel means</dfn> executing the following steps:
+	unit to decibel</dfn> means executing the following steps:
 
 	1. If \(v\) is equal to zero, return -1000.
 

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 6183b7307468d4ebe91020ec360b3be2140e71df" name="generator">
   <link href="https://www.w3.org/TR/webaudio/" rel="canonical">
-  <meta content="a4a729f98d1109968b818cfa8cdff55f8871a995" name="document-revision">
+  <meta content="a67bd7e94b47c7b8ff3ee6bedf1a4502a6a69fbf" name="document-revision">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML" rel="preload">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/jax.js?rev=2.6.1" rel="preload">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/fonts/STIX/fontdata.js?rev=2.6.1" rel="preload">
@@ -1571,7 +1571,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web Audio API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-04-11">11 April 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-04-12">12 April 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -8747,8 +8747,8 @@ function MUST be monotonically increasing and continuous.</p>
     </ol>
    </div>
    <div class="algorithm" data-algorithm="convert linear to db">
-     Converting a value \(v\) in <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="linear gain unit to decibel means" data-noexport="" id="linear-to-decibel">linear gain
-	unit to decibel means</dfn> executing the following steps: 
+     Converting a value \(v\) in <dfn class="dfn-paneled" data-dfn-type="dfn" data-lt="linear gain unit to decibel" data-noexport="" id="linear-to-decibel">linear gain
+	unit to decibel</dfn> means executing the following steps: 
     <ol>
      <li data-md="">
       <p>If \(v\) is equal to zero, return -1000.</p>
@@ -13536,7 +13536,7 @@ from March 2011 to July 2012; Mandyam, Giridhar (Qualcomm Innovation Center, Inc
     </ul>
    <li><a href="#dom-audiobuffer-length-slot">[[length]]</a><span>, in §1.4</span>
    <li><a href="#dom-distancemodeltype-linear">linear</a><span>, in §1.28</span>
-   <li><a href="#linear-to-decibel">linear gain unit to decibel means</a><span>, in §1.19.4</span>
+   <li><a href="#linear-to-decibel">linear gain unit to decibel</a><span>, in §1.19.4</span>
    <li><a href="#dom-audioparam-linearramptovalueattime">linearRampToValueAtTime(value, endTime)</a><span>, in §1.6.2</span>
    <li><a href="#dom-baseaudiocontext-listener">listener</a><span>, in §1.1.1</span>
    <li>


### PR DESCRIPTION
"linear gain unit to decibel means" is the dfn and is in bold text. But "means" should not be part of the definition and shouldn't be bold.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1564.html" title="Last updated on Apr 12, 2018, 3:46 PM GMT (9b4069b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1564/8fdf86a...rtoy:9b4069b.html" title="Last updated on Apr 12, 2018, 3:46 PM GMT (9b4069b)">Diff</a>