### PR TITLE
Minor fixes to AudioBuffer.copy[To|From]Channel descriptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2279,17 +2279,17 @@ Methods</h4>
 
 	: <dfn>copyToChannel(source, channelNumber, startInChannel)</dfn>
 	::
-		The {{AudioBuffer/copyToChannel()}} method copies the samples from
-		the specified channel of the {{AudioBuffer}} to the
-		<code>destination</code> array.
+		The {{AudioBuffer/copyToChannel()}} method copies the samples to
+		the specified channel of the {{AudioBuffer}} from the
+		<code>source</code> array.
 
-		Let {{AudioBufferSourceNode/buffer}} be the {{AudioBuffer}} buffer with
+		Let {{AudioBufferSourceNode/buffer}} be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
-		<code>destination</code> array, and \(k\) be the value of
+		<code>source</code> array, and \(k\) be the value of
 		<code>startInChannel</code>. Then the number of frames copied
-		from {{AudioBufferSourceNode/buffer}} to <code>destination</code> is
+		from <code>source </code> to the {{AudioBufferSourceNode/buffer}} is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
-		remaining elements of <code>destination</code> are not
+		remaining elements of {{AudioBufferSourceNode/buffer}} are not
 		modified.
 
 		<pre class=argumentdef for="AudioBuffer/copyToChannel()">

--- a/index.bs
+++ b/index.bs
@@ -2258,11 +2258,11 @@ Methods</h4>
 		the specified channel of the {{AudioBuffer}} to the
 		<code>destination</code> array.
 
-		Let {{AudioBufferSourceNode/buffer}} be the {{AudioBuffer}} buffer with
+		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		<code>destination</code> array, and \(k\) be the value of
 		<code>startInChannel</code>. Then the number of frames copied
-		from {{AudioBufferSourceNode/buffer}} to <code>destination</code> is
+		from <code>buffer</code> to <code>destination</code> is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
 		remaining elements of <code>destination</code> are not
 		modified.
@@ -2283,13 +2283,13 @@ Methods</h4>
 		the specified channel of the {{AudioBuffer}} from the
 		<code>source</code> array.
 
-		Let {{AudioBufferSourceNode/buffer}} be the {{AudioBuffer}} with
+		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		<code>source</code> array, and \(k\) be the value of
 		<code>startInChannel</code>. Then the number of frames copied
-		from <code>source </code> to the {{AudioBufferSourceNode/buffer}} is
+		from <code>source</code> to the <code>buffer</code> is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
-		remaining elements of {{AudioBufferSourceNode/buffer}} are not
+		remaining elements of <code>buffer</code> are not
 		modified.
 
 		<pre class=argumentdef for="AudioBuffer/copyToChannel()">


### PR DESCRIPTION
It seems that the `AudioBuffer.copyToChannel` description was an exact copy of the `AudioBuffer.copyFromChannel` one, while I believe it shouldn't be.

I removed the references to `AudioBufferSourceNode.buffer` cause IIUC an AudioBuffer may not always be attached to an `AudioBufferSourceNode`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ferjm/web-audio-api/pull/1655.html" title="Last updated on Jun 7, 2018, 8:39 AM GMT (02dbbc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1655/5e40eb0...ferjm:02dbbc5.html" title="Last updated on Jun 7, 2018, 8:39 AM GMT (02dbbc5)">Diff</a>