### PR TITLE
Issue #1625: Use bikeshed-style links where possible in rendering algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10611,8 +10611,8 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 <div id="rendering-a-graph" algorithm="rendering a graph">
 	1. Prepare the rendering.
 
-		1. Let <em>Q<sub>rendering</sub></em> be an empty <a>control message
-			queue</a>. <a>Atomically</a> <a>swap</a>
+		1. Let <em>Q<sub>rendering</sub></em> be an empty [=control message
+			queue=]. [=Atomically=] [=swap=]
 			<em>Q<sub>rendering</sub></em> and <em>Q</em>.
 
 		2. Set the internal slot <dfn attribute
@@ -10621,23 +10621,23 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 		3. Let <var>RenderResult</var> be false.
 
-	2. Process the <a>control message queue</a>.
+	2. Process the [=control message queue=].
 
-		1. Let <em>Q<sub>rendering</sub></em> be an empty <a>control message
-			queue</a>. <a>Atomically</a> <a>swap</a> <em>Q<sub>rendering</sub></em>
+		1. Let <em>Q<sub>rendering</sub></em> be an empty [=control message
+			queue=]. [=Atomically=] [=swap=] <em>Q<sub>rendering</sub></em>
 			and <em>Q</em>.
 
 		2. While there are messages in <em>Q<sub>rendering</sub></em>, execute the
 			following steps:
 
-			1. Execute the asynchronous section of the <a>oldest message</a> of
+			1. Execute the asynchronous section of the [=oldest message=] of
 				<em>Q<sub>rendering</sub></em>.
 
-			2. Remove the <a>oldest message</a> of <em>Q<sub>rendering</sub></em>.
+			2. Remove the [=oldest message=] of <em>Q<sub>rendering</sub></em>.
 
 	3. Process a render quantum.
 
-		1. If the <a>rendering thread state</a> of the {{AudioContext}} is not
+		1. If the [=rendering thread state=] of the {{AudioContext}} is not
 			<code>running</code>, return false.
 
 		2. Order the {{AudioNode}}s of the {{AudioContext}} to be processed.
@@ -10657,7 +10657,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 				1. If <em>node</em> is a {{DelayNode}} that is part of a cycle, add it
 					to <em>cycle breakers</em> and remove it from <em>nodes</em>.
 
-			5. If <em>nodes</em> contains cycles, <a href="#mute">mute</a> all the
+			5. If <em>nodes</em> contains cycles, [=mute=] all the
 				{{AudioNode}}s that are part of this cycle, and remove them from
 				<em>nodes</em>.
 
@@ -10665,7 +10665,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 				1. Choose an {{AudioNode}} <em>node</em> in <em>nodes</em>.
 
-				2. <a>Visit</a> <em>node</em>.
+				2. [=Visit=] <em>node</em>.
 
 				<div algorithm="visiting a node">
 					<dfn lt="Visit">Visiting a node</dfn> <em>node</em> means performing
@@ -10677,15 +10677,15 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 					3. For each {{AudioNode}} <em>input</em> connected to <em>node</em>:
 
-						1. <a>Visit</a> <em>input</em>.
+						1. [=Visit=] <em>input</em>.
 				</div>
 
 			7. Add <em>node</em> to the beginning of <em>ordered</em>.
 
 			8. Reverse the order of <em>nodes</em>.
 
-		3. For each {{DelayNode}} in a cycle, <a href="#available-for-reading">make
-			available for reading</a> a block of audio from the {{DelayNode}} buffer.
+		3. For each {{DelayNode}} in a cycle, [=Making a buffer available for reading|make
+			available for reading=] a block of audio from the {{DelayNode}} buffer.
 
 		4. <a href="#computation-of-value">Compute the value(s)</a> of the
 			{{AudioListener}}'s {{AudioParam}}s for this block.
@@ -10696,7 +10696,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 				1. If this {{AudioParam}} has any {{AudioNode}} connected to it,
 					<a href="#SummingJunction">sum</a> the buffers
-					<a href="#available-for-reading"> made available for reading</a> by
+					[=Making a buffer available for reading|made available for reading=] by
 					all {{AudioNode}} connected to this {{AudioParam}},
 					<a href="#down-mix">down mix</a> the resulting buffer down to a mono
 					channel, and call this buffer the <dfn id="input-audioparam-buffer">
@@ -10711,7 +10711,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 			2. If this {{AudioNode}} has any {{AudioNode}}s connected to its input,
 				<a href="#SummingJunction">sum</a> the buffers
-				<a href="#available-for-reading">made available for reading</a> by all
+				[=Making a buffer available for reading|made available for reading=] by all
 				{{AudioNode}}s connected to this {{AudioNode}}. The resulting buffer is
 				called the <dfn>input buffer</dfn>.
 				<a href="#channel-up-mixing-and-down-mixing">Up or down-mix</a> it to
@@ -10719,7 +10719,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 			3. If this {{AudioNode}} is a <a>source node</a>,
 				[=Computing a block of audio|compute a block of audio=], and
-				<a href="#available-for-reading">make it available for reading</a>.
+				[=Making a buffer available for reading|make it available for reading=].
 
 			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, invoke associated
 				{{AudioWorkletProcessor}}'s <a href="#audioworkletprocessor-process">
@@ -10735,10 +10735,10 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 				[=Recording the input|record the input=] of this {{AudioNode}}.
 
 			6. Else, <a>process</a> the <a>input buffer</a>, and
-				<a href="#available-for-reading">make available for reading</a> the
+				[=Making a buffer available for reading|make available for reading=] the
 				resulting buffer.
 
-		6. <a>Atomically</a> perform the following steps:
+		6. [=Atomically=] perform the following steps:
 
 			1. Increment {{[[current frame]]}} by the [=render quantum size=].
 

--- a/index.bs
+++ b/index.bs
@@ -10636,7 +10636,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 		3. For each {{DelayNode}} in a cycle, [=Making a buffer available for reading|make
 			available for reading=] a block of audio from the {{DelayNode}} buffer.
 
-		4. <a href="#computation-of-value">Compute the value(s)</a> of the
+		4. [[#computation-of-value|Compute the value(s)]] of the
 			{{AudioListener}}'s {{AudioParam}}s for this block.
 
 		5. For each {{AudioNode}}, in the order determined previously:
@@ -10644,26 +10644,26 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 			1. For each {{AudioParam}} of this {{AudioNode}}, execute these steps:
 
 				1. If this {{AudioParam}} has any {{AudioNode}} connected to it,
-					<a href="#SummingJunction">sum</a> the buffers
+					[[#SummingJunction|sum]] the buffers
 					[=Making a buffer available for reading|made available for reading=] by
 					all {{AudioNode}} connected to this {{AudioParam}},
-					<a href="#down-mix">down mix</a> the resulting buffer down to a mono
+					[[#down-mix|down mix]] the resulting buffer down to a mono
 					channel, and call this buffer the <dfn id="input-audioparam-buffer">
 					input AudioParam buffer</dfn>.
 
-				2. <a href="#computation-of-value">Compute the value(s)</a> of this
+				2. [[#computation-of-value|Compute the value(s)]] of this
 					{{AudioParam}} for this block.
 
-				3. <a>Queue a control message</a> to set the {{[[current value]]}} slot
+				3. [=Queue a control message=] to set the {{[[current value]]}} slot
 					of this {{AudioParam}} to the last value computed in the preceding
 					step.
 
 			2. If this {{AudioNode}} has any {{AudioNode}}s connected to its input,
-				<a href="#SummingJunction">sum</a> the buffers
+				[[#SummingJunction|sum]] the buffers
 				[=Making a buffer available for reading|made available for reading=] by all
 				{{AudioNode}}s connected to this {{AudioNode}}. The resulting buffer is
 				called the <dfn>input buffer</dfn>.
-				<a href="#channel-up-mixing-and-down-mixing">Up or down-mix</a> it to
+				[[#channel-up-mixing-and-down-mixing|Up or down-mix]] it to
 				match if number of input channels of this {{AudioNode}}.
 
 			3. If this {{AudioNode}} is a <a>source node</a>,
@@ -10673,8 +10673,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, invoke associated
 				{{AudioWorkletProcessor}}'s {{AudioWorkletProcessor/process()}} method to [=Computing a block of audio|compute a block of
 				audio=] with the argument of [=input buffer=], output
-				buffer and <a href="#input-audioparam-buffer">input AudioParam buffer
-				</a>.
+				buffer and [=input AudioParam buffer=].
 
 				1. Any {{Promise}} resolved within the execution of process method will
 					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.
@@ -10695,8 +10694,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 		7. Set <var>RenderResult</var> to true.
 
-	4. <a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">
-		Perform a microtask checkpoint</a>.
+	4. [=Perform a microtask checkpoint=].
 
 	5. Return <var>RenderResult</var>.
 </div>


### PR DESCRIPTION
In the rendering loop algorithm, try to use bikeshed-style links where possible so that bikeshed can catch missing links.  The current `<a href>` style is error-prone if we rename things.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1630.html" title="Last updated on May 17, 2018, 8:30 PM GMT (53f9280)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1630/2c94dbb...rtoy:53f9280.html" title="Last updated on May 17, 2018, 8:30 PM GMT (53f9280)">Diff</a>