### PR TITLE
fix #1486

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5712,7 +5712,7 @@ enum BiquadFilterType {
 			:: Not used in this filter type.
 </table>
 </div>
-	
+
 All attributes of the {{BiquadFilterNode}} are <a>a-rate</a> {{AudioParam}}s.
 
 <pre class="idl">
@@ -11853,12 +11853,22 @@ to Consider</a>
 	It does of necessity allow access to the users audio output device
 	or devices, which are sometimes separate units to the computer.
 
-	For voice or sound-actuated devices, Web Audio API might be used
+	For voice or sound-actuated devices, Web Audio API <em>might</em> be used
 	to control other devices. In addition, if the sound-operated device is sensitive
 	to near ultrasonic frequencies, such control might not be audible.
 	This possibility also exists with HTML, through
 	the &lt;audio&gt; element. At common audio sampling rates, there is (by design)
-	insufficient headroom for much ultrasonic information.
+	insufficient headroom for much ultrasonic information:
+
+	The limit of human hearing is usually stated as 20kHz. For a 44.1kHz
+	sampling rate, the Nyquist limit is 22.05kHz. Given that a true
+	brickwall filter cannot be physically realized, the space between
+	20kHz and 22.05kHz is used for a rapid rolloff filter to strongly
+	attenuate all frequencies above Nyquist.
+
+	At 48kHz sampling rate, there is still rapid attenuation in the
+	20kHz to 24kHz band (but it is easier to avoid phase ripple
+	errors in the passband).
 
 11. Does this specification allow an origin some measure of control
 	over a user agent’s native UI?
@@ -11994,8 +12004,8 @@ Since Working Draft of 08 December 2015</h3>
 * Added a list of nodes and reason why they can add latency, in an informative section.
 * Speced nominal ranges, nyquist, and behavior when outside the range.
 * Spec the processing model for the Web Audio API.
-* Merge the SpatialPannerNode into the PannerNode, undeprecating the PannerNode. 
-* Merge the SpatialListener into the AudioListener, undeprecating the AudioListener. 
+* Merge the SpatialPannerNode into the PannerNode, undeprecating the PannerNode.
+* Merge the SpatialListener into the AudioListener, undeprecating the AudioListener.
 * Added latencyHint(s).
 * Move the constructor from BaseAudioContext to AudioContext where it belongs; BaseAudioContext is not constructible.
 * Specified the Behavior of automations and nominal ranges.


### PR DESCRIPTION
Add requested detail on ultrasonic headroom to relevant part of privacy appendix re: ultrasonic signalling


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/1585.html" title="Last updated on Apr 27, 2018, 3:50 PM GMT (2adf734)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1585/9703e2d...2adf734.html" title="Last updated on Apr 27, 2018, 3:50 PM GMT (2adf734)">Diff</a>