### PR TITLE
Fix #1664: Add more markup to copyFromChannel and copyToChannel

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2260,11 +2260,11 @@ Methods</h4>
 
 		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
-		<code>destination</code> array, and \(k\) be the value of
-		<code>startInChannel</code>. Then the number of frames copied
-		from <code>buffer</code> to <code>destination</code> is
+		{{AudioBuffer/copyFromChannel()/destination}} array, and \(k\) be the value of
+		{{AudioBuffer/copyFromChannel()/startInChannel}}. Then the number of frames copied
+		from <code>buffer</code> to {{AudioBuffer/copyFromChannel()/destination}} is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
-		remaining elements of <code>destination</code> are not
+		remaining elements of {{AudioBuffer/copyFromChannel()/destination}} are not
 		modified.
 
 		<pre class=argumentdef for="AudioBuffer/copyFromChannel()">
@@ -2285,9 +2285,9 @@ Methods</h4>
 
 		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
-		<code>source</code> array, and \(k\) be the value of
-		<code>startInChannel</code>. Then the number of frames copied
-		from <code>source</code> to the <code>buffer</code> is
+		{{AudioBuffer/copyToChannel()/source}} array, and \(k\) be the value of
+		{{AudioBuffer/copyToChannel()/startInChannel}}. Then the number of frames copied
+		from {{AudioBuffer/copyToChannel()/source}} to the <code>buffer</code> is
 		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
 		remaining elements of <code>buffer</code> are not
 		modified.


### PR DESCRIPTION
In the description of these methods, make references to `destination`,
`source`, and `startInChannel` link to the args of the methods.