### PR TITLE
Use vars in algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1191,29 +1191,29 @@ Methods</h4>
 		<div algorithm="resume()">
 			<span class="synchronous">When resume is called, execute these steps:</span>
 
-			1. Let <em>promise</em> be a new Promise.
+			1. Let <var>promise</var> be a new Promise.
 
 			2. If the <em>control thread state</em> flag on the
 				{{BaseAudioContext}} is <code>closed</code> reject the
 				promise with {{InvalidStateError}}, abort these steps,
-				returning <em>promise</em>.
+				returning <var>promise</var>.
 
 			3. If the {{BaseAudioContext/state}}
 				attribute of the {{BaseAudioContext}} is already
-				<code>running</code>, resolve <em>promise</em>, return it, and
+				<code>running</code>, resolve <var>promise</var>, return it, and
 				abort these steps.
 
 			4. If the {{BaseAudioContext}} is not <a>allowed to
-				start</a>, append <em>promise</em> to
+				start</a>, append <var>promise</var> to
 				<a>pendingResumePromises</a> and abort these steps, returning
-				<em>promise</em>.
+				<var>promise</var>.
 
 			5. Set the <em>control thread state</em> flag on the
 				{{BaseAudioContext}} to <code>running</code>.
 
 			6. <a>Queue a control message</a> to resume the {{BaseAudioContext}}.
 
-			7. Return <em>promise</em>.
+			7. Return <var>promise</var>.
 		</div>
 
 		<div algorithm="run a control message">
@@ -4535,17 +4535,17 @@ Attributes</h4>
 		<div algorithm="set the buffer attribute">
 			To set the {{AudioBufferSourceNode/buffer}} attribute, execute these steps:
 
-			1. Let <code>new buffer</code> be the {{AudioBuffer}} or
+			1. Let <var>new buffer</var> be the {{AudioBuffer}} or
 				<code>null</code> value to be assigned to {{AudioBufferSourceNode/buffer}}.
 
-			2. If <code>new buffer</code> is not <code>null</code> and
+			2. If <var>new buffer</var> is not <code>null</code> and
 				{{AudioBufferSourceNode/[[buffer set]]}} is true, throw an
 				{{InvalidStateError}} and abort these steps.
 
-			3. If <code>new buffer</code> is not <code>null</code>, set
+			3. If <var>new buffer</var> is not <code>null</code>, set
 				{{AudioBufferSourceNode/[[buffer set]]}} to true.
 
-			4. Assign <code>new buffer</code> to the {{AudioBufferSourceNode/buffer}}
+			4. Assign <var>new buffer</var> to the {{AudioBufferSourceNode/buffer}}
 				attribute.
 
 			5. If <code>start()</code> has previously been called on this
@@ -6481,17 +6481,17 @@ Attributes</h4>
 		<div algorithm="ConvolverNode.buffer">
 			To set the {{ConvolverNode/buffer}} attribute, execute these steps:
 
-			1. Let <code>new buffer</code> be the {{AudioBuffer}} to be
+			1. Let <var>new buffer</var> be the {{AudioBuffer}} to be
 				assigned to {{ConvolverNode/buffer}}.
 
-			2. If <code>new buffer</code> is not <code>null</code> and
+			2. If <var>new buffer</var> is not <code>null</code> and
 				{{ConvolverNode/[[buffer set]]}} is true, <span class="synchronous">throw an {{InvalidStateError}} and abort
 				these steps</span>.
 
-			3. If <code>new buffer</code> is not <code>null</code>, set
+			3. If <var>new buffer</var> is not <code>null</code>, set
 				{{ConvolverNode/[[buffer set]]}} to true.
 
-			4. Assign <code>new buffer</code> to the {{ConvolverNode/buffer}}
+			4. Assign <var>new buffer</var> to the {{ConvolverNode/buffer}}
 				attribute.
 		</div>
 
@@ -11344,9 +11344,9 @@ value is ignored. This algorithm MUST be implemented using
 <div algorithm="equalpower panning">
 	1. For each sample to be computed by this {{AudioNode}}:
 
-		1. Let <em>azimuth</em> be the value computed in the <a href="#azimuth-elevation">azimuth and elevation</a> section.
+		1. Let <var>azimuth</var> be the value computed in the <a href="#azimuth-elevation">azimuth and elevation</a> section.
 
-		2. The <em>azimuth</em> value is first contained to be within
+		2. The <var>azimuth</var> value is first contained to be within
 			the range [-90, 90] according to:
 
 			<pre highlight="js">
@@ -11362,7 +11362,7 @@ value is ignored. This algorithm MUST be implemented using
 			</pre>
 
 		3. A normalized value <em>x</em> is calculated from
-			<em>azimuth</em> for a mono input as:
+			<var>azimuth</var> for a mono input as:
 
 			<pre highlight="js">
 			x = (azimuth + 90) / 180;
@@ -11433,18 +11433,18 @@ StereoPannerNode Panning</h4>
 	MUST be implemented.
 
 	1. For each sample to be computed by this {{AudioNode}}
-		1. Let <em>pan</em> be the <a>computedValue</a> of the
+		1. Let <var>pan</var> be the <a>computedValue</a> of the
 			<code>pan</code> {{AudioParam}} of this
 			{{StereoPannerNode}}.
 
-		2. Clamp <em>pan</em> to [-1, 1].
+		2. Clamp <var>pan</var> to [-1, 1].
 
 			<pre highlight="js">
 			pan = max(-1, pan);
 			pan = min(1, pan);
 			</pre>
 
-		3. Calculate <em>x</em> by normalizing <em>pan</em> value to
+		3. Calculate <em>x</em> by normalizing <var>pan</var> value to
 			[0, 1]. For mono input:
 
 			<pre highlight="js">


### PR DESCRIPTION
Instead of using `<em>` and `<code>` markup, use `<var>` markup as
appropriate to mark the variables as such in the algorithms.  This
allows bikeshed to catch single use of such vars and also allows
bikeshed to highlight the vars when clicked.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1644.html" title="Last updated on May 29, 2018, 8:18 PM GMT (fc26b9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1644/6722250...rtoy:fc26b9a.html" title="Last updated on May 29, 2018, 8:18 PM GMT (fc26b9a)">Diff</a>