### PR TITLE
Fix typo "is is", and regenerate html

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9944,7 +9944,7 @@ To propagate the flag change <a>queue a task</a> on the control thread to update
 
 If <code>process()</code> is not called during some rendering
 quantum due to the lack of any applicable <a>active processing
-conditions</a>, the result is is as if the processor emitted
+conditions</a>, the result is as if the processor emitted
 silence for this period.
 
 <h5 dictionary lt="AudioParamDescriptor">

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 6183b7307468d4ebe91020ec360b3be2140e71df" name="generator">
   <link href="https://www.w3.org/TR/webaudio/" rel="canonical">
-  <meta content="94a50063e3b6aa333dfe84d314112027d8d0d5ed" name="document-revision">
+  <meta content="cf8b377780ef1e9e4a14f698fd73d61cf9888a7e" name="document-revision">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML" rel="preload">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/jax.js?rev=2.6.1" rel="preload">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/fonts/STIX/fontdata.js?rev=2.6.1" rel="preload">
@@ -1571,7 +1571,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web Audio API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-04-12">12 April 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-04-13">13 April 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -5070,7 +5070,7 @@ producing different results.) <img alt="Graphical representation of calling canc
        <li data-md="">
         <p>Remove all events with time greater than \(t_c\).</p>
       </ol>
-      <p>If no events are added, then the automation value after <code class="idl"><a data-link-type="idl" href="#dom-audioparam-cancelandholdattime" id="ref-for-dom-audioparam-cancelandholdattime④">cancelAndHoldAtTime()</a></code> is the the constant value that
+      <p>If no events are added, then the automation value after <code class="idl"><a data-link-type="idl" href="#dom-audioparam-cancelandholdattime" id="ref-for-dom-audioparam-cancelandholdattime④">cancelAndHoldAtTime()</a></code> is the constant value that
 	the original timeline would have had at time \(t_c\).</p>
      </div>
      <table class="argumentdef data">
@@ -11418,7 +11418,7 @@ longer producing an output.</p>
    </div>
    <p>If <code>process()</code> is not called during some rendering
 quantum due to the lack of any applicable <a data-link-type="dfn" href="#active-processing-conditions" id="ref-for-active-processing-conditions">active processing
-conditions</a>, the result is is as if the processor emitted
+conditions</a>, the result is as if the processor emitted
 silence for this period.</p>
    <h5 class="heading settled dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" data-level="1.33.4.4" data-lt="AudioParamDescriptor" id="dictdef-audioparamdescriptor"><span class="secno">1.33.4.4. </span><span class="content"> <code class="idl"><a data-link-type="idl" href="#dictdef-audioparamdescriptor" id="ref-for-dictdef-audioparamdescriptor②">AudioParamDescriptor</a></code></span></h5>
    <p>The <code class="idl"><a data-link-type="idl" href="#dictdef-audioparamdescriptor" id="ref-for-dictdef-audioparamdescriptor③">AudioParamDescriptor</a></code> dictionary is used to


### PR DESCRIPTION
Fixes the typo "is is" -> "is"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1569.html" title="Last updated on Apr 13, 2018, 9:05 PM GMT (54b12cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1569/cf8b377...rtoy:54b12cc.html" title="Last updated on Apr 13, 2018, 9:05 PM GMT (54b12cc)">Diff</a>