### PR TITLE
Fix #1614: Remove [Exposed=Window] from enums and dictionaries

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1355,7 +1355,6 @@ Note: For example, a user agent could require that an
 running is <a>triggered by user activation</a> (as described in [[HTML]]).
 
 <pre class="idl">
-[Exposed=Window]
 enum AudioContextLatencyCategory {
 		"balanced",
 		"interactive",
@@ -1783,7 +1782,6 @@ The {{AudioContextOptions}} dictionary is used to
 specify user-specified options for an {{AudioContext}}.
 
 <pre class="idl">
-[Exposed=Window]
 dictionary AudioContextOptions {
 	(AudioContextLatencyCategory or double) latencyHint = "interactive";
 	float sampleRate;
@@ -1825,7 +1823,6 @@ Dictionary {{AudioContextOptions}} Members</h5>
 {{AudioTimestamp}}</h4>
 
 <pre class="idl">
-[Exposed=Window]
 dictionary AudioTimestamp {
 	double contextTime;
 	DOMHighResTimeStamp performanceTime;
@@ -2070,7 +2067,6 @@ This specifies the options to use in constructing an
 {{OfflineAudioContext}}.
 
 <pre class="idl">
-[Exposed=Window]
 dictionary OfflineAudioContextOptions {
 	unsigned long numberOfChannels = 1;
 	required unsigned long length;
@@ -2122,7 +2118,6 @@ Attributes</h5>
 {{OfflineAudioCompletionEventInit}}</h5>
 
 <pre class="idl">
-[Exposed=Window]
 dictionary OfflineAudioCompletionEventInit : EventInit {
 	required AudioBuffer renderedBuffer;
 };
@@ -2616,7 +2611,6 @@ This means that it is possible to dispatch events to
 accept events.
 
 <pre class="idl">
-[Exposed=Window]
 enum ChannelCountMode {
 	"max",
 	"clamped-max",
@@ -2659,7 +2653,6 @@ mixing is to be done.
 </div>
 
 <pre class="idl">
-[Exposed=Window]
 enum ChannelInterpretation {
 	"speakers",
 	"discrete"


### PR DESCRIPTION
As it says, remove `[Exposed=Window]` from `enum` and `dictionary` entries.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1615.html" title="Last updated on May 15, 2018, 3:48 PM GMT (3475dba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1615/868ad5c...rtoy:3475dba.html" title="Last updated on May 15, 2018, 3:48 PM GMT (3475dba)">Diff</a>