### PR TITLE
Issue #1658: Fix broken link to worklet import

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9342,7 +9342,7 @@ are run in one or more {{AudioWorkletGlobalScope}} global scopes,
 which are created to process audio associated with that
 {{BaseAudioContext}}.
 
-Importing a script via the <a href="https://drafts.css-houdini.org/worklets/#dom-worklet-import">import(moduleUrl)</a>
+Importing a script via the {{addModule(moduleURL, options)|addModule(moduleUrl)}}
 method registers class definitions of {{AudioWorkletProcessor}}
 under the {{AudioWorkletGlobalScope}}. There are two internal
 storage areas for the imported class definitions and the active
@@ -9364,7 +9364,7 @@ instances created from the definition.
 	populated as a consequence of calling the {{registerProcessor()}} method in the
         <a>rendering thread</a>. The population is guaranteed to complete
         prior to the resolution of the promise returned by
-	<a href="https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule">addModule()</a>
+	{{addModule()}}
 	on a context's {{BaseAudioContext/audioWorklet}}.
 
 
@@ -10118,7 +10118,7 @@ of an {{AudioWorkletNode}} and its associated
 		a key (<code>"custom"</code> in the above diagram) within the {{AudioWorkletGlobalScope}}.
 		This populates maps both in the global scope and in the {{AudioContext}}.
 
-	3. The promise for the <code>addModule()</code> call is resolved.
+	3. The promise for the {{addModule()}} call is resolved.
 
 	6. In the main scope, an {{AudioWorkletNode}} is created using
 		the user-specified key along with a


### PR DESCRIPTION
This should really be worklet `addModule`.  Also updated other places
referencing `addModule` so that we use bikeshed-style links intead of
direct `href` links.