### PR TITLE
Issue #1502: Fix single use of attack and release vars

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -1,7 +1,5 @@
 WARNING: The following <var>s were only used once in the document:
   'target gain', in algorithm 'reduction-gain'
-  'release', in algorithm 'reduction-gain'
-  'attack', in algorithm 'reduction-gain'
   'final gain', in algorithm 'reduction-gain'
   'this', in algorithm 'audioworklet construction'
 If these are not typos, please add an ignore='' attribute to the <var>.

--- a/index.bs
+++ b/index.bs
@@ -7116,7 +7116,7 @@ values. Those values persist accros invocation of this algorithm.
 
 		5. Clamp <var>detector average</var> to a maximum of 1.0.
 
-		6. Let <var>envelope rate</var> be the result of <a>computing the envelope rate</a>.
+		6. Let <var>envelope rate</var> be the result of <a>computing the envelope rate</a> based on values of <var>attack</var> and <var>release</var>.
 
 		7. If <var>releasing</var> is `true`, set
 			<var>compressor gain</var> to the multiplication of
@@ -7171,7 +7171,7 @@ the compressor so it is comparable to the input level.
 	<dfn>Computing the envelope rate</dfn> is done
 	by applying a function to the ratio of the <var>compressor
 	gain</var> and the <var>detector average</var>. User-agents are
-	allowed to choose the shape the envelope function. However, this
+	allowed to choose the shape of the envelope function. However, this
 	function MUST respect the following constraints:
 
 	* The envelope rate MUST be the calculated from the ratio of the
@@ -7181,10 +7181,10 @@ the compressor so it is comparable to the input level.
 		releasing, this number is strictly greater than 1.
 
 	* The attack curve MUST be a continuous, monotonically increasing
-		function in the range \([0, 1]\).
+		function in the range \([0, 1]\).  The shape of this curve MAY be controlled by {{DynamicsCompressorNode/attack}}.
 
 	* The release curve MUST be a continuous, monotonically
-		decreasing function that is always greater than 1.
+		decreasing function that is always greater than 1.  The shape of this curve MAY be controlled by {{DynamicsCompressorNode/release}}.
 
 	This operation returns the value computed by applying this function
 	to the ratio of <var>compressor gain</var> and <var>detector


### PR DESCRIPTION
Add a reference to these vars to the item step where the envelope rate
is computed.  Also add a note the envelope rate algorithm.

Finally, fix a simple typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1612.html" title="Last updated on May 14, 2018, 6:15 PM GMT (30770ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1612/868ad5c...rtoy:30770ce.html" title="Last updated on May 14, 2018, 6:15 PM GMT (30770ce)">Diff</a>