### PR TITLE
Fix #1652: Use Note for non-normative text in convolver buffer descri…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6495,16 +6495,15 @@ Attributes</h4>
 				attribute.
 		</div>
 
-		<em>The following text is non-normative. For normative
-		information please see the <a href="#Convolution-channel-configurations">channel configuration
-		diagrams</a>.</em>
-
-		The {{ConvolverNode}} only produces a mono output in the
+		Note: The {{ConvolverNode}} produces a mono output only in the
 		single case where there is a single input channel and a
 		single-channel {{ConvolverNode/buffer}}. In all other cases, the
 		output is stereo. In particular, when the {{ConvolverNode/buffer}}
 		has four channels and there are two input channels, the
-		{{ConvolverNode}} performs matrix "true" stereo convolution.
+		{{ConvolverNode}} performs matrix "true" stereo
+		convolution. For normative information please see the
+		<a href="#Convolution-channel-configurations">channel
+		configuration diagrams</a>
 
 	: <dfn>normalize</dfn>
 	::


### PR DESCRIPTION
…ption

Just remove the paragraph that says the following is non-normative and
makes the following paragraph a Note so that it's highlighted as
non-normative.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1654.html" title="Last updated on May 31, 2018, 11:16 PM GMT (f40b2ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1654/5e40eb0...rtoy:f40b2ad.html" title="Last updated on May 31, 2018, 11:16 PM GMT (f40b2ad)">Diff</a>