### PR TITLE
Fix typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3509,7 +3509,7 @@ Methods</h4>
 			5. Remove all events with time greater than \(t_c\).
 
 			If no events are added, then the automation value after
-			{{AudioParam/cancelAndHoldAtTime()}} is the the constant value that
+			{{AudioParam/cancelAndHoldAtTime()}} is the constant value that
 			the original timeline would have had at time \(t_c\).
 		</div>
 


### PR DESCRIPTION
"the the" -> "the"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1567.html" title="Last updated on Apr 13, 2018, 6:52 PM GMT (120f87f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1567/24c5c6f...rtoy:120f87f.html" title="Last updated on Apr 13, 2018, 6:52 PM GMT (120f87f)">Diff</a>