### PR TITLE
Fix #1577: Add constraints in constructor methods if necessary

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2410,19 +2410,20 @@ dictionary AudioBufferOptions {
 <h5 id="dictionary-audiobufferoptions-members">
 Dictionary {{AudioBufferOptions}} Members</h5>
 
+The allowed values for the members of this dictionary are constrained.  See {{BaseAudioContext/createBuffer()}.
+
 <dl dfn-type=dict-member dfn-for="AudioBufferOptions">
 	: <dfn>length</dfn>
 	::
-		The length in sample frames of the buffer.  This cannot be zero. (See {{BaseAudioContext/createBuffer()}}).
+		The length in sample frames of the buffer.
 
 	: <dfn>numberOfChannels</dfn>
 	::
-		The number of channels for the buffer.  This cannot be zero. (See {{BaseAudioContext/createBuffer()}}).
+		The number of channels for the buffer.
 
 	: <dfn>sampleRate</dfn>
 	::
-		The sample rate in Hz for the buffer. The value is constrained to it's nominal
-		range. (See {{BaseAudioContext/createBuffer()}}).
+		The sample rate in Hz for the buffer.
 </dl>
 
 
@@ -6173,7 +6174,7 @@ Dictionary {{ChannelMergerOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="ChannelMergerOptions">
 	: <dfn>numberOfInputs</dfn>
-	:: The number inputs for the {{ChannelSplitterNode}}.  See {{BaseAudioContext/createChannelMerger()}} for constraints on this value.
+	:: The number inputs for the {{ChannelMergerNode}}.  See {{BaseAudioContext/createChannelMerger()}} for constraints on this value.
 </dl>
 
 
@@ -6782,7 +6783,7 @@ Dictionary {{DelayOptions}} Members</h5>
 	:: The initial delay time for the node.
 
 	: <dfn>maxDelayTime</dfn>
-	:: The maximum delay time for the node.  See {{BaseAudioContext/createDelay()/maxDelayTime}} for constraints.
+	:: The maximum delay time for the node.  See {{BaseAudioContext/createDelay(maxDelayTime)/maxDelayTime!!argument|createDelay(maxDelayTime)}} for constraints.
 </dl>
 
 
@@ -7457,13 +7458,13 @@ Dictionary {{IIRFilterOptions}} Members</h5>
 	::
 		The feedforward coefficients for the
 		{{IIRFilterNode}}. This member is required. If
-		not specifed, a {{NotFoundError}} MUST be thrown.  See {{BaseAudioContext/createIIRFilter()/feedforward}} for other constraints.
+		not specifed, a {{NotFoundError}} MUST be thrown.  See {{BaseAudioContext/createIIRFilter()/feedforward}} argument of {{BaseAudioContext/createIIRFilter()}} for other constraints.
 
 	: <dfn>feedback</dfn>
 	::
 		The feedback coefficients for the
 		{{IIRFilterNode}}. This member is required. If
-		not specifed, a {{NotFoundError}} MUST be thrown. See {{BaseAudioContext/createIIRFilter()/feedback}} for other constraints.
+		not specifed, a {{NotFoundError}} MUST be thrown. See {{BaseAudioContext/createIIRFilter()/feedback}} argument of {{BaseAudioContext/createIIRFilter()}} for other constraints.
 </dl>
 
 <h4 id="IIRFilterNode-filter-definition">

--- a/index.bs
+++ b/index.bs
@@ -2413,15 +2413,16 @@ Dictionary {{AudioBufferOptions}} Members</h5>
 <dl dfn-type=dict-member dfn-for="AudioBufferOptions">
 	: <dfn>length</dfn>
 	::
-		The length in sample frames of the buffer.
+		The length in sample frames of the buffer.  This cannot be zero. (See {{BaseAudioContext/createBuffer()}}).
 
 	: <dfn>numberOfChannels</dfn>
 	::
-		The number of channels for the buffer.
+		The number of channels for the buffer.  This cannot be zero. (See {{BaseAudioContext/createBuffer()}}).
 
 	: <dfn>sampleRate</dfn>
 	::
-		The sample rate in Hz for the buffer.
+		The sample rate in Hz for the buffer. The value is constrained to it's nominal
+		range. (See {{BaseAudioContext/createBuffer()}}).
 </dl>
 
 
@@ -6172,7 +6173,7 @@ Dictionary {{ChannelMergerOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="ChannelMergerOptions">
 	: <dfn>numberOfInputs</dfn>
-	:: The number inputs for the {{ChannelSplitterNode}}.
+	:: The number inputs for the {{ChannelSplitterNode}}.  See {{BaseAudioContext/createChannelMerger()}} for constraints on this value.
 </dl>
 
 
@@ -6284,7 +6285,7 @@ Dictionary {{ChannelSplitterOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="ChannelSplitterOptions">
 	: <dfn>numberOfOutputs</dfn>
-	:: The number outputs for the {{ChannelSplitterNode}}.
+	:: The number outputs for the {{ChannelSplitterNode}}.  See {{BaseAudioContext/createChannelSplitter()}} for constraints on this value.
 </dl>
 
 
@@ -6778,10 +6779,10 @@ Dictionary {{DelayOptions}} Members</h5>
 
 <dl dfn-type=dict-member dfn-for="DelayOptions">
 	: <dfn>delayTime</dfn>
-	:: The maximum delay time for the node.
+	:: The initial delay time for the node.
 
 	: <dfn>maxDelayTime</dfn>
-	:: The initial delay time for the node.
+	:: The maximum delay time for the node.  See {{BaseAudioContext/createDelay()/maxDelayTime}} for constraints.
 </dl>
 
 
@@ -7456,13 +7457,13 @@ Dictionary {{IIRFilterOptions}} Members</h5>
 	::
 		The feedforward coefficients for the
 		{{IIRFilterNode}}. This member is required. If
-		not specifed, a {{NotFoundError}} MUST be thrown.
+		not specifed, a {{NotFoundError}} MUST be thrown.  See {{BaseAudioContext/createIIRFilter()/feedforward}} for other constraints.
 
 	: <dfn>feedback</dfn>
 	::
 		The feedback coefficients for the
 		{{IIRFilterNode}}. This member is required. If
-		not specifed, a {{NotFoundError}} MUST be thrown.
+		not specifed, a {{NotFoundError}} MUST be thrown. See {{BaseAudioContext/createIIRFilter()/feedback}} for other constraints.
 </dl>
 
 <h4 id="IIRFilterNode-filter-definition">

--- a/index.bs
+++ b/index.bs
@@ -2410,7 +2410,7 @@ dictionary AudioBufferOptions {
 <h5 id="dictionary-audiobufferoptions-members">
 Dictionary {{AudioBufferOptions}} Members</h5>
 
-The allowed values for the members of this dictionary are constrained.  See {{BaseAudioContext/createBuffer()}.
+The allowed values for the members of this dictionary are constrained.  See {{BaseAudioContext/createBuffer()}}.
 
 <dl dfn-type=dict-member dfn-for="AudioBufferOptions">
 	: <dfn>length</dfn>


### PR DESCRIPTION
Just went through the factory methods that had parameters and looked
to see if there were constraints on the values of the parameters.
Then looked at the constructor options dictionary and linked to these
constraints if needed.

While we're here also fix #1588, which has the descriptions of the
`DelayOptions` members backwards.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1589.html" title="Last updated on Apr 27, 2018, 11:28 PM GMT (ca7bcd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1589/d5a5d1c...rtoy:ca7bcd8.html" title="Last updated on Apr 27, 2018, 11:28 PM GMT (ca7bcd8)">Diff</a>