### PR TITLE
Fix 1566: adding output channel security info

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11756,7 +11756,7 @@ to Consider</a>
 4. Does this specification expose persistent, cross-origin state to
 	the web?
 
-	Yes, the supported audio sample rate(s) are exposed.
+	Yes, the supported audio sample rate(s) and the output device channel count are exposed.
 
 5. Does this specification expose any other data to an origin that it
 	doesn’t currently have access to?


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/1579.html" title="Last updated on Apr 20, 2018, 12:59 PM GMT (f43e8f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1579/a8c2b6a...f43e8f8.html" title="Last updated on Apr 20, 2018, 12:59 PM GMT (f43e8f8)">Diff</a>