### PR TITLE
Set up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,8 @@
+---
 name: Bug Report
 about: Create a report to fix the specification
 
+---
 **Describe the issue**
 A clear and concise description of what the problem is in the spec.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,8 @@
+---
 name: Feature Request
 about: Suggest additions for WebAudio
 
+---
 **Describe the feature**
 Briefly describe the feature you would like WebAudio to have.
 


### PR DESCRIPTION
I think the problem with the original is that I was missing the `---` markers to tell github about the descriptions of the templates.

Maybe.