### PR TITLE
Fix #1590: Be more explicit about number of inputs/outputs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -885,8 +885,8 @@ Methods</h4>
 		<a>Factory method</a> for a
 		{{ChannelMergerNode}} representing a channel
 		merger. <span class="synchronous">An
-		{{IndexSizeError}} exception MUST be thrown for
-		invalid parameter values.</span>
+		{{IndexSizeError}} exception MUST be thrown if
+		{{BaseAudioContext/createChannelMerger(numberOfInputs)/numberOfInputs}} is less than 1 or is greater than the number of supported channels.</span>
 
 		<pre class=argumentdef for="BaseAudioContext/createChannelMerger(numberOfInputs)">
 		numberOfInputs: Determines the number of inputs. Values of up to 32 MUST be supported. If not specified, then `6` will be used.
@@ -901,8 +901,8 @@ Methods</h4>
 		<a>Factory method</a> for a
 		{{ChannelSplitterNode}} representing a channel
 		splitter. <span class="synchronous">An
-		{{IndexSizeError}} exception MUST be thrown for invalid
-		parameter values.</span>
+		{{IndexSizeError}} exception MUST be thrown if
+		{{BaseAudioContext/createChannelSplitter(numberOfOutputs)/numberOfOutputs}}  is less than 1 or is greater than the number of supported channels.</span>
 
 		<pre class=argumentdef for="BaseAudioContext/createChannelSplitter(numberOfOutputs)">
 		numberOfOutputs: The number of outputs. Values of up to 32 MUST be supported. If not specified, then `6` will be used.


### PR DESCRIPTION
Specify more clearly the valid range for the number of inputs and outputs for createChannelMerger and createChannelSplitter.  The valid range is 1 to the number of supported channels.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1656.html" title="Last updated on Jun 6, 2018, 7:35 PM GMT (d44b6fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1656/5e40eb0...rtoy:d44b6fd.html" title="Last updated on Jun 6, 2018, 7:35 PM GMT (d44b6fd)">Diff</a>