### PR TITLE
Remove extra angle brackets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -618,7 +618,7 @@ There are also several features that have been deprecated from the
 Web Audio API but not yet removed, pending implementation experience
 of their replacements:
 
-* A {{ScriptProcessorNode}} interface, an {{AudioNode}}> for generating or processing audio directly
+* A {{ScriptProcessorNode}} interface, an {{AudioNode}} for generating or processing audio directly
 	using scripts.
 
 * An {{AudioProcessingEvent}} interface, which is
@@ -1147,7 +1147,7 @@ Methods</h4>
 				event loop:
 
 				1. Let <var>error</var> be a <code>DOMException</code>
-					whose name is {{EncodingError}}>.
+					whose name is {{EncodingError}}.
 
 				2. Reject <var>promise</var> with <var>error</var>.
 
@@ -9338,7 +9338,7 @@ within a special scope named {{AudioWorkletGlobalScope}}.
 
 Each {{BaseAudioContext}} possesses exactly one
 {{AudioWorklet}}. Scripts imported using this {{AudioWorklet}}
-are run in one or more {{AudioWorkletGlobalScope}}> global scopes,
+are run in one or more {{AudioWorkletGlobalScope}} global scopes,
 which are created to process audio associated with that
 {{BaseAudioContext}}.
 


### PR DESCRIPTION
A minor fix to remove some extraneous `">"` characters.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisn/web-audio-api/pull/1666.html" title="Last updated on Jun 10, 2018, 2:51 PM GMT (d1cf90e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1666/05d24f4...chrisn:d1cf90e.html" title="Last updated on Jun 10, 2018, 2:51 PM GMT (d1cf90e)">Diff</a>