### PR TITLE
Fix #1573: Order IDL section methods

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -706,7 +706,6 @@ interface BaseAudioContext : EventTarget {
 	readonly attribute AudioContextState state;
 	[SameObject, SecureContext]
 	readonly attribute AudioWorklet audioWorklet;
-	Promise<void> resume ();
 	attribute EventHandler onstatechange;
 
 	AnalyserNode createAnalyser ();
@@ -733,6 +732,7 @@ interface BaseAudioContext : EventTarget {
 	Promise<AudioBuffer> decodeAudioData (ArrayBuffer audioData,
 	                                      optional DecodeSuccessCallback successCallback,
 	                                      optional DecodeErrorCallback errorCallback);
+	Promise<void> resume ();
 };
 </xmp>
 

--- a/index.bs
+++ b/index.bs
@@ -708,29 +708,31 @@ interface BaseAudioContext : EventTarget {
 	readonly attribute AudioWorklet audioWorklet;
 	Promise<void> resume ();
 	attribute EventHandler onstatechange;
+
+	AnalyserNode createAnalyser ();
+	BiquadFilterNode createBiquadFilter ();
 	AudioBuffer createBuffer (unsigned long numberOfChannels, unsigned long length, float sampleRate);
-	Promise<AudioBuffer> decodeAudioData (ArrayBuffer audioData,
-	                                      optional DecodeSuccessCallback successCallback,
-	                                      optional DecodeErrorCallback errorCallback);
 	AudioBufferSourceNode createBufferSource ();
+	ChannelMergerNode createChannelMerger (optional unsigned long numberOfInputs = 6);
+	ChannelSplitterNode createChannelSplitter (optional unsigned long numberOfOutputs = 6);
 	ConstantSourceNode createConstantSource ();
+	ConvolverNode createConvolver ();
+	DelayNode createDelay (optional double maxDelayTime = 1.0);
+	DynamicsCompressorNode createDynamicsCompressor ();
+	GainNode createGain ();
+	IIRFilterNode createIIRFilter (sequence<double> feedforward, sequence<double> feedback);
+	OscillatorNode createOscillator ();
+	PannerNode createPanner ();
+	PeriodicWave createPeriodicWave (sequence<float> real, sequence<float> imag, optional PeriodicWaveConstraints constraints);
 	ScriptProcessorNode createScriptProcessor(optional unsigned long bufferSize = 0,
 	                                          optional unsigned long numberOfInputChannels = 2,
 	                                          optional unsigned long numberOfOutputChannels = 2);
-	AnalyserNode createAnalyser ();
-	GainNode createGain ();
-	DelayNode createDelay (optional double maxDelayTime = 1.0);
-	BiquadFilterNode createBiquadFilter ();
-	IIRFilterNode createIIRFilter (sequence<double> feedforward, sequence<double> feedback);
-	WaveShaperNode createWaveShaper ();
-	PannerNode createPanner ();
 	StereoPannerNode createStereoPanner ();
-	ConvolverNode createConvolver ();
-	ChannelSplitterNode createChannelSplitter (optional unsigned long numberOfOutputs = 6);
-	ChannelMergerNode createChannelMerger (optional unsigned long numberOfInputs = 6);
-	DynamicsCompressorNode createDynamicsCompressor ();
-	OscillatorNode createOscillator ();
-	PeriodicWave createPeriodicWave (sequence<float> real, sequence<float> imag, optional PeriodicWaveConstraints constraints);
+	WaveShaperNode createWaveShaper ();
+
+	Promise<AudioBuffer> decodeAudioData (ArrayBuffer audioData,
+	                                      optional DecodeSuccessCallback successCallback,
+	                                      optional DecodeErrorCallback errorCallback);
 };
 </xmp>
 


### PR DESCRIPTION
Order the methods in the BaseAudioContext IDL section to match the
alphabetical ordering of the methods in the Methods section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1574.html" title="Last updated on Apr 18, 2018, 6:02 PM GMT (5fd7d0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1574/1d2caa9...rtoy:5fd7d0b.html" title="Last updated on Apr 18, 2018, 6:02 PM GMT (5fd7d0b)">Diff</a>