### PR TITLE
Fix two wrong names used in the compressor algorithm

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -1,7 +1,3 @@
-WARNING: The following <var>s were only used once in the document:
-  'target gain', in algorithm 'reduction-gain'
-  'final gain', in algorithm 'reduction-gain'
-If these are not typos, please add an ignore='' attribute to the <var>.
 WARNING: Multiple elements have the same ID 'dom-decodeerrorcallback-error'.
 Deduping, but this ID may not be stable across revisions.
 WARNING: Multiple elements have the same ID 'dom-decodesuccesscallback-decodeddata'.

--- a/index.bs
+++ b/index.bs
@@ -7135,7 +7135,7 @@ values. Those values persist accros invocation of this algorithm.
 			gain</var> multiplied by the return value of <a>computing the
 			makeup gain</a>.
 
-		10. Compute <var>metering gain</var> to be <var>final gain</var>, <a href="#linear-to-decibel">converted to
+		10. Compute <var>metering gain</var> to be <var>reduction gain</var>, <a href="#linear-to-decibel">converted to
 			decibel</a>.
 
 	1. Set {{[[compressor gain]]}} to <var>compressor

--- a/index.bs
+++ b/index.bs
@@ -7098,15 +7098,15 @@ values. Those values persist accros invocation of this algorithm.
 	1. For each sample <var>input</var> of the render quantum to be
 		processed, execute the following steps:
 
-		1. Let <var>releasing</var> be `true` if
-			<var>target gain</var> is greater than <var>compressor
-			gain</var>, <code>false</code> otherwise.
-
-		2. If the absolute value of <var>input</var> is less than
+		1. If the absolute value of <var>input</var> is less than
 			0.0001, let <var>attenuation</var> be 1.0. Else, let
 			<var>shaped input</var> be the value of applying the <a href="#compression-curve">compression curve</a> to the absolute
 			value of <var>input</var>. Let <var>attenuation</var> be
 			<var>shaped input</var> divided by the absolute value of <var>input</var>.
+
+		2. Let <var>releasing</var> be `true` if
+			<var>attenuation</var> is greater than <var>compressor
+			gain</var>, <code>false</code> otherwise.
 
 		3. Let <var>detector rate</var> be the result of applying the
 			<a href="#detector-curve">detector curve</a> to


### PR DESCRIPTION
This fixes #1502.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1707.html" title="Last updated on Jul 23, 2018, 12:22 PM GMT (79544ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1707/cf0ad00...padenot:79544ff.html" title="Last updated on Jul 23, 2018, 12:22 PM GMT (79544ff)">Diff</a>