### PR TITLE
Fix #1580: Do not throw errors for closed contexts

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -684,12 +684,6 @@ enum AudioContextState {
 			<td>
 				This context has been released, and can no longer be used to
 				process audio. All system audio resources have been released.
-				<span class="synchronous">Attempts to create new Nodes on the
-				AudioContext will throw {{InvalidStateError}}</span>.
-				(AudioBuffers may still be created,
-				through {{BaseAudioContext/createBuffer()}},
-				{{BaseAudioContext/decodeAudioData()}},
-				or the {{AudioBuffer}} constructor.)
 </table>
 </div>
 


### PR DESCRIPTION
Operations (node creation, connections, etc.) on a closed context do
not throw errors.  Hence remove the paragraph that says creating nodes
on a closed context throws an error.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1704.html" title="Last updated on Jul 19, 2018, 5:55 PM GMT (29db014)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1704/cf0ad00...rtoy:29db014.html" title="Last updated on Jul 19, 2018, 5:55 PM GMT (29db014)">Diff</a>