### PR TITLE
Fix #1698: Restrict nominal range of OscillatorNode.detune

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7979,16 +7979,19 @@ Attributes</h4>
 		{{OscillatorNode/frequency}} by the given amount. Its default
 		<code>value</code> is 0. This parameter is <a>a-rate</a>. It
 		forms a <a>compound parameter</a> with {{OscillatorNode/frequency}}
-		to form the <a>computedOscFrequency</a>.
+		to form the <a>computedOscFrequency</a>.  The nominal
+		range listed below allows this parameter to detune the
+		{{OscillatorNode/frequency}} over the entire possible
+		range of frequencies.
 
 		<pre class=include>
 		path: audioparam.include
 		macros:
 			default: 0
-			min: <a>most-negative-single-float</a>
-			min-notes: Approximately -3.4028235e38
-			max: <a>most-positive-single-float</a>
-			max-notes: Approximately 3.4028235e38
+			min: \(-1200 \log_2(F_s)\)
+			min-notes: \(F_s\) is the {{BaseAudioContext/sampleRate}} of the context
+			max: \(1200 \log_2(F_s)\)
+			max-notes: 
 			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 


### PR DESCRIPTION
The current range for the detune attribute is way too wide because the
computed oscillator frequency needs to be within the Nyquist
frequency.

The new limits allow the detune parameter to combine with any valid
frequency to result in a frequency that still covers the entire
frequency range.  Thus you can detune a frequency of -Nyquist to
Nyquist if so desired.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1703.html" title="Last updated on Jul 19, 2018, 5:24 PM GMT (2c0b0a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1703/cf0ad00...rtoy:2c0b0a0.html" title="Last updated on Jul 19, 2018, 5:24 PM GMT (2c0b0a0)">Diff</a>