### PR TITLE
Fix #1607: Media nodes are only for AudioContexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7536,7 +7536,7 @@ by this node.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, MediaElementAudioSourceOptions options)]
+ Constructor (AudioContext context, MediaElementAudioSourceOptions options)]
 interface MediaElementAudioSourceNode : AudioNode {
 	[SameObject] readonly attribute HTMLMediaElement mediaElement;
 };
@@ -7665,7 +7665,7 @@ The number of channels of the input is by default 2 (stereo).
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional AudioNodeOptions options)]
+ Constructor (AudioContext context, optional AudioNodeOptions options)]
 interface MediaStreamAudioDestinationNode : AudioNode {
 	readonly attribute MediaStream stream;
 };
@@ -7732,7 +7732,7 @@ channel.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, MediaStreamAudioSourceOptions options)]
+ Constructor (AudioContext context, MediaStreamAudioSourceOptions options)]
 interface MediaStreamAudioSourceNode : AudioNode {
 	[SameObject] readonly attribute MediaStream mediaStream;
 };


### PR DESCRIPTION
Update IDL so that the constructors for the Media nodes only accept
`AudioContext`, not `BaseAudioContext`.  The factory methods are only
defined for an `AudioContext`, so the constructors should have the
same constraint.

Plus, it's not really clear how such real-time objects should work on
an offline context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1609.html" title="Last updated on May 11, 2018, 3:56 PM GMT (13be893)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1609/4d27958...rtoy:13be893.html" title="Last updated on May 11, 2018, 3:56 PM GMT (13be893)">Diff</a>