### PR TITLE
Fix #1606: decodeAudioData callbacks are nullable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -730,8 +730,8 @@ interface BaseAudioContext : EventTarget {
 	WaveShaperNode createWaveShaper ();
 
 	Promise<AudioBuffer> decodeAudioData (ArrayBuffer audioData,
-	                                      optional DecodeSuccessCallback successCallback,
-	                                      optional DecodeErrorCallback errorCallback);
+	                                      optional DecodeSuccessCallback? successCallback,
+	                                      optional DecodeErrorCallback? errorCallback);
 	Promise<void> resume ();
 };
 </xmp>


### PR DESCRIPTION
Allow null for the callbacks.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1627.html" title="Last updated on May 16, 2018, 10:32 PM GMT (9e17380)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1627/679aba0...rtoy:9e17380.html" title="Last updated on May 16, 2018, 10:32 PM GMT (9e17380)">Diff</a>