### PR TITLE
Fix #1702: allow parameterDescriptors to be undefined

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9520,7 +9520,7 @@ Methods</h5>
 				Get</a>(O=<i>processorCtor</i>,
 				P="parameterDescriptors")</code>.
 
-			<li> If <var>descriptors</var> is not an array or
+			<li> If <var>descriptors</var> is neither an array nor
 				<code>undefined</code>, <span class="synchronous">throw a
 				{{TypeError}} and abort these steps</span>.
 			<li> Let <em>definition</em> be a new


### PR DESCRIPTION
This pull request is intended to fix #1702. It changes the wording of the algorithm as proposed by @karlt https://github.com/WebAudio/web-audio-api/issues/1702#issuecomment-406102638


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisguttandin/web-audio-api/pull/1711.html" title="Last updated on Jul 20, 2018, 9:12 PM GMT (1010a31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1711/141e4f2...chrisguttandin:1010a31.html" title="Last updated on Jul 20, 2018, 9:12 PM GMT (1010a31)">Diff</a>