### PR TITLE
fix #1743 by adding norm ref to fetch

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6497,7 +6497,7 @@ Attributes</h4>
 		<div algorithm="ConvolverNode.buffer">
 			To set the {{ConvolverNode/buffer}} attribute, execute these steps:
 
-			1. Let <var>new buffer</var> be an {{AudioBuffer}} to be 
+			1. Let <var>new buffer</var> be an {{AudioBuffer}} to be
 				assigned to {{ConvolverNode/buffer}} or <code>null</code> .
 
 			2. If <var>new buffer</var> is not <code>null</code> and
@@ -7641,7 +7641,7 @@ To prevent this, a {{MediaElementAudioSourceNode}} MUST output
 {{HTMLMediaElement}} if it has been created using an
 {{HTMLMediaElement}} for which the execution of the
 <a href="https://fetch.spec.whatwg.org/#fetching">fetch
-algorithm</a> labeled the resource as
+algorithm</a> [[!FETCH]] labeled the resource as
 <a href="https://html.spec.whatwg.org/#cors-cross-origin">CORS-cross-origin</a>.
 
 
@@ -7995,7 +7995,7 @@ Attributes</h4>
 		macros:
 			default: 0
 			min: \(\approx -153600\)
-			min-notes: 
+			min-notes:
 			max: \(\approx 153600\)
 			max-notes: This value is approximately \(1200 \log_2 \mathrm{FLT\_MAX}\) where FLT_MAX is the largest {{float}} value.
 			rate: "{{AutomationRate/a-rate}}"
@@ -8345,7 +8345,7 @@ Constructors</h4>
 	::
 		If {{PannerNode/PannerNode()/options}} is given, check
 		for valid values.  If values are not valid, an error
-		is thrown.  Validity is determined as if the 
+		is thrown.  Validity is determined as if the
 		attribute of the same name as the
 		{{PannerNode/PannerNode()/options}} member were set to
 		the given value. If an error would be thrown for when
@@ -9676,7 +9676,7 @@ Attributes</h5>
 	: <dfn>port</dfn>
 	::
 		Every {{AudioWorkletNode}} has an associated
-		<code>port</code> which is a 
+		<code>port</code> which is a
 		{{MessagePort}}. It is connected to the port on the
 		corresponding {{AudioWorkletProcessor}} object allowing
 		bidirectional communication between a pair of
@@ -10057,11 +10057,11 @@ thread and the rendering thread.
 	6. Let <var>processorPortOnThisSide</var> be the value of
 		<var>messageChannel</var>'s <code>port2</code> attribute.
 
-	7. Let <var>processorPortSerialization</var> be 
+	7. Let <var>processorPortSerialization</var> be
 			[$StructuredSerializeWithTransfer$](<var>processorPortOnThisSide</var>,
 			« <var>processorPortOnThisSide</var> »).
 
-	7. Let <var>optionsSerialization</var> be 
+	7. Let <var>optionsSerialization</var> be
 		[$StructuredSerialize$](<var>options</var>).
 
 	8. Set <var>node</var>'s {{AudioWorkletNode/port}} to <var>nodePort</var>.
@@ -10119,7 +10119,7 @@ thread and the rendering thread.
 		[$StructuredDeserializeWithTransfer$](<var>processorPortSerialization</var>,
 		the current Realm).
 
-	1. Let <var>options</var> be 
+	1. Let <var>options</var> be
 		  [$StructuredDeserialize$](<code>optionsSerialization</code>, the
 		  current Realm).
 


### PR DESCRIPTION
Add the missing normative reference


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/1744.html" title="Last updated on Sep 8, 2018, 4:06 PM GMT (ce79a60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1744/532202f...ce79a60.html" title="Last updated on Sep 8, 2018, 4:06 PM GMT (ce79a60)">Diff</a>