### PR TITLE
Clarify that one must always keep around the last max-fft-size frames.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4117,6 +4117,13 @@ Attributes</h4>
 		used for <a href="#smoothing-over-time">smoothing over time</a>
 		is set to 0 for all \(k\).
 
+		Note that increasing {{AnalyserNode/fftSize}} does mean that the
+		<a>current time-domain data</a> must be expanded to include past
+		frames that it previously did not. This means that the
+		{{AnalyserNode}} effectively MUST keep around the last 32768 sample-
+		frames and the <a>current time-domain data</a> is the most recent
+		{{AnalyserNode/fftSize}} sample-frames out of that.
+
 	: <dfn>frequencyBinCount</dfn>
 	::
 		Half the FFT size.


### PR DESCRIPTION
r? @rtoy

fixes #1746


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/web-audio-api/pull/1750.html" title="Last updated on Sep 14, 2018, 5:48 AM GMT (a0dcf9f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1750/9c67621...Manishearth:a0dcf9f.html" title="Last updated on Sep 14, 2018, 5:48 AM GMT (a0dcf9f)">Diff</a>