### PR TITLE
Fix #1616: Fix warnings about unexported dfns.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8957,7 +8957,7 @@ macros:
 </pre>
 
 The {{ScriptProcessorNode}} is constructed with a
-{{bufferSize}} which MUST be one of the following values: 256,
+{{BaseAudioContext/createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)/bufferSize}} which MUST be one of the following values: 256,
 512, 1024, 2048, 4096, 8192, 16384. This value controls how
 frequently the {{ScriptProcessorNode/onaudioprocess}} event is dispatched and how
 many sample-frames need to be processed each call. {{ScriptProcessorNode/onaudioprocess}} events are only

--- a/index.bs
+++ b/index.bs
@@ -8957,7 +8957,7 @@ macros:
 </pre>
 
 The {{ScriptProcessorNode}} is constructed with a
-<dfn>bufferSize</dfn> which MUST be one of the following values: 256,
+{{bufferSize}} which MUST be one of the following values: 256,
 512, 1024, 2048, 4096, 8192, 16384. This value controls how
 frequently the {{ScriptProcessorNode/onaudioprocess}} event is dispatched and how
 many sample-frames need to be processed each call. {{ScriptProcessorNode/onaudioprocess}} events are only
@@ -10739,7 +10739,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.
 
 			5. Else, if this {{AudioNode}} is a <a>destination node</a>,
-				<a href="record-input">record the input</a> of this {{AudioNode}}.
+				[=Recording the input|record the input=] of this {{AudioNode}}.
 
 			6. Else, <a>process</a> the <a>input buffer</a>, and
 				<a href="#available-for-reading">make available for reading</a> the


### PR DESCRIPTION
The `dfn` for `bufferSize` should really be a link to the `bufferSize`
parameter fo `createScriptProcessor`

The link to "record the input" should link to "Recording the input"
dfn.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1617.html" title="Last updated on May 15, 2018, 6:00 PM GMT (5a50aae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1617/868ad5c...rtoy:5a50aae.html" title="Last updated on May 15, 2018, 6:00 PM GMT (5a50aae)">Diff</a>