### PR TITLE
Fix #1576: Remove sentence from AudioWorkletNodeOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9663,10 +9663,7 @@ Attributes</h5>
 The {{AudioWorkletNodeOptions}} dictionary can be used
 for the custom initialization of {{AudioNode}}
 attributes in the {{AudioWorkletNode}}
-constructor. Entries in this dictionary whose names correspond to
-{{AudioParam}}s in the class definition of an
-{{AudioWorkletProcessor}} are used to initialize
-the parameter values upon the creation of a node.
+constructor.
 
 <xmp class="idl">
 dictionary AudioWorkletNodeOptions : AudioNodeOptions {


### PR DESCRIPTION
Just remove the sentence which is no longer needed; paramerData is
good enough.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1657.html" title="Last updated on Jun 6, 2018, 7:40 PM GMT (c3a6de2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1657/5e40eb0...rtoy:c3a6de2.html" title="Last updated on Jun 6, 2018, 7:40 PM GMT (c3a6de2)">Diff</a>