### PR TITLE
Fix #1593: Return false from process() in BypassProcessor example.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9376,8 +9376,8 @@ class BypassProcessor extends AudioWorkletProcessor {
 		let output = outputs[0];
 		output[0].set(input[0]);
 
-		// To keep this processor alive.
-		return true;
+		// Process only while there are inputs.
+		return false;
 	}
 });
 


### PR DESCRIPTION
This is consistent with guidelines for "Nodes that transform their inputs".
It avoids unnecessary processing and supports garbage collection of the
processor resources when the processor is no longer accessible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/karlt/web-audio-api/pull/1635.html" title="Last updated on May 22, 2018, 11:27 AM GMT (5a3dcc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1635/b6d8674...karlt:5a3dcc0.html" title="Last updated on May 22, 2018, 11:27 AM GMT (5a3dcc0)">Diff</a>