### PR TITLE
Fix #1620: broken links in rendering algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10723,8 +10723,8 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, invoke associated
 				{{AudioWorkletProcessor}}'s <a href="#audioworkletprocessor-process">
-				process</a> method to <a href="computing-block">compute a block of
-				audio</a> with the argument of <a href="#">input buffer</a>, output
+				process</a> method to [=Computing a block of audio|compute a block of
+				audio=] with the argument of [=input buffer=], output
 				buffer and <a href="#input-audioparam-buffer">input AudioParam buffer
 				</a>.
 


### PR DESCRIPTION
Just fixed the broken link from AudioWorklet "input buffer" to point
to the current "input buffer" dfn in the algorithm.

Also fixed the broken link about computing a block of audio (for the
AudioWorklet).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1624.html" title="Last updated on May 16, 2018, 7:42 PM GMT (29d613a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1624/a016c3d...rtoy:29d613a.html" title="Last updated on May 16, 2018, 7:42 PM GMT (29d613a)">Diff</a>