### PR TITLE
Stop returning early in suspend() and resume() based on the main thread state, promises can be in flight

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1198,22 +1198,17 @@ Methods</h4>
 				promise with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
 
-			3. If the {{BaseAudioContext/state}}
-				attribute of the {{BaseAudioContext}} is already
-				"{{AudioContextState/running}}", resolve <var>promise</var>, return it, and
-				abort these steps.
-
-			4. If the {{BaseAudioContext}} is not <a>allowed to
+			3. If the {{BaseAudioContext}} is not <a>allowed to
 				start</a>, append <var>promise</var> to
 				<a>pendingResumePromises</a> and abort these steps, returning
 				<var>promise</var>.
 
-			5. Set the <em>control thread state</em> flag on the
+			4. Set the <em>control thread state</em> flag on the
 				{{BaseAudioContext}} to <code>running</code>.
 
-			6. <a>Queue a control message</a> to resume the {{BaseAudioContext}}.
+			5. <a>Queue a control message</a> to resume the {{BaseAudioContext}}.
 
-			7. Return <var>promise</var>.
+			6. Return <var>promise</var>.
 		</div>
 
 		<div algorithm="run a control message">
@@ -1721,14 +1716,11 @@ Methods</h4>
 				with {{InvalidStateError}}, abort these steps,
 				returning <em>promise</em>.
 
-			3. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is already "{{AudioContextState/suspended}}",
-				resolve <em>promise</em>, return it, and abort these steps.
+			3. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>suspended</code>.
 
-			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>suspended</code>.
+			4. <a>Queue a control message</a> to suspend the {{AudioContext}}.
 
-			5. <a>Queue a control message</a> to suspend the {{AudioContext}}.
-
-			6. Return <em>promise</em>.
+			5. Return <em>promise</em>.
 		</div>
 
 		<div algorithm="run a control message to suspend an AudioContext">


### PR DESCRIPTION
This fixes #1674.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1688.html" title="Last updated on Jul 11, 2018, 1:47 PM GMT (8a71630)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1688/93a16ff...padenot:8a71630.html" title="Last updated on Jul 11, 2018, 1:47 PM GMT (8a71630)">Diff</a>