### PR TITLE
Issue #1658: Use bikeshed-style links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9649,8 +9649,8 @@ Attributes</h5>
 	: <dfn>port</dfn>
 	::
 		Every {{AudioWorkletNode}} has an associated
-		<code>port</code> which is a <a href="https://html.spec.whatwg.org/multipage/comms.html#message-ports">
-		MessagePort</a>. It is connected to the port on the
+		<code>port</code> which is a 
+		{{MessagePort}}. It is connected to the port on the
 		corresponding {{AudioWorkletProcessor}} object allowing
 		bidirectional communication between a pair of
 		{{AudioWorkletNode}} and {{AudioWorkletProcessor}}.

--- a/index.bs
+++ b/index.bs
@@ -9994,12 +9994,12 @@ thread and the rendering thread.
 	6. Let <var>processorPortOnThisSide</var> be the value of
 		<var>messageChannel</var>'s <code>port2</code> attribute.
 
-	7. Let <var>processorPortSerialization</var> be <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserializewithtransfer">
-			StructuredSerializeWithTransfer</a>(<var>processorPortOnThisSide</var>,
+	7. Let <var>processorPortSerialization</var> be 
+			[$StructuredSerializeWithTransfer$](<var>processorPortOnThisSide</var>,
 			« <var>processorPortOnThisSide</var> »).
 
-	7. Let <var>optionsSerialization</var> be <a href=
-		"https://html.spec.whatwg.org/multipage/infrastructure.html#structuredserialize">StructuredSerialize</a>(<var>options</var>).
+	7. Let <var>optionsSerialization</var> be 
+		[$StructuredSerialize$](<var>options</var>).
 
 	8. Set <var>node</var>'s {{AudioWorkletNode/port}} to <var>nodePort</var>.
 
@@ -10053,13 +10053,11 @@ thread and the rendering thread.
 	<var>node</var>.
 
 	1. Let <var>processorPort</var> be
-		<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
-		StructuredDeserializeWithTransfer</a>(<var>processorPortSerialization</var>,
+		[$StructuredDeserializeWithTransfer$](<var>processorPortSerialization</var>,
 		the current Realm).
 
-	1. Let <var>options</var> be <a href=
-		"https://html.spec.whatwg.org/multipage/infrastructure.html#structureddeserializewithtransfer">
-		  StructuredDeserialize</a>(<code>optionsSerialization</code>, the
+	1. Let <var>options</var> be 
+		  [$StructuredDeserialize$](<code>optionsSerialization</code>, the
 		  current Realm).
 
 	2. Let <var>processorConstructor</var> be the result of looking up


### PR DESCRIPTION
Convert the links about structured serialize to use bikeshed
abstract-op (English-language algorithms) links.  The resulting link
is the same, but this ensures we have the right link (as long as
bikeshed does).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1661.html" title="Last updated on Jun 8, 2018, 3:06 PM GMT (33b3e3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1661/2688b9a...rtoy:33b3e3e.html" title="Last updated on Jun 8, 2018, 3:06 PM GMT (33b3e3e)">Diff</a>