### PR TITLE
Copy SVG in additions to PNGs when publishing the spec. 

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -30,4 +30,5 @@ if [ -d out ]; then
     fi
     cp index.html out
     cp images/*.png out/images
+    cp images/*.svg out/images
 fi


### PR DESCRIPTION
This fixes #1705.