### PR TITLE
refDistance is allowed to be zero

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8518,7 +8518,7 @@ Attributes</h4>
 		A reference distance for reducing volume as source moves further
 		from the listener. The default value is 1. A
 		{{RangeError}} exception MUST be thrown if this is set
-		to a non-positive value.
+		to a negative value.
 
 	: <dfn>rolloffFactor</dfn>
 	::


### PR DESCRIPTION
[The test](https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/webaudio/the-audio-api/the-pannernode-interface/panner-distance-clamping.html) and Chrome's impl allow this, and a zero value works fine in the algorithm.


r? @rtoy


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/web-audio-api/pull/1736.html" title="Last updated on Sep 5, 2018, 5:37 AM GMT (ff90b88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1736/c05ff33...Manishearth:ff90b88.html" title="Last updated on Sep 5, 2018, 5:37 AM GMT (ff90b88)">Diff</a>