### PR TITLE
Fix #1643: Clarify waveshaper curve setting algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9176,6 +9176,8 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="WaveShaperNode">
 	: <dfn>WaveShaperNode(context, options)</dfn>
 	::
+		Let <var>node</var> be a new {{WaveShaperNode}} object. Initialize <var>node</var>. Set an internal boolean slot <dfn attribute for="WaveShaperNode">[[curve set]]</dfn>, and initialize it to false. Return <var>node</var>.
+
 		<pre class=argumentdef for="WaveShaperNode/WaveShaperNode()">
 			context: The {{BaseAudioContext}} this new {{WaveShaperNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{WaveShaperNode}}.
@@ -9221,19 +9223,19 @@ Attributes</h4>
 		again in order to change the curve.
 
 		<div algorithm="WaveShaperNode.curve">
-			To set the <code>curve</code> attribute, execute these steps:
+			To set the {{WaveShaperNode/curve}} attribute, execute these steps:
 
-			1. Let <code>new curve</code> be the {{Float32Array}}
-				to be assigned to <code>curve</code>.
+			1. Let <var>new curve</var> be the {{Float32Array}}
+				to be assigned to {{WaveShaperNode/curve}}.
 
-			2. If <code>new curve</code> is not <code>null</code> and
-				<code>curve set</code> is true, throw an
+			2. If <var>new curve</var> is not <code>null</code> and
+				{{WaveShaperNode/[[curve set]]}} is true, throw an
 				{{InvalidStateError}} and abort these steps.
 
-			3. If <code>new curve</code> is not <code>null</code>, set
-				<code>curve set</code> to true.
+			3. If <var>new curve</var> is not <code>null</code>, set
+				{{WaveShaperNode/[[curve set]]}} to true.
 
-			4. Assign <code>new curve</code> to the <code>curve</code>
+			4. Assign <var>new curve</var> to the {{WaveShaperNode/curve}}
 				attribute.
 		</div>
 


### PR DESCRIPTION
Basically make it look like the buffer setting algorithm for
`AudioBufferSourceNode` and `ConvolverNode` by adding an internal slot
named `curve set`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1645.html" title="Last updated on May 29, 2018, 8:12 PM GMT (5cdbe85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1645/0851814...rtoy:5cdbe85.html" title="Last updated on May 29, 2018, 8:12 PM GMT (5cdbe85)">Diff</a>