### PR TITLE
Make it easier to maintain expected-errs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ install:
   - bikeshed update
 
 script:
-  # Run bikeshed and save the output, but remove the line numbers from
-  # the log. Then compare with the expected results.  Any differences
-  # need to be fixed.
-  - bikeshed --print=plain -f spec 2>&1 | sed 's;^LINE [0-9]*:;LINE:;' | tee bs.log
-  # Make sure bs.log ends with a newline and compare with expected results.
-  - sed -e '$a\'  bs.log | diff -u expected-errs.txt -
+  # Run bikeshed and save the output.  You can use this output as is
+  # to update expected-errs.txt.
+  - bikeshed --print=plain -f spec 2>&1 | tee bs.log
+  # Remove the line numbers from the log, and make sure it ends with a
+  # newline.
+  - sed 's;^LINE [0-9]*:;LINE:;' bs.log | sed -e '$a\' > actual-errs.txt
+  # Do the same for the expected errors and compare the two.  Any
+  # differences need to be fixed.
+  - sed 's;^LINE [0-9]*:;LINE:;' expected-errs.txt | sed -e '$a\' | diff -u - actual-errs.txt
 
 branches:
   only:

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -9,53 +9,53 @@ WARNING: Multiple elements have the same ID 'dom-decodeerrorcallback-error'.
 Deduping, but this ID may not be stable across revisions.
 WARNING: Multiple elements have the same ID 'dom-decodesuccesscallback-decodeddata'.
 Deduping, but this ID may not be stable across revisions.
-LINE: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE 1904: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)' in the argumentdef block.
+LINE 2907: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
+LINE 2907: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
+LINE 3008: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE 3018: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE 3033: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE 3033: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINK ERROR: No 'idl-name' refs found for 'MediaStream'.
 <a data-link-type="idl-name" class="n" data-lt="MediaStream">MediaStream</a>
 LINK ERROR: No 'idl-name' refs found for 'MediaStreamTrack'.
 <a data-link-type="idl-name" class="n" data-lt="MediaStreamTrack">MediaStreamTrack</a>
-LINE: No 'method' refs found for 'AudioContext()'.
+LINE 1470: No 'method' refs found for 'AudioContext()'.
 LINK ERROR: No 'idl-name' refs found for 'DOMHighResTimeStamp'.
 <a data-link-type="idl-name" class="n" data-lt="DOMHighResTimeStamp">DOMHighResTimeStamp</a>
 LINK ERROR: No 'idl-name' refs found for 'DOMHighResTimeStamp'.
 <a data-link-type="idl-name" data-lt="DOMHighResTimeStamp">DOMHighResTimeStamp</a>
-LINE: No 'method' refs found for 'OfflineAudioContext(contextOptions)'.
-LINE: No 'method' refs found for 'OfflineAudioContext(numberOfChannels, length, sampleRate)'.
-LINE: No 'method' refs found for 'AudioBuffer()'.
-LINE: No 'method' refs found for 'AnalyserNode()'.
-LINE: No 'method' refs found for 'AudioBufferSourceNode()'.
-LINE: No 'method' refs found for 'BiquadFilterNode()'.
-LINE: No 'method' refs found for 'ChannelMergerNode()'.
-LINE: No 'method' refs found for 'ChannelSplitterNode()'.
-LINE: No 'method' refs found for 'ConstantSourceNode()'.
-LINE: No 'method' refs found for 'ConvolverNode()'.
-LINE: No 'method' refs found for 'DelayNode()'.
-LINE: No 'method' refs found for 'DynamicsCompressorNode()'.
-LINE: No 'method' refs found for 'GainNode()'.
-LINE: No 'method' refs found for 'IIRFilterNode()'.
-LINE: No 'method' refs found for 'MediaElementAudioSourceNode()'.
-LINE: No 'method' refs found for 'MediaStreamAudioDestinationNode()'.
+LINE 1904: No 'method' refs found for 'OfflineAudioContext(contextOptions)'.
+LINE 1928: No 'method' refs found for 'OfflineAudioContext(numberOfChannels, length, sampleRate)'.
+LINE 2222: No 'method' refs found for 'AudioBuffer()'.
+LINE 4091: No 'method' refs found for 'AnalyserNode()'.
+LINE 4528: No 'method' refs found for 'AudioBufferSourceNode()'.
+LINE 5743: No 'method' refs found for 'BiquadFilterNode()'.
+LINE 6157: No 'method' refs found for 'ChannelMergerNode()'.
+LINE 6269: No 'method' refs found for 'ChannelSplitterNode()'.
+LINE 6351: No 'method' refs found for 'ConstantSourceNode()'.
+LINE 6462: No 'method' refs found for 'ConvolverNode()'.
+LINE 6731: No 'method' refs found for 'DelayNode()'.
+LINE 6865: No 'method' refs found for 'DynamicsCompressorNode()'.
+LINE 7308: No 'method' refs found for 'GainNode()'.
+LINE 7415: No 'method' refs found for 'IIRFilterNode()'.
+LINE 7559: No 'method' refs found for 'MediaElementAudioSourceNode()'.
+LINE 7688: No 'method' refs found for 'MediaStreamAudioDestinationNode()'.
 LINK ERROR: No 'idl-name' refs found for 'MediaStream'.
 <a data-link-type="idl-name" data-lt="MediaStream">MediaStream</a>
-LINE: No 'method' refs found for 'MediaStreamAudioSourceNode()'.
-LINE: No 'method' refs found for 'MediaStreamTrackAudioSourceNode()'.
+LINE 7755: No 'method' refs found for 'MediaStreamAudioSourceNode()'.
+LINE 7825: No 'method' refs found for 'MediaStreamTrackAudioSourceNode()'.
 LINK ERROR: No 'idl-name' refs found for 'MediaStreamTrack'.
 <a data-link-type="idl-name" data-lt="MediaStreamTrack">MediaStreamTrack</a>
-LINE: No 'method' refs found for 'OscillatorNode()'.
-LINE: No 'method' refs found for 'PannerNode()'.
-LINE: No 'method' refs found for 'PeriodicWave()'.
-LINE: No 'method' refs found for 'StereoPannerNode()'.
-LINE: No 'method' refs found for 'WaveShaperNode()'.
-LINE: No 'method' refs found for 'AudioWorkletNode()'.
+LINE 7964: No 'method' refs found for 'OscillatorNode()'.
+LINE 8339: No 'method' refs found for 'PannerNode()'.
+LINE 8744: No 'method' refs found for 'PeriodicWave()'.
+LINE 9056: No 'method' refs found for 'StereoPannerNode()'.
+LINE 9186: No 'method' refs found for 'WaveShaperNode()'.
+LINE 9624: No 'method' refs found for 'AudioWorkletNode()'.
 LINK ERROR: No 'idl-name' refs found for 'sequence<unsigned long>'.
 <a data-link-type="idl-name" data-lt="sequence&lt;unsigned long&gt;">sequence&lt;unsigned long&gt;</a>
 LINK ERROR: No 'idl-name' refs found for 'record<DOMString, double>'.
 <a data-link-type="idl-name" data-lt="record&lt;DOMString, double&gt;">record&lt;DOMString, double&gt;</a>
-LINE: No 'method' refs found for 'AudioWorkletProcessor()'.
+LINE 9798: No 'method' refs found for 'AudioWorkletProcessor()'.
 YAY Successfully generated, but fatal errors were suppressed


### PR DESCRIPTION
When building locally and the expected errors change, it would be
really nice if you could just copy the actual output from bikeshed to
expected-errs.txt.  Then when running travis, have travis do the
necessary things to compare the actual output with the expected.

And printing out the actual log might make it easier to find and fix
issues because bikeshed does produce line numbers for where the issues
are.

Travis takes care of removing the line numbers and such from both and
does the comparison.