### PR TITLE
Issue #1727: Refine startRendering algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1949,18 +1949,20 @@ Methods</h4>
 		event named <code>complete</code> for legacy reasons.
 
 		<div algorithm="OfflineAudioContext.startRendering()">
+			Let <dfn attribute for="OfflineAudioContext">[[rendering started]]</dfn> be an internal slot of this {{OfflineAudioContext}}.  Initialize this slot to <em>false</em>.
+
 			<span class="synchronous">When <code>startRendering</code> is
 			called, the following steps MUST be performed on the <a>control
 			thread</a>:</span>
 
 			<ol>
-				<li>Set a flag called <var>renderingStarted</var> on the
-				{{OfflineAudioContext}} to <em>true</em>.
-
-				<li>If the <var>renderingStarted</var> flag on the
+				<li>If the {{[[rendering started]]}} slot on the
 				{{OfflineAudioContext}} is <em>true</em>, return a rejected
 				promise with {{InvalidStateError}}, and abort these
 				steps.
+
+				<li>Set the {{[[rendering started]]}} slot of the
+				{{OfflineAudioContext}} to <em>true</em>.
 
 				<li>Let <var>promise</var> be a new promise.
 


### PR DESCRIPTION
Add an internal slot which we can initialize to false before running the startRendering algorithm.

Addresses issue #1727.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1731.html" title="Last updated on Aug 27, 2018, 10:28 PM GMT (e90b798)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1731/2a69b75...rtoy:e90b798.html" title="Last updated on Aug 27, 2018, 10:28 PM GMT (e90b798)">Diff</a>