### PR TITLE
Issue #1502: Fix single use of threshold, knee, and ratio

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -1,10 +1,7 @@
 WARNING: The following <var>s were only used once in the document:
   'target gain', in algorithm 'reduction-gain'
-  'attack', in algorithm 'reduction-gain'
-  'threshold', in algorithm 'reduction-gain'
   'release', in algorithm 'reduction-gain'
   'final gain', in algorithm 'reduction-gain'
-  'ratio', in algorithm 'reduction-gain'
   'this', in algorithm 'audioworklet construction'
   'knee', in algorithm 'reduction-gain'
 If these are not typos, please add an ignore='' attribute to the <var>.

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -4,7 +4,6 @@ WARNING: The following <var>s were only used once in the document:
   'attack', in algorithm 'reduction-gain'
   'final gain', in algorithm 'reduction-gain'
   'this', in algorithm 'audioworklet construction'
-  'knee', in algorithm 'reduction-gain'
 If these are not typos, please add an ignore='' attribute to the <var>.
 WARNING: Multiple elements have the same ID 'dom-decodeerrorcallback-error'.
 Deduping, but this ID may not be stable across revisions.

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -1,6 +1,7 @@
 WARNING: The following <var>s were only used once in the document:
   'target gain', in algorithm 'reduction-gain'
   'release', in algorithm 'reduction-gain'
+  'attack', in algorithm 'reduction-gain'
   'final gain', in algorithm 'reduction-gain'
   'this', in algorithm 'audioworklet construction'
   'knee', in algorithm 'reduction-gain'

--- a/index.bs
+++ b/index.bs
@@ -7078,8 +7078,8 @@ values. Those values persist accros invocation of this algorithm.
 	quantum of audio.
 
 
-	1. Let <var>attack</var> and <var>release</var> have the value of
-		the {{AudioParam}} of the same name, sampled at the time of
+	1. Let <var>attack</var> and <var>release</var> have the values of
+		{{DynamicsCompressorNode/attack}} and {{DynamicsCompressorNode/release}}, respectively, sampled at the time of
 		processing (those are <a>k-rate</a> parameters), mutiplied by the
 		sample-rate of the {{BaseAudioContext}} this
 		{{DynamicsCompressorNode}} is <a href="#associated">associated</a> with.
@@ -7107,8 +7107,7 @@ values. Those values persist accros invocation of this algorithm.
 
 		4. Substract <var>detector average</var> to
 			<var>attenuation</var>, and multiply the result by
-			<var>detector rate</var>. Add this new result to <var>detector
-			average</var>.
+			<var>detector rate</var>. Add this new result to <var>detector average</var>.
 
 		5. Clamp <var>detector average</var> to a maximum of 1.0.
 
@@ -7214,7 +7213,7 @@ of the same shape.
 		units=] sampled at the time of processing of this
 		block (as [=k-rate=] parameters).
 
-	2. Let <var>ratio</var> have the value of the
+	1. Let <var>ratio</var> have the value of the
 		{{DynamicsCompressorNode/ratio}}, sampled at the time
 		of processing of this block (as a [=k-rate=]
 		parameter).
@@ -7222,14 +7221,14 @@ of the same shape.
 	1. This function is the identity up to the value of the linear
 		<var>threshold</var> (i.e., \(f(x) = x\)).
 
-	2. From the <var>threshold</var> up to the <var>threshold</var> +
+	1. From the <var>threshold</var> up to the <var>threshold</var> +
 		<var>knee</var>, User-Agents can choose the curve shape. The whole
 		function MUST be monotonically increasing and continuous.
 
 		Note: If the <var>knee</var> is 0, the
 		{{DynamicsCompressorNode}} is called a hard-knee compressor.
 
-	3. This function is linear, based on the <var>ratio</var>, after the
+	1. This function is linear, based on the <var>ratio</var>, after the
 		<var>threshold</var> and the soft knee (i.e., \(f(x) =
 		\frac{1}{ratio} \cdot x \)).
 </div>

--- a/index.bs
+++ b/index.bs
@@ -7077,25 +7077,18 @@ values. Those values persist accros invocation of this algorithm.
 	<var>reduction gain</var>, for each sample of input, for a render
 	quantum of audio.
 
-	1. Let <var>threshold</var>, <var>knee</var> have the value of the
-		{{AudioParam}} of the same name, <a href="#db-to-linear">converted to linear unit</a> sampled at the time of
-		processing of this block (as <a>k-rate</a> parameters).
 
-	2. Let <var>ratio</var> have the value of the <code>ratio</code>
-		{{AudioParam}}, sampled at the time of processing of this block
-		(as a <a>k-rate</a> parameter).
-
-	3. Let <var>attack</var> and <var>release</var> have the value of
+	1. Let <var>attack</var> and <var>release</var> have the value of
 		the {{AudioParam}} of the same name, sampled at the time of
 		processing (those are <a>k-rate</a> parameters), mutiplied by the
 		sample-rate of the {{BaseAudioContext}} this
 		{{DynamicsCompressorNode}} is <a href="#associated">associated</a> with.
 
-	4. Let <var>detector average</var> be the value of the slot {{[[detector average]]}}.
+	1. Let <var>detector average</var> be the value of the slot {{[[detector average]]}}.
 
-	5. Let <var>compressor gain</var> be the value of the slot {{[[compressor gain]]}}.
+	1. Let <var>compressor gain</var> be the value of the slot {{[[compressor gain]]}}.
 
-	6. For each sample <var>input</var> of the render quantum to be
+	1. For each sample <var>input</var> of the render quantum to be
 		processed, execute the following steps:
 
 		1. Let <var>releasing</var> be `true` if
@@ -7139,13 +7132,13 @@ values. Those values persist accros invocation of this algorithm.
 		10. Compute <var>metering gain</var> to be <var>final gain</var>, <a href="#linear-to-decibel">converted to
 			decibel</a>.
 
-	7. Set {{[[compressor gain]]}} to <var>compressor
+	1. Set {{[[compressor gain]]}} to <var>compressor
 		gain</var>.
 
-	8. Set {{[[detector average]]}} to <var>detector
+	1. Set {{[[detector average]]}} to <var>detector
 		average</var>.
 
-	9. <a>Atomically</a> set the internal slot {{[[internal reduction]]}}
+	1. <a>Atomically</a> set the internal slot {{[[internal reduction]]}}
 		to the value of <var>metering gain</var>.
 
 		Note: This step makes the metering gain update once per block, at the
@@ -7214,18 +7207,24 @@ of the same shape.
 	the computed value. This function MUST respect the following
 	characteristics:
 
-	1. This function is the identity up to the value of the linear
-		<code>threshold</code> (i.e., \(f(x) = x\)).
+	1. Let <var>threshold</var>, <var>knee</var> have the values of {{DynamicsCompressorNode/threshold}} and {{DynamicsCompressorNode/knee}}, respectively, <a href="#db-to-linear">converted to linear unit</a> sampled at the time of
+		processing of this block (as <a>k-rate</a> parameters).
 
-	2. From the <code>threshold</code> up to the <code>threshold +
-		knee</code>, User-Agents can choose the curve shape. The whole
+	2. Let <var>ratio</var> have the value of the {{DynamicsCompressorNode/ratio}}, sampled at the time of processing of this block
+		(as a <a>k-rate</a> parameter).
+
+	1. This function is the identity up to the value of the linear
+		<var>threshold</var> (i.e., \(f(x) = x\)).
+
+	2. From the <var>threshold</var> up to the <var>threshold</var> +
+		<var>knee</var>, User-Agents can choose the curve shape. The whole
 		function MUST be monotonically increasing and continuous.
 
-		Note: If the <code>knee</code> is 0, the
+		Note: If the <var>knee</var> is 0, the
 		{{DynamicsCompressorNode}} is called a hard-knee compressor.
 
-	3. This function is linear, based on the ratio, after the
-		<code>threshold</code> and the soft knee (i.e., \(f(x) =
+	3. This function is linear, based on the <var>ratio</var>, after the
+		<var>threshold</var> and the soft knee (i.e., \(f(x) =
 		\frac{1}{ratio} \cdot x \)).
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -7207,11 +7207,17 @@ of the same shape.
 	the computed value. This function MUST respect the following
 	characteristics:
 
-	1. Let <var>threshold</var>, <var>knee</var> have the values of {{DynamicsCompressorNode/threshold}} and {{DynamicsCompressorNode/knee}}, respectively, <a href="#db-to-linear">converted to linear unit</a> sampled at the time of
-		processing of this block (as <a>k-rate</a> parameters).
+	1. Let <var>threshold</var> and <var>knee</var> have the
+		values of {{DynamicsCompressorNode/threshold}} and
+		{{DynamicsCompressorNode/knee}}, respectively,
+		[=decibels to linear gain unit|converted to linear
+		units=] sampled at the time of processing of this
+		block (as [=k-rate=] parameters).
 
-	2. Let <var>ratio</var> have the value of the {{DynamicsCompressorNode/ratio}}, sampled at the time of processing of this block
-		(as a <a>k-rate</a> parameter).
+	2. Let <var>ratio</var> have the value of the
+		{{DynamicsCompressorNode/ratio}}, sampled at the time
+		of processing of this block (as a [=k-rate=]
+		parameter).
 
 	1. This function is the identity up to the value of the linear
 		<var>threshold</var> (i.e., \(f(x) = x\)).
@@ -7238,7 +7244,7 @@ of the same shape.
 </div>
 
 <div algorithm="convert db to linear">
-	Converting a value \(v\) in <dfn id="db-to-linear">decibels to
+	Converting a value \(v\) in <dfn>decibels to
 	linear gain unit</dfn> means returning \(10^\frac{v}{20}\)
 </div>
 


### PR DESCRIPTION
Move the vars `threshold`, `knee`, and `ratio` from the reduction gain
algorithm to the compressor curve algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1568.html" title="Last updated on May 11, 2018, 4:50 PM GMT (3a7004f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1568/cf8b377...rtoy:3a7004f.html" title="Last updated on May 11, 2018, 4:50 PM GMT (3a7004f)">Diff</a>