### PR TITLE
Fix #1766: Fix section number

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8036,8 +8036,8 @@ interface OscillatorNode : AudioScheduledSourceNode {
 };
 </pre>
 
-<h3 id="OscillatorNode-constructors">
-Constructors</h3>
+<h4 id="OscillatorNode-constructors">
+Constructors</h4>
 
 <dl dfn-type=constructor dfn-for="OscillatorNode">
 	: <dfn>OscillatorNode(context, options)</dfn>


### PR DESCRIPTION
The constructors for `OscillatorNode` should be numbered 1.26.1, not
1.27.

Change the h3 tag to h4 to get the right nesting.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1769.html" title="Last updated on Sep 24, 2018, 7:36 PM GMT (b5381ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1769/fe44183...rtoy:b5381ad.html" title="Last updated on Sep 24, 2018, 7:36 PM GMT (b5381ad)">Diff</a>