### PR TITLE
Fix #1648, #1649: refine algorithm for setting buffer and curve

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6481,17 +6481,17 @@ Attributes</h4>
 		<div algorithm="ConvolverNode.buffer">
 			To set the {{ConvolverNode/buffer}} attribute, execute these steps:
 
-			1. Let <code>new buffer</code> be the {{AudioBuffer}} to be
+			1. Let <var>new buffer</var> be the {{AudioBuffer}} or <code>null</code> to be
 				assigned to {{ConvolverNode/buffer}}.
 
-			2. If <code>new buffer</code> is not <code>null</code> and
+			2. If <var>new buffer</var> is not <code>null</code> and
 				{{ConvolverNode/[[buffer set]]}} is true, <span class="synchronous">throw an {{InvalidStateError}} and abort
 				these steps</span>.
 
-			3. If <code>new buffer</code> is not <code>null</code>, set
+			3. If <var>new buffer</var> is not <code>null</code>, set
 				{{ConvolverNode/[[buffer set]]}} to true.
 
-			4. Assign <code>new buffer</code> to the {{ConvolverNode/buffer}}
+			4. Assign <var>new buffer</var> to the {{ConvolverNode/buffer}}
 				attribute.
 		</div>
 
@@ -9225,7 +9225,7 @@ Attributes</h4>
 		<div algorithm="WaveShaperNode.curve">
 			To set the {{WaveShaperNode/curve}} attribute, execute these steps:
 
-			1. Let <var>new curve</var> be the {{Float32Array}}
+			1. Let <var>new curve</var> be the {{Float32Array}} or <code>null</code>
 				to be assigned to {{WaveShaperNode/curve}}.
 
 			2. If <var>new curve</var> is not <code>null</code> and


### PR DESCRIPTION
These algorithms for setting the buffer (ConvovlerNode) and the curve
(WaveShaperNode) should be consistent with how the buffer for an
AudioBufferSourceNode is handled.  The original intent was that you
can only set the buffer(curve) just once, but you can set them to null
as many times as you want, but you can't then set it to a non-null
buffer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1653.html" title="Last updated on May 31, 2018, 11:06 PM GMT (301542b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1653/5e40eb0...rtoy:301542b.html" title="Last updated on May 31, 2018, 11:06 PM GMT (301542b)">Diff</a>