### PR TITLE
Fix #1734: Make "queue a task" link to the HTML spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1118,7 +1118,7 @@ Methods</h4>
 
 				1. Let <var>error</var> be a {{DataCloneError}}.
 				2. Reject <var>promise</var> with <var>error</var>.
-				3. Queue a task to invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
+				3. <a>Queue a task</a> to invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
 
 			4. Return <var>promise</var>.
 		</div>
@@ -1137,7 +1137,7 @@ Methods</h4>
 
 			2. If a decoding error is encountered due to the audio format
 				not being recognized or supported, or because of
-				corrupted/unexpected/inconsistent data, then queue a task to
+				corrupted/unexpected/inconsistent data, then <a>queue a task</a> to
 				execute the following step, on the <a>control thread</a>'s
 				event loop:
 
@@ -1154,7 +1154,7 @@ Methods</h4>
 					{{AudioContext}} if it is different from
 					the sample-rate of {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}.
 
-				2. Queue a task on the <a>control thread</a>'s event loop
+				2. <a>Queue a task</a> on the <a>control thread</a>'s event loop
 					to execute the following steps:
 
 					1.Let <var>buffer</var> be an
@@ -1217,14 +1217,14 @@ Methods</h4>
 
 			3. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
-			4. In case of failure, queue a task on the <a>control thread</a> to execute the following,
+			4. In case of failure, <a>queue a task</a> on the <a>control thread</a> to execute the following,
 				and abort these steps:
 
 				1. Reject all promises from <a>pendingResumePromises</a> in order, then clear <a>pendingResumePromises</a>.
 
 				2. Reject <em>promise</em>.
 
-			5. Queue a task on the <a>control thread</a>'s event loop, to
+			5. <a>Queue a task</a> on the <a>control thread</a>'s event loop, to
 				execute these steps:
 
 				1. Resolve all promises from <a>pendingResumePromises</a> in order, then clear <a>pendingResumePromises</a>.
@@ -1235,7 +1235,7 @@ Methods</h4>
 
 					1. Set the {{BaseAudioContext/state}} attribute of the {{BaseAudioContext}} to "{{AudioContextState/running}}".
 
-					2. Queue a task to fire a simple event named <code>statechange</code> at the {{BaseAudioContext}}.
+					2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{BaseAudioContext}}.
 		</div>
 
 		<div>
@@ -1443,11 +1443,11 @@ Constructors</h4>
 
 			3. Set the <a>rendering thread state</a> to <code>running</code> on the {{AudioContext}}.
 
-			4. Queue a task on the <a>control thread</a> event loop, to execute these steps:
+			4. <a>Queue a task</a> on the <a>control thread</a> event loop, to execute these steps:
 
 				1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
-				2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+				2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
 		</div>
 
 		Note: It is unfortunately not possible to programatically notify
@@ -1544,11 +1544,11 @@ Methods</h4>
 
 			2. Set the <a>rendering thread state</a> to <code>suspended</code>.
 
-			3. Queue a task on the <a>control thread</a>'s event loop, to execute these steps:
+			3. <a>Queue a task</a> on the <a>control thread</a>'s event loop, to execute these steps:
 				1. Resolve <em>promise</em>.
 				2. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is not already "{{AudioContextState/closed}}":
 					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/closed}}".
-					2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+					2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
 		</div>
 
 		When an {{AudioContext}} is closed, any
@@ -1727,7 +1727,7 @@ Methods</h4>
 
 			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>suspended</code>.
 
-			3. Queue a task on the <a>control thread</a>'s event loop, to execute these steps:
+			3. <a>Queue a task</a> on the <a>control thread</a>'s event loop, to execute these steps:
 
 				1. Resolve <em>promise</em>.
 
@@ -1735,7 +1735,7 @@ Methods</h4>
 					attribute of the {{AudioContext}} is not already "{{AudioContextState/suspended}}":
 
 					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/suspended}}".
-					2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+					2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
 		</div>
 
 		While an {{AudioContext}} is suspended,
@@ -2001,13 +2001,13 @@ Methods</h4>
 				<li>If a suspended context is resumed, continue to render the
 				buffer.
 
-				<li>Once the rendering is complete, queue a task on the
+				<li>Once the rendering is complete, <a>queue a task</a> on the
 				<a>control thread</a>'s event loop to perform the following
 				steps:
 					<ol>
 						<li>Resolve the <var ignore>promise</var> created by {{startRendering()}} with {{[[rendered buffer]]}}.
 
-						<li>Queue a task to fire an event named
+						<li><a>Queue a task</a> to fire an event named
 						<code>complete</code> at this instance, using an instance
 						of {{OfflineAudioCompletionEvent}} whose
 						<code>renderedBuffer</code> property is set to
@@ -9540,7 +9540,7 @@ Methods</h5>
 				definition map</a> of the associated
 				{{AudioWorkletGlobalScope}}.
 
-			<li> Queue a task to the <a>control thread</a> to add the
+			<li> <a>Queue a task</a> to the <a>control thread</a> to add the
 				key-value pair (<em>name</em> - <em>descriptors</em>) to the
 				<a>node name to parameter descriptor map</a> of the
 				associated {{BaseAudioContext}}.
@@ -9642,7 +9642,7 @@ Attributes</h5>
 		When an exception is thrown from the processor's
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
-		queue a task on the control thread to fire
+		<a>queue a task</a> on the control thread to fire
 		{{onprocessorerror}} event to the node. Note that
 		once an exception is thrown, the processor will output
 		silence throughout its lifetime.
@@ -10093,7 +10093,7 @@ thread and the rendering thread.
 	{{AudioWorkletNode}} <var>node</var>, perform the following
 	steps on the <a>rendering thread</a>. If any of these steps throws
 	an exception (either explicitly or implicitly), abort the rest of
-	steps and queue a task on the <a>control thread</a> to fire
+	steps and <a>queue a task</a> on the <a>control thread</a> to fire
 	{{AudioWorkletNode/onprocessorerror}} event to
 	<var>node</var>.
 
@@ -10127,7 +10127,7 @@ thread and the rendering thread.
 	8. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.
 
-	9. Queue a task the <a>control thread</a> to set the associated
+	9. <a>Queue a task</a> the <a>control thread</a> to set the associated
 		{{AudioWorkletNode}}'s state to <code>running</code>, then fire
 		a <code>statechange</code> event.
 </div>


### PR DESCRIPTION
Make references to queuing a task link to the HTML spec.  Basically
did a search for "[Qq]ueue a task" and add `<a></a>` around it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1735.html" title="Last updated on Aug 31, 2018, 12:31 AM GMT (909a6c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1735/2e726d7...rtoy:909a6c3.html" title="Last updated on Aug 31, 2018, 12:31 AM GMT (909a6c3)">Diff</a>