### PR TITLE
Spec more precisely events overlapping with SetValueCurveAtTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3263,19 +3263,20 @@ The following rules will apply when calling these methods:
 	one or more events, then it will be placed in the list after them,
 	but before events whose times are after the event.
 
-* <span class="synchronous">If <a data-link-for="AudioParam">setValueCurveAtTime()</a> is called for time \(T\) and
-	duration \(D\) and there are any events having a time greater than
-	\(T\), but less than \(T + D\), then a
-	{{NotSupportedError}} exception MUST be thrown.</span> In
-	other words, it's not ok to schedule a value curve during a time
-	period containing other events.
+* <span class="synchronous">If <a
+	data-link-for="AudioParam">setValueCurveAtTime()</a> is called for time \(T\)
+	and duration \(D\) and there are any events having a time strictly greater than
+	\(T\), but strictly less than \(T + D\), then a {{NotSupportedError}} exception
+	MUST be thrown.</span> In other words, it's not ok to schedule a value curve
+	during a time period containing other events, but it's ok to schedule a value
+	curve exactly at the time of another event.
 
 * <span class="synchronous">Similarly a
 	{{NotSupportedError}} exception MUST be thrown if any
 	<a href="#dfn-automation-method">automation method</a> is called at
-	a time which is inside of the time interval of a
-	<code>SetValueCurve</code> event at time \(T\) and duration
-	\(D\).</span>
+	a time which is contained in \([T, T+D)\), \(T\) being the time of the curve
+	and \(D\) its duration.
+	</span>
 
 Note: {{AudioParam}} attributes are read only, with the exception
 of the {{AudioParam/value}} attribute.


### PR DESCRIPTION
This fixes issue #1721.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1723.html" title="Last updated on Aug 24, 2018, 3:21 PM GMT (361bda1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1723/6920e8b...padenot:361bda1.html" title="Last updated on Aug 24, 2018, 3:21 PM GMT (361bda1)">Diff</a>