### PR TITLE
Fix #1631: zero-fill output arrays for process()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9891,7 +9891,7 @@ validity of a given {{AudioWorkletProcessor}} subclass.
 				If no connections exist to the \(n\)th input of the node during the current render quantum, then the content of <code>inputs[n]</code> is an empty array, indicating that zero channels of input are available. This is the only circumstance under which the number of elements of <code>inputs[n]</code> can be zero.
 
 			outputs:
-				The output audio buffer that is to be consumed by the user agent. It has type <code>&lt;sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has single output.
+				The output audio buffer that is to be consumed by the user agent. It has type <code>&lt;sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has single output.
 
 			parameters:
 				A map of string keys and associated {{Float32Array}}s. <code>parameters["name"]</code> corresponds to the automation values of the AudioParam named <code>"name"</code>.


### PR DESCRIPTION
State that the Float32Array's are zero-filled.  This implies that if
the user doesn't write anything into the arrays, the output will be
silence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1641.html" title="Last updated on May 29, 2018, 5:31 PM GMT (47009f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1641/0851814...rtoy:47009f8.html" title="Last updated on May 29, 2018, 5:31 PM GMT (47009f8)">Diff</a>