### PR TITLE
Adds "MyProcessor" code example back again

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9930,7 +9930,9 @@ class MyProcessor extends AudioWorkletProcessor {
 		let output = outputs[0];
 		let myParam = parameters.myParam;
 
-		// A simple amplifier for single input and output.
+		// A simple amplifier for single input and output. Note that the
+		// automationRate is "k-rate", so it will have a single value at index [0]
+		// for each render quantum.
 		for (let channel = 0; channel &lt; output.length; ++channel) {
 			for (let i = 0; i &lt; output[channel].length; ++i) {
 				output[channel][i] = input[channel][i] * myParam[0];

--- a/index.bs
+++ b/index.bs
@@ -9912,35 +9912,38 @@ validity of a given {{AudioWorkletProcessor}} subclass.
 		</div>
 </dl>
 
-<pre class="example" highlight="js" title="Subclassing AudioWorkletProcessor">
+The example below shows how {{AudioParam}} can be defined and used in an
+{{AudioWorkletProcessor}}.
+
+<xmp class="example" highlight="js" title="Subclassing AudioWorkletProcessor">
 class MyProcessor extends AudioWorkletProcessor {
-	static get parameterDescriptors() {
-		return [{
-			name: 'myParam',
-			defaultValue: 0.5,
-			minValue: 0,
-			maxValue: 1,
-			automationRate: "k-rate"
-		}];
-	}
+  static get parameterDescriptors() {
+    return [{
+      name: 'myParam',
+      defaultValue: 0.5,
+      minValue: 0,
+      maxValue: 1,
+      automationRate: "k-rate"
+    }];
+  }
 
-	process(inputs, outputs, parameters) {
-		// Get the first input and output.
-		let input = inputs[0];
-		let output = outputs[0];
-		let myParam = parameters.myParam;
+  process(inputs, outputs, parameters) {
+    // Get the first input and output.
+    let input = inputs[0];
+    let output = outputs[0];
+    let myParam = parameters.myParam;
 
-		// A simple amplifier for single input and output. Note that the
-		// automationRate is "k-rate", so it will have a single value at index [0]
-		// for each render quantum.
-		for (let channel = 0; channel &lt; output.length; ++channel) {
-			for (let i = 0; i &lt; output[channel].length; ++i) {
-				output[channel][i] = input[channel][i] * myParam[0];
-			}
-		}
-	}
+    // A simple amplifier for single input and output. Note that the
+    // automationRate is "k-rate", so it will have a single value at index [0]
+    // for each render quantum.
+    for (let channel = 0; channel < output.length; ++channel) {
+      for (let i = 0; i < output[channel].length; ++i) {
+        output[channel][i] = input[channel][i] * myParam[0];
+      }
+    }
+  }
 }
-</pre>
+</xmp>
 
 <h5 dictionary lt="AudioParamDescriptor">
 {{AudioParamDescriptor}}</h5>

--- a/index.bs
+++ b/index.bs
@@ -9821,7 +9821,7 @@ Methods</h5>
 User can define a custom audio processor by extending
 {{AudioWorkletProcessor}}. The subclass MUST define a method
 named {{process()}} that implements the audio processing
-algorithm and have a valid static property named
+algorithm and may have a valid static property named
 <code><dfn>parameterDescriptors</dfn></code> which is an iterable
 of {{AudioParamDescriptor}} that is looked up by the
 {{AudioWorkletProcessor}} constructor to create instances of
@@ -9911,7 +9911,35 @@ validity of a given {{AudioWorkletProcessor}} subclass.
 			<em>Return type:</em> {{boolean}}
 		</div>
 </dl>
-	
+
+<pre class="example" highlight="js" title="Subclassing AudioWorkletProcessor">
+class MyProcessor extends AudioWorkletProcessor {
+	static get parameterDescriptors() {
+		return [{
+			name: 'myParam',
+			defaultValue: 0.5,
+			minValue: 0,
+			maxValue: 1,
+			automationRate: "k-rate"
+		}];
+	}
+
+	process(inputs, outputs, parameters) {
+		// Get the first input and output.
+		let input = inputs[0];
+		let output = outputs[0];
+		let myParam = parameters.myParam;
+
+		// A simple amplifier for single input and output.
+		for (let channel = 0; channel &lt; output.length; ++channel) {
+			for (let i = 0; i &lt; output[channel].length; ++i) {
+				output[channel][i] = input[channel][i] * myParam[0];
+			}
+		}
+	}
+}
+</pre>
+
 <h5 dictionary lt="AudioParamDescriptor">
 {{AudioParamDescriptor}}</h5>
 


### PR DESCRIPTION
Fixes #1679.

- Adds `MyProcessor` example back again.
- Adds more comments on the "k-rate" specifier.
- A minor fix: adds "may" in the paragraph to clarify `parameterDescriptors` can be omitted.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1701.html" title="Last updated on Jul 18, 2018, 5:41 PM GMT (117b511)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1701/e8171b6...hoch:117b511.html" title="Last updated on Jul 18, 2018, 5:41 PM GMT (117b511)">Diff</a>