### PR TITLE
Fix processorOptions in audioworkletnodeoptions IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9672,7 +9672,7 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
 	unsigned long numberOfOutputs = 1;
 	sequence<unsigned long> outputChannelCount;
 	record<DOMString, double> parameterData;
-	object processorOptions = null;
+	object? processorOptions = null;
 };
 </xmp>
 


### PR DESCRIPTION
I'm starting to implement this on Firefox and have build error because the following '?' was missing.
I'm not an expert on WebIDL, but someone pointed me to [1] which indeed seems to state that '?' is required.

[1]: https://heycam.github.io/webidl/#idl-nullable-type
