### PR TITLE
Fix #1625: Mark variables use `<var>` in rendering algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10560,9 +10560,9 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 <div id="rendering-a-graph" algorithm="rendering a graph">
 	1. Prepare the rendering.
 
-		1. Let <em>Q<sub>rendering</sub></em> be an empty [=control message
+		1. Let <var>Q<sub>rendering</sub></var> be an empty [=control message
 			queue=]. [=Atomically=] [=swap=]
-			<em>Q<sub>rendering</sub></em> and <em>Q</em>.
+			<var>Q<sub>rendering</sub></var> and <var>Q</var>.
 
 		2. Set the internal slot <dfn attribute
 			for="BaseAudioContext">[[current frame]]</dfn> of the
@@ -10572,17 +10572,17 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 	2. Process the [=control message queue=].
 
-		1. Let <em>Q<sub>rendering</sub></em> be an empty [=control message
-			queue=]. [=Atomically=] [=swap=] <em>Q<sub>rendering</sub></em>
-			and <em>Q</em>.
+		1. Let <var>Q<sub>rendering</sub></var> be an empty [=control message
+			queue=]. [=Atomically=] [=swap=] <var>Q<sub>rendering</sub></var>
+			and <var>Q</var>.
 
-		2. While there are messages in <em>Q<sub>rendering</sub></em>, execute the
+		2. While there are messages in <var>Q<sub>rendering</sub></var>, execute the
 			following steps:
 
 			1. Execute the asynchronous section of the [=oldest message=] of
-				<em>Q<sub>rendering</sub></em>.
+				<var>Q<sub>rendering</sub></var>.
 
-			2. Remove the [=oldest message=] of <em>Q<sub>rendering</sub></em>.
+			2. Remove the [=oldest message=] of <var>Q<sub>rendering</sub></var>.
 
 	3. Process a render quantum.
 

--- a/index.bs
+++ b/index.bs
@@ -10591,47 +10591,47 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 		2. Order the {{AudioNode}}s of the {{AudioContext}} to be processed.
 
-			1. Let <em>ordered</em> be an empty list of {{AudioNode}}s. It will
+			1. Let <var>ordered</var> be an empty list of {{AudioNode}}s. It will
 				contain an ordered list of {{AudioNode}}s when this ordering algorithm
 				terminates.
 
-			2. Let <em>nodes</em> be the set of all nodes created by this
+			2. Let <var>nodes</var> be the set of all nodes created by this
 				{{AudioContext}}, and still alive.
 
-			3. Let <em>cycle breakers</em> be an empty set of {{DelayNode}}s. It will
+			3. Let <var>cycle breakers</var> be an empty set of {{DelayNode}}s. It will
 				contain all the {{DelayNode}}s that are part of a cycle.
 
-			4. For each {{AudioNode}} <em>node</em> in <em>nodes</em>:
+			4. For each {{AudioNode}} <var>node</var> in <var>nodes</var>:
 
-				1. If <em>node</em> is a {{DelayNode}} that is part of a cycle, add it
-					to <em>cycle breakers</em> and remove it from <em>nodes</em>.
+				1. If <var>node</var> is a {{DelayNode}} that is part of a cycle, add it
+					to <var>cycle breakers</var> and remove it from <var>nodes</var>.
 
-			5. If <em>nodes</em> contains cycles, [=mute=] all the
+			5. If <var>nodes</var> contains cycles, [=mute=] all the
 				{{AudioNode}}s that are part of this cycle, and remove them from
-				<em>nodes</em>.
+				<var>nodes</var>.
 
-			6. While there are unmarked {{AudioNode}}s in <em>nodes</em>:
+			6. While there are unmarked {{AudioNode}}s in <var>nodes</var>:
 
-				1. Choose an {{AudioNode}} <em>node</em> in <em>nodes</em>.
+				1. Choose an {{AudioNode}} <var>node</var> in <var>nodes</var>.
 
-				2. [=Visit=] <em>node</em>.
+				2. [=Visit=] <var>node</var>.
 
 				<div algorithm="visiting a node">
-					<dfn lt="Visit">Visiting a node</dfn> <em>node</em> means performing
+					<dfn lt="Visit">Visiting a node</dfn> <var>node</var> means performing
 					the following steps:
 
-					1. If <em>node</em> is marked, abort these steps.
+					1. If <var>node</var> is marked, abort these steps.
 
-					2. Mark <em>node</em>.
+					2. Mark <var>node</var>.
 
-					3. For each {{AudioNode}} <em>input</em> connected to <em>node</em>:
+					3. For each {{AudioNode}} <var>input</var> connected to <var>node</var>:
 
-						1. [=Visit=] <em>input</em>.
+						1. [=Visit=] <var>input</var>.
 				</div>
 
-			7. Add <em>node</em> to the beginning of <em>ordered</em>.
+			7. Add <var>node</var> to the beginning of <var>ordered</var>.
 
-			8. Reverse the order of <em>nodes</em>.
+			8. Reverse the order of <var>nodes</var>.
 
 		3. For each {{DelayNode}} in a cycle, [=Making a buffer available for reading|make
 			available for reading=] a block of audio from the {{DelayNode}} buffer.


### PR DESCRIPTION
Just went through changed names that were marked using `<em>` to use
`<var>` to make them variables in the algorithm.  This allows bikeshed
to note if we have single-use vars and also allows you to click on the
variable and see where they are used in the algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1633.html" title="Last updated on May 18, 2018, 8:56 PM GMT (da1a804)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1633/3f4df5c...rtoy:da1a804.html" title="Last updated on May 18, 2018, 8:56 PM GMT (da1a804)">Diff</a>