### PR TITLE
Explicitly include time-domain processing code for BiquadFilterNode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5920,15 +5920,24 @@ implement, as they determine the characteristics of the different
 filter types. They are inspired by formulas found in the
 <a href="https://www.w3.org/2011/audio/audio-eq-cookbook.html">Audio EQ Cookbook</a>.
 
-The transfer function for the filters implemented by the
-{{BiquadFilterNode}} is:
+The {{BiquadFilterNode}} processes audio with a transfer function of
 
 <pre nohighlight>
 $$
-H(z) = \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} + \frac{b_2}{a_0}z^{-2}}
-						{1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}
+ H(z) = \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} + \frac{b_2}{a_0}z^{-2}}
+                                          {1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}
 $$
 </pre>
+
+which is equivalent to a time-domain equation of:
+
+<pre nohighlight>
+$$
+a_0 y(n) + a_1 y(n-1) + a_2 y(n-2) =
+	b_0 x(n) + b_1 x(n-1) + b_2 x(n-2)
+$$
+</pre>
+
 
 The initial filter state is 0.
 The coefficients in the transfer function above are different for


### PR DESCRIPTION
The spec mentions the transfer function but not the time-domain
equation which is what is more useful for implementors.

It should mention this and also mention how it was obtained.


r? @rtoy


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/web-audio-api/pull/1758.html" title="Last updated on Sep 28, 2018, 7:08 PM GMT (c181491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1758/a225429...Manishearth:c181491.html" title="Last updated on Sep 28, 2018, 7:08 PM GMT (c181491)">Diff</a>