### PR TITLE
Fix #1599: Mention that some AudioBuffer methods may throw errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2283,6 +2283,10 @@ Methods</h4>
 		the specified channel of the {{AudioBuffer}} from the
 		<code>source</code> array.
 
+		A {{RangeError}} may be thrown if
+		{{AudioBuffer/copyToChannel()/source}} cannot be
+		copied to the buffer.
+
 		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		{{AudioBuffer/copyToChannel()/source}} array, and \(k\) be the value of
@@ -2308,7 +2312,11 @@ Methods</h4>
 		either [=get a reference to the buffer source|get a reference to=]
 		or [=get a copy of the buffer source|get a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
-		{{Float32Array}}.
+		{{Float32Array}}
+
+		A {{RangeError}} may be thrown if the {{[[internal
+		data]]}} or the new {{Float32Array}} cannot be
+		created.
 
 		<pre class=argumentdef for="AudioBuffer/getChannelData()">
 		channel: This parameter is an index representing the particular channel to get data for. An index value of 0 represents the first channel. <span class="synchronous">This index value MUST be less than <code>numberOfChannels</code> or an {{IndexSizeError}} exception MUST be thrown.</span>

--- a/index.bs
+++ b/index.bs
@@ -2283,7 +2283,7 @@ Methods</h4>
 		the specified channel of the {{AudioBuffer}} from the
 		<code>source</code> array.
 
-		A {{RangeError}} may be thrown if
+		A {{UnknownError}} may be thrown if
 		{{AudioBuffer/copyToChannel()/source}} cannot be
 		copied to the buffer.
 
@@ -2314,7 +2314,7 @@ Methods</h4>
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}
 
-		A {{RangeError}} may be thrown if the {{[[internal
+		A {{UnknownError}} may be thrown if the {{[[internal
 		data]]}} or the new {{Float32Array}} cannot be
 		created.
 


### PR DESCRIPTION
Say that `copyToChannel` and `getChannelData` may signal errors if the
internal arrays can't be allocated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1670.html" title="Last updated on Jul 11, 2018, 9:12 PM GMT (fd90c6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1670/f9a90c3...rtoy:fd90c6a.html" title="Last updated on Jul 11, 2018, 9:12 PM GMT (fd90c6a)">Diff</a>