### PR TITLE
Make section capitalization consistent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1280,7 +1280,7 @@ Once created, an {{AudioContext}} will continue to play
 sound until it has no more sound to play, or the page goes away.
 
 <h4 id="lack-of-introspection-or-serialization-primitives" class=informative>
-Lack of introspection or serialization primitives</h4>
+Lack of Introspection or Serialization Primitives</h4>
 
 The Web Audio API takes a <em>fire-and-forget</em> approach to
 audio source scheduling. That is, <a>source nodes</a> are created
@@ -1293,7 +1293,7 @@ Moreover, having an introspection API would allow content script to
 be able to observe garbage collections.
 
 <h4 id="system-resources-associated-with-baseaudiocontext-subclasses">
-System resources associated with {{BaseAudioContext}} subclasses</h4>
+System Resources Associated with {{BaseAudioContext}} Subclasses</h4>
 
 The subclasses {{AudioContext}} and {{OfflineAudioContext}}
 should be considered expensive objects. Creating these objects may
@@ -4309,7 +4309,7 @@ Time-Domain Down-Mixing</h4>
 	down-mixing operation.
 
 <h4 id="fft-windowing-and-smoothing-over-time">
-FFT Windowing and smoothing over time</h4>
+FFT Windowing and Smoothing over Time</h4>
 
 When the <dfn id="current-frequency-data">current frequency
 data</dfn> are computed, the following operations are to be
@@ -7611,7 +7611,7 @@ Dictionary {{MediaElementAudioSourceOptions}} Members</h5>
 </dl>
 
 <h4 id="MediaElementAudioSourceOptions-security">
-Security with MediaElementAudioSourceNode and cross-origin resources</h4>
+Security with MediaElementAudioSourceNode and Cross-Origin Resources</h4>
 
 {{HTMLMediaElement}} allows the playback of cross-origin
 resources. Because Web Audio allows inspection of the content of
@@ -10421,7 +10421,7 @@ queue, implementors can use memory that is shared between threads, as
 long as the memory operations are not reordered.
 
 <h3 id="control-thread-and-rendering-thread">
-Control thread and rendering thread</h3>
+Control Thread and Rendering Thread</h3>
 
 The Web Audio API MUST be implemented using a <a>control thread</a>,
 and a <a>rendering thread</a>.
@@ -10485,7 +10485,7 @@ one at the front of the <a>control message queue</a>.
 </div>
 
 <h3 id="asynchronous-operations">
-Asynchronous operations</h3>
+Asynchronous Operations</h3>
 
 Calling methods on {{AudioNode}}s is effectively asynchronous, and
 MUST to be done in two phases, a synchronous part and an asynchronous
@@ -10518,7 +10518,7 @@ before <var>B<sub>Async</sub></var>. In other words, synchronous and
 asynchronous sections can't be reordered.
 
 <h3 id="rendering-loop">
-Rendering an audio graph</h3>
+Rendering an Audio Graph</h3>
 
 Rendering an audio graph is done in blocks of 128 samples-frames. A
 block of 128 samples-frames is called a <dfn>render quantum</dfn>, and
@@ -10994,7 +10994,7 @@ function playSound() {
 </pre>
 
 <h2 id="channel-up-mixing-and-down-mixing">
-Channel up-mixing and down-mixing</h2>
+Channel Up-Mixing and Down-Mixing</h2>
 
 <em>This section is normative.</em>
 
@@ -11055,7 +11055,7 @@ Mono (one channel), stereo (two channels), quad (four channels), and
 supported in future version of this specification.
 
 <h3 id="ChannelOrdering">
-Channel ordering</h3>
+Channel Ordering</h3>
 
 Channel ordering is defined by the following table. Individual
 multichannel formats MAY not support all intermediate channels.
@@ -11093,7 +11093,7 @@ defined below, skipping over those channels not present.
 </table>
 
 <h3 id="UpMix-sub">
-Up Mixing speaker layouts</h3>
+Up Mixing Speaker Layouts</h3>
 
 <pre>
 Mono up-mix:
@@ -11144,7 +11144,7 @@ Quad up-mix:
 </pre>
 
 <h3 id="down-mix">
-Down Mixing speaker layouts</h3>
+Down Mixing Speaker Layouts</h3>
 
 A down-mix will be necessary, for example, if processing 5.1 source
 material, but playing back stereo.
@@ -11408,7 +11408,7 @@ value is ignored. This algorithm MUST be implemented using
 </div>
 
 <h4 id="Spatialization-hrtf-panning">
-PannerNode "HRTF" Panning (stereo only)</h4>
+PannerNode "HRTF" Panning (Stereo Only)</h4>
 
 This requires a set of <a href="https://en.wikipedia.org/wiki/Head-related_transfer_function">HRTF</a>
 (Head-related Transfer Function) impulse responses recorded at a


### PR DESCRIPTION
Generally follow the rule about capitalizing sections:  first and last
word are capitalized along with important words.

We do this in most section headings but not all.  Make it uniform.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1638.html" title="Last updated on May 24, 2018, 8:54 PM GMT (071c491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1638/7b0a947...rtoy:071c491.html" title="Last updated on May 24, 2018, 8:54 PM GMT (071c491)">Diff</a>