### PR TITLE
Fix #1580: connect/disconnect must throw on closed contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -683,12 +683,16 @@ enum AudioContextState {
 			<td>
 				This context has been released, and can no longer be used to
 				process audio. All system audio resources have been released.
-				<span class="synchronous">Attempts to create new Nodes on the
-				AudioContext will throw {{InvalidStateError}}</span>.
-				(AudioBuffers may still be created,
-				through {{BaseAudioContext/createBuffer()}},
-				{{BaseAudioContext/decodeAudioData()}},
-				or the {{AudioBuffer}} constructor.)
+				<span class="synchronous">Attempts to create new {{AudioNode}}s on the
+				{{BaseAudioContext}} MUST throw {{InvalidStateError}}</span>.
+				<span class="synchronous">{{AudioNode/connect()|Connecting}} or
+				{{AudioNode/disconnect()|disconnecting}} audio
+				nodes MUST throw {{InvalidStateError}}</span>.
+
+				AudioBuffers may still be created, through
+				{{BaseAudioContext/createBuffer()}},
+				{{BaseAudioContext/decodeAudioData()}}, or the {{AudioBuffer}}
+				constructor.)
 </table>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -685,8 +685,7 @@ enum AudioContextState {
 				process audio. All system audio resources have been released.
 				<span class="synchronous">Attempts to create new {{AudioNode}}s on the
 				{{BaseAudioContext}} MUST throw {{InvalidStateError}}</span>.
-				<span class="synchronous">{{AudioNode/connect()|Connecting}} or
-				{{AudioNode/disconnect()|disconnecting}} audio
+				<span class="synchronous">Connecting or disconnecting audio
 				nodes MUST throw {{InvalidStateError}}</span>.
 
 				AudioBuffers may still be created, through


### PR DESCRIPTION
Update the description of the "closed" state to say you can't connect
or disconnect if the context is closed.  Also change "will" to MUST
for the sentence about creating new nodes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1586.html" title="Last updated on Apr 27, 2018, 7:07 PM GMT (6d353cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1586/d5a5d1c...rtoy:6d353cc.html" title="Last updated on Apr 27, 2018, 7:07 PM GMT (6d353cc)">Diff</a>