### PR TITLE
Fix #1571: Link back to createIIRFilter for error conditions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7477,8 +7477,8 @@ $$
 </pre>
 
 where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is
-the length of the \(a\) array. The coefficient \(a_0\) cannot be 0.
-At least one of \(b_m\) MUST be non-zero.
+the length of the \(a\) array. The coefficient \(a_0\) MUST not be 0 (see {{BaseAudioContext/createIIRFilter()/feedback|feedback parameter}} for {{BaseAudioContext/createIIRFilter()}}).
+At least one of \(b_m\) MUST be non-zero (see {{BaseAudioContext/createIIRFilter()/feedforward|feedforward parameter}} for {{BaseAudioContext/createIIRFilter()}}).
 
 Equivalently, the time-domain equation is:
 


### PR DESCRIPTION
Add links back to createIIRFilter parameters to explain what happens
if the coefficients are invalid.