### PR TITLE
AnalyserNode's default channelCount is 1

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4063,7 +4063,7 @@ macros:
 	noi: 1
 	noo: 1
 	noo-notes: This output may be left unconnected.
-	cc: 2
+	cc: 1
 	cc-mode: max
 	cc-interp: speakers
 	tail-time: No


### PR DESCRIPTION
This matches Firefox/Chrome as well as the [expectations of the WPT test](https://github.com/web-platform-tests/wpt/blob/e241e4de1c07c47f004199fc12d031559208b922/webaudio/the-audio-api/the-analysernode-interface/ctor-analyser.html#L35)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/web-audio-api/pull/1751.html" title="Last updated on Sep 14, 2018, 12:09 PM GMT (d966720)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1751/c776aa1...Manishearth:d966720.html" title="Last updated on Sep 14, 2018, 12:09 PM GMT (d966720)">Diff</a>