### PR TITLE
Fix some prose that was stating that multiple AudioWorkletGlobalScope could exist for a single AudioContext

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9442,14 +9442,10 @@ script code is evaluated in this scope to define one or more
 instantiate {{AudioWorkletProcessor}}s, in a 1:1 association
 with {{AudioWorkletNode}}s in the main scope.
 
-At least one {{AudioWorkletGlobalScope}} exists for each
+Exactly one {{AudioWorkletGlobalScope}} exists for each
 {{AudioContext}} that contains one or more
 {{AudioWorkletNode}}s. The running of imported scripts is
-performed by the UA as defined in [[!worklets-1]], in such a way
-that all scripts are applied consistently to every global scope,
-and all scopes thus exhibit identical behavior. Beyond these
-guarantees, the creation of global scopes is transparent to the
-author and cannot be observed from the main window scope.
+performed by the UA as defined in [[!worklets-1]].
 
 {{AudioWorkletGlobalScope}} has a <a>node name to processor
 definition map</a>. This map stores definitions of
@@ -9463,7 +9459,7 @@ and code to be shared by these instances. As an example, multiple
 processors might share an ArrayBuffer defining a wavetable or an
 impulse response.
 
-Note: Every {{AudioWorkletGlobalScope}} is associated with a single
+Note: An {{AudioWorkletGlobalScope}} is associated with a single
 {{BaseAudioContext}}, and with a single audio rendering thread
 for that context. This prevents data races from occurring in global
 scope code running within concurrent threads.


### PR DESCRIPTION
This fixes #1753.

I think that's everything we need to fix?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1760.html" title="Last updated on Sep 19, 2018, 9:07 AM GMT (c91e1d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1760/a225429...padenot:c91e1d6.html" title="Last updated on Sep 19, 2018, 9:07 AM GMT (c91e1d6)">Diff</a>