### PR TITLE
Fix #1728: PannerNode constructor throws errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8334,7 +8334,16 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="PannerNode">
 	: <dfn>PannerNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{PannerNode}} object.
+		If {{PannerNode/PannerNode()/options}} is given, check
+		for valid values.  If values are not valid, an error
+		is thrown.  Validity is determined as if the the
+		attribute of the same name as the
+		{{PannerNode/PannerNode()/options}} emmber were set to
+		the given value. If an error would be thrown for when
+		setting this value, the same error MUST be thrown when
+		constructing this node.
+
+		Otherwise, let <var>node</var> be a new {{PannerNode}} object.
 		<a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
 		and return <var>node</var>.
 

--- a/index.bs
+++ b/index.bs
@@ -8336,9 +8336,9 @@ Constructors</h4>
 	::
 		If {{PannerNode/PannerNode()/options}} is given, check
 		for valid values.  If values are not valid, an error
-		is thrown.  Validity is determined as if the the
+		is thrown.  Validity is determined as if the 
 		attribute of the same name as the
-		{{PannerNode/PannerNode()/options}} emmber were set to
+		{{PannerNode/PannerNode()/options}} member were set to
 		the given value. If an error would be thrown for when
 		setting this value, the same error MUST be thrown when
 		constructing this node.


### PR DESCRIPTION
If a member of the options dictionary would assign an invalid value,
then the contructor must throw an error of the same type as assigning
the attribute would throw.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1733.html" title="Last updated on Aug 31, 2018, 6:07 PM GMT (46185f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1733/2e726d7...rtoy:46185f2.html" title="Last updated on Aug 31, 2018, 6:07 PM GMT (46185f2)">Diff</a>