### PR TITLE
Fix AudioWorkletProcessor process function examples: they should retu…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9376,6 +9376,9 @@ class BypassProcessor extends AudioWorkletProcessor {
 		let input = inputs[0];
 		let output = outputs[0];
 		output[0].set(input[0]);
+
+		// To keep this processor alive.
+		return true;
 	}
 });
 
@@ -9844,6 +9847,9 @@ class MyProcessor extends AudioWorkletProcessor {
 				output[channel][i] = input[channel][i] * myParam[0];
 			}
 		}
+
+		// To keep this processor alive.
+		return true;
 	}
 }
 </pre>


### PR DESCRIPTION
…rn true so processing will continue

As discussed in #1593.

@hoch I used the same wording you used in [1] which LGTM.

[1]: https://developers.google.com/web/updates/2017/12/audio-worklet#audioworkletprocessorprocess_method


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ArnaudBienner/web-audio-api/pull/1594.html" title="Last updated on May 1, 2018, 10:04 PM GMT (ccbca13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1594/7776603...ArnaudBienner:ccbca13.html" title="Last updated on May 1, 2018, 10:04 PM GMT (ccbca13)">Diff</a>