### PR TITLE
fix typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2781,7 +2781,7 @@ Attributes</h4>
 			: {{AudioContext}}
 			::
 				The channel count MUST be between 1 and
-o				{{AudioDestinationNode/maxChannelCount}}. An <span class="synchronous">{{IndexSizeError}} exception MUST
+				{{AudioDestinationNode/maxChannelCount}}. An <span class="synchronous">{{IndexSizeError}} exception MUST
 				be thrown for any attempt to set the count outside this
 				range</span>.
 			: {{OfflineAudioContext}}


### PR DESCRIPTION
This pull request simply fixes a typo. In fact it only removes a single character. It causes a weird indentation of the [attributes section](https://webaudio.github.io/web-audio-api/#AudioNode-attributes).

It looks like it was accidentally introduced with this pull request: https://github.com/WebAudio/web-audio-api/pull/1742/files