### PR TITLE
Fix #1698: Widen range for detune values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7985,10 +7985,10 @@ Attributes</h4>
 		path: audioparam.include
 		macros:
 			default: 0
-			min: \(-1200 \log_2(F_s)\)
-			min-notes: \(F_s\) is the {{BaseAudioContext/sampleRate}} of the context
-			max: \(1200 \log_2(F_s)\)
-			max-notes: 
+			min: \(\approx -153600\)
+			min-notes: 
+			max: \(\approx 153600\)
+			max-notes: This value is approximately \(1200 \log_2 \mathrm{FLT\_MAX}\) where FLT_MAX is the largest {{float}} value.
 			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 


### PR DESCRIPTION
Widen the valid range of detune values so that any value that doesn't
cause 2^(d/1200) to overflow is valid.