### PR TITLE
Replaced AudioContext with BaseAudioContext where it's appropriate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10659,7 +10659,7 @@ Operations that happen <dfn>atomically</dfn> on a
 given thread can only be executed when no other [=Atomically|atomic=]
 operation is running on another thread.
 
-The algorithm for rendering a block of audio from an {{BaseAudioContext}}
+The algorithm for rendering a block of audio from a {{BaseAudioContext}}
 <em>G</em> with a <a href="#control-message-queue">control message queue</a>
 <em>Q</em> is comprised of multiple steps and explained in further detail
 in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.

--- a/index.bs
+++ b/index.bs
@@ -10584,9 +10584,9 @@ queue</dfn>, that is a list of <dfn lt="control message">control
 messages</dfn> that are operations running on the <a>control
 thread</a>.
 
-<dfn id="queuing" lt="queue a control message">Queuing a control message</dfn> means adding the
-message to the end of the <a>control message queue</a> of an
-{{AudioContext}}.
+<dfn id="queuing" lt="queue a control message">Queuing a control message</dfn>
+means adding the message to the end of the <a>control message queue</a> of an
+{{BaseAudioContext}}.
 
 <a>Control messages</a> in a <a>control message queue</a> are ordered
 by time of insertion. The <dfn>oldest message</dfn> is therefore the
@@ -10612,7 +10612,7 @@ one at the front of the <a>control message queue</a>.
 	Note: For example, successfuly calling <code>start()</code> on an
 	{{AudioBufferSourceNode}} <code>source</code> adds a <a>control
 	message</a> to the <a href="#control-message-queue">control message
-	queue</a> of the {{AudioContext}} <code>source.context</code>.
+	queue</a> of the associated {{BaseAudioContext}}.
 </div>
 
 <h3 id="asynchronous-operations">
@@ -10626,7 +10626,7 @@ invalid parameters), and some part happens on the <a>rendering
 thread</a> (for example, changing the value of an {{AudioParam}}).
 
 In the description of each operation on {{AudioNode}}s and
-{{AudioContext}}s, the synchronous section is marked with a ⌛. All
+{{BaseAudioContext}}s, the synchronous section is marked with a ⌛. All
 the other operations are executed <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">
 in parallel</a>, as described in [[HTML]].
 
@@ -10659,10 +10659,10 @@ Operations that happen <dfn>atomically</dfn> on a
 given thread can only be executed when no other [=Atomically|atomic=]
 operation is running on another thread.
 
-The algorithm for rendering a block of audio from an {{AudioContext}} <em>G</em>
-with a <a href="#control-message-queue">control message queue</a> <em>Q</em> is
-comprised of multiple steps and explained in further detail in the algorithm
-of <a href="#rendering-a-graph">rendering a graph</a>.
+The algorithm for rendering a block of audio from an {{BaseAudioContext}}
+<em>G</em> with a <a href="#control-message-queue">control message queue</a>
+<em>Q</em> is comprised of multiple steps and explained in further detail
+in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.
 
 <div class="note">
 	In practice, the {{AudioContext}} <a>rendering thread</a> is
@@ -10715,17 +10715,17 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 	3. Process a render quantum.
 
-		1. If the [=rendering thread state=] of the {{AudioContext}} is not
+		1. If the [=rendering thread state=] of the {{BaseAudioContext}} is not
 			<code>running</code>, return false.
 
-		2. Order the {{AudioNode}}s of the {{AudioContext}} to be processed.
+		2. Order the {{AudioNode}}s of the {{BaseAudioContext}} to be processed.
 
 			1. Let <var>ordered node list</var> be an empty list of {{AudioNode}}s. It will
 				contain an ordered list of {{AudioNode}}s when this ordering algorithm
 				terminates.
 
 			2. Let <var>nodes</var> be the set of all nodes created by this
-				{{AudioContext}}, and still alive.
+				{{BaseAudioContext}}, and still alive.
 
 			3. Let <var>cycle breakers</var> be an empty set of {{DelayNode}}s. It will
 				contain all the {{DelayNode}}s that are part of a cycle.


### PR DESCRIPTION
Simple editorial changes. Fixes #1739.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1765.html" title="Last updated on Sep 21, 2018, 8:23 PM GMT (747576c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1765/8091590...hoch:747576c.html" title="Last updated on Sep 21, 2018, 8:23 PM GMT (747576c)">Diff</a>