### PR TITLE
Use enum strings when referring to AudioContextStates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -770,7 +770,7 @@ Attributes</h4>
 		value of {{BaseAudioContext/currentTime}}.
 
 		When the {{BaseAudioContext}} is in the
-		{{AudioContextState/running}} state, the
+		"{{AudioContextState/running}}" state, the
 		value of this attribute is monotonically increasing and is
 		updated by the rendering thread in uniform increments,
 		corresponding to one <a>render quantum</a>. Thus, for a running
@@ -1200,7 +1200,7 @@ Methods</h4>
 
 			3. If the {{BaseAudioContext/state}}
 				attribute of the {{BaseAudioContext}} is already
-				<code>running</code>, resolve <em>promise</em>, return it, and
+				"{{AudioContextState/running}}", resolve <em>promise</em>, return it, and
 				abort these steps.
 
 			4. If the {{BaseAudioContext}} is not <a>allowed to
@@ -1241,9 +1241,9 @@ Methods</h4>
 
 				2. Resolve <em>promise</em>.
 
-				3. If the {{BaseAudioContext/state}} attribute of the {{BaseAudioContext}} is not already <code>running</code>:
+				3. If the {{BaseAudioContext/state}} attribute of the {{BaseAudioContext}} is not already "{{AudioContextState/running}}":
 
-					1. Set the {{BaseAudioContext/state}} attribute of the {{BaseAudioContext}} to <code>running</code>.
+					1. Set the {{BaseAudioContext/state}} attribute of the {{BaseAudioContext}} to "{{AudioContextState/running}}".
 
 					2. Queue a task to fire a simple event named <code>statechange</code> at the {{BaseAudioContext}}.
 		</div>
@@ -1455,7 +1455,7 @@ Constructors</h4>
 
 			4. Queue a task on the <a>control thread</a> event loop, to execute these steps:
 
-				1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to <code>running</code>.
+				1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
 				2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
 		</div>
@@ -1535,7 +1535,7 @@ Methods</h4>
 				returning <em>promise</em>.
 
 			3. If the {{BaseAudioContext/state}} attribute
-				of the {{AudioContext}} is already <code>closed</code>,
+				of the {{AudioContext}} is already "{{AudioContextState/closed}}",
 				resolve <em>promise</em>, return it, and abort these steps.
 
 			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>closed</code>.
@@ -1556,8 +1556,8 @@ Methods</h4>
 
 			3. Queue a task on the <a>control thread</a>'s event loop, to execute these steps:
 				1. Resolve <em>promise</em>.
-				2. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is not already <code>closed</code>:
-					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to <code>closed</code>.
+				2. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is not already "{{AudioContextState/closed}}":
+					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/closed}}".
 					2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
 		</div>
 
@@ -1721,7 +1721,7 @@ Methods</h4>
 				with {{InvalidStateError}}, abort these steps,
 				returning <em>promise</em>.
 
-			3. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is already <code>suspended</code>,
+			3. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is already "{{AudioContextState/suspended}}",
 				resolve <em>promise</em>, return it, and abort these steps.
 
 			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>suspended</code>.
@@ -1745,9 +1745,9 @@ Methods</h4>
 				1. Resolve <em>promise</em>.
 
 				2. If the {{BaseAudioContext/state}}
-					attribute of the {{AudioContext}} is not already <code>suspended</code>:
+					attribute of the {{AudioContext}} is not already "{{AudioContextState/suspended}}":
 
-					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to <code>suspended</code>.
+					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/suspended}}".
 					2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
 		</div>
 


### PR DESCRIPTION
Wherever we refer to the value of the state attrribute of a
BaseAudioContext, use the enum strings (with links) instead of plain
`<code>` tags.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1642.html" title="Last updated on May 29, 2018, 7:32 PM GMT (bb0c733)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1642/0851814...rtoy:bb0c733.html" title="Last updated on May 29, 2018, 7:32 PM GMT (bb0c733)">Diff</a>