### PR TITLE
ChannelSplitterNode should receive ChannelSplitterOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6249,7 +6249,7 @@ desired.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelSplitterNode options)]
+ Constructor (BaseAudioContext context, optional ChannelSplitterOptions options)]
 interface ChannelSplitterNode : AudioNode {
 };
 </pre>


### PR DESCRIPTION
https://webaudio.github.io/web-audio-api/#ChannelSplitterNode-constructors

Its constructor should receive a dictionary but instead is receiving an instance of itself.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/web-audio-api/pull/1602.html" title="Last updated on May 6, 2018, 7:41 AM GMT (ee04138)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1602/567584d...saschanaz:ee04138.html" title="Last updated on May 6, 2018, 7:41 AM GMT (ee04138)">Diff</a>