### PR TITLE
[WIP] ChannelSplitter constructor accespts ChannelSplitterOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6249,7 +6249,7 @@ desired.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelSplitterNode options)]
+ Constructor (BaseAudioContext context, optional ChannelSplitterOptions options)]
 interface ChannelSplitterNode : AudioNode {
 };
 </pre>


### PR DESCRIPTION
Not ChannelSplitterNode.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1603.html" title="Last updated on May 7, 2018, 4:46 PM GMT (2514225)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1603/567584d...rtoy:2514225.html" title="Last updated on May 7, 2018, 4:46 PM GMT (2514225)">Diff</a>