### PR TITLE
Order nodes alphabetically

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2722,12 +2722,12 @@ Attributes</h4>
 				MUST be thrown for any attempt to change the
 				value.</span>
 
-		: {{ChannelSplitterNode}}
+		: {{ChannelMergerNode}}
 		::
 			The channel count cannot be changed, and an <span class="synchronous">{{InvalidStateError}} exception MUST
 			be thrown for any attempt to change the value.</span>
 
-		: {{ChannelMergerNode}}
+		: {{ChannelSplitterNode}}
 		::
 			The channel count cannot be changed, and an <span class="synchronous">{{InvalidStateError}} exception MUST
 			be thrown for any attempt to change the value.</span>
@@ -2781,15 +2781,15 @@ Attributes</h4>
 			{{OfflineAudioContext}}, then the channel count mode
 			cannot be changed. An <span class="synchronous">{{InvalidStateError}} exception MUST
 			be thrown for any attempt to change the value.</span>
-
-		: {{ChannelSplitterNode}}
+		: {{ChannelMergerNode}}
 		::
 			The channel count mode cannot be changed from "{{ChannelCountMode/explicit}}" and
 			an <span class="synchronous">{{InvalidStateError}}
 			exception MUST be thrown for any attempt to change the
 			value.</span>
 
-		: {{ChannelMergerNode}}
+
+		: {{ChannelSplitterNode}}
 		::
 			The channel count mode cannot be changed from "{{ChannelCountMode/explicit}}" and
 			an <span class="synchronous">{{InvalidStateError}}

--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ Possible extra rowspan handling
   </style>
   <meta content="Bikeshed version 6183b7307468d4ebe91020ec360b3be2140e71df" name="generator">
   <link href="https://www.w3.org/TR/webaudio/" rel="canonical">
-  <meta content="d5a5d1c94ec7ea0f935fe0dbc9604b97327c3355" name="document-revision">
+  <meta content="aeebab871159f8251277e3ef21abc2a8d6f875ae" name="document-revision">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML" rel="preload">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/jax.js?rev=2.6.1" rel="preload">
   <link as="script" href="https://www.w3.org/scripts/MathJax/2.6.1/jax/output/HTML-CSS/fonts/STIX/fontdata.js?rev=2.6.1" rel="preload">
@@ -1571,7 +1571,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Web Audio API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-04-30">30 April 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-05-01">1 May 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -4386,11 +4386,11 @@ range</span>.</p>
 MUST be thrown for any attempt to change the
 value.</span></p>
        </dl>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelsplitternode" id="ref-for-channelsplitternode④">ChannelSplitterNode</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelmergernode" id="ref-for-channelmergernode④">ChannelMergerNode</a></code>
       <dd data-md="">
        <p>The channel count cannot be changed, and an <span class="synchronous"><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①⓪">InvalidStateError</a></code> exception MUST
 be thrown for any attempt to change the value.</span></p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelmergernode" id="ref-for-channelmergernode④">ChannelMergerNode</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelsplitternode" id="ref-for-channelsplitternode④">ChannelSplitterNode</a></code>
       <dd data-md="">
        <p>The channel count cannot be changed, and an <span class="synchronous"><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①①">InvalidStateError</a></code> exception MUST
 be thrown for any attempt to change the value.</span></p>
@@ -4430,12 +4430,12 @@ mode:</p>
        <p>If the <code class="idl"><a data-link-type="idl" href="#AudioDestinationNode" id="ref-for-AudioDestinationNode①④">AudioDestinationNode</a></code> is the <code class="idl"><a data-link-type="idl" href="#dom-baseaudiocontext-destination" id="ref-for-dom-baseaudiocontext-destination②">destination</a></code> node of an <code class="idl"><a data-link-type="idl" href="#offlineaudiocontext" id="ref-for-offlineaudiocontext①⑨">OfflineAudioContext</a></code>, then the channel count mode
 cannot be changed. An <span class="synchronous"><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①③">InvalidStateError</a></code> exception MUST
 be thrown for any attempt to change the value.</span></p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelsplitternode" id="ref-for-channelsplitternode⑤">ChannelSplitterNode</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelmergernode" id="ref-for-channelmergernode⑤">ChannelMergerNode</a></code>
       <dd data-md="">
        <p>The channel count mode cannot be changed from "<code class="idl"><a data-link-type="idl" href="#dom-channelcountmode-explicit" id="ref-for-dom-channelcountmode-explicit①">explicit</a></code>" and
 an <span class="synchronous"><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①④">InvalidStateError</a></code> exception MUST be thrown for any attempt to change the
 value.</span></p>
-      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelmergernode" id="ref-for-channelmergernode⑤">ChannelMergerNode</a></code>
+      <dt data-md=""><code class="idl"><a data-link-type="idl" href="#channelsplitternode" id="ref-for-channelsplitternode⑤">ChannelSplitterNode</a></code>
       <dd data-md="">
        <p>The channel count mode cannot be changed from "<code class="idl"><a data-link-type="idl" href="#dom-channelcountmode-explicit" id="ref-for-dom-channelcountmode-explicit②">explicit</a></code>" and
 an <span class="synchronous"><code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#invalidstateerror" id="ref-for-invalidstateerror①⑤">InvalidStateError</a></code> exception MUST be thrown for any attempt to change the


### PR DESCRIPTION
In the sections giving contraints on the `channelCount` and
`channelCountMode`, the nodes are listed alphabetically except that
`ChannelSplitterNode` comes before `ChannelMergerNode`.  Reverse the
order so that everything is alphabetical.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1592.html" title="Last updated on May 1, 2018, 4:34 PM GMT (0842a3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1592/7b1ef2b...rtoy:0842a3d.html" title="Last updated on May 1, 2018, 4:34 PM GMT (0842a3d)">Diff</a>