### PR TITLE
Shorten comment lines in playback algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4897,7 +4897,8 @@ function process(numberOfFrames) {
 
 	// Render each sample frame in the quantum
 	for (let index = 0; index &lt; numberOfFrames; index++) {
-		// Check that currentTime and bufferTimeElapsed are within allowable range for playback
+		// Check that currentTime and bufferTimeElapsed are
+		// within allowable range for playback
 		if (currentTime &lt; start || currentTime >= stop || bufferTimeElapsed >= duration) {
 			output.push(0); // this sample frame is silent
 			currentTime += dt;
@@ -4905,7 +4906,8 @@ function process(numberOfFrames) {
 		}
 
 		if (!started) {
-			// Take note that buffer has started playing and get initial playhead position.
+			// Take note that buffer has started playing and get initial
+			// playhead position.
 			bufferTime = offset;
 			started = true;
 		}
@@ -4915,11 +4917,13 @@ function process(numberOfFrames) {
 			// Determine if looped portion has been entered for the first time
 			if (!enteredLoop) {
 				if (offset &lt; actualLoopEnd &amp;& bufferTime >= actualLoopStart) {
-					// playback began before or within loop, and playhead is now past loop start
+					// playback began before or within loop, and playhead is
+					// now past loop start
 					enteredLoop = true;
 				}
 				if (offset >= actualLoopEnd &amp;& bufferTime &lt; actualLoopEnd) {
-					// playback began after loop, and playhead is now prior to the loop end
+					// playback began after loop, and playhead is now prior
+					// to the loop end
 					enteredLoop = true;
 				}
 			}


### PR DESCRIPTION
Try to make the code fit in a short line so that we don't need a
scrollbar at the bottom to see the algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/1697.html" title="Last updated on Jul 13, 2018, 11:01 PM GMT (1c7bed7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1697/f607766...1c7bed7.html" title="Last updated on Jul 13, 2018, 11:01 PM GMT (1c7bed7)">Diff</a>