### PR TITLE
Link to correct algorithm for StereoPannerNode, mention algorithm is equal-power

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9034,7 +9034,7 @@ Attributes</h4>
 The {{StereoPannerNode}} Interface</h3>
 
 This interface represents a processing node which positions an
-incoming audio stream in a stereo image using a low-cost <a href="#Spatialization-equal-power-panning">equal-power panning
+incoming audio stream in a stereo image using <a href="#stereopanner-algorithm">a low-cost panning
 algorithm</a>. This panning effect is common in positioning audio
 components in a stereo stream.
 


### PR DESCRIPTION
StereoPannerNode currently links to PannerNode's algorithm, which asks for the computation of the azimuth. This isn't necessary, StereoPannerNode's `pan` argument is the equivalent of the azimuth, in different units.


r? @rtoy


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Manishearth/web-audio-api/pull/1770.html" title="Last updated on Sep 24, 2018, 10:53 PM GMT (113885f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1770/a225429...Manishearth:113885f.html" title="Last updated on Sep 24, 2018, 10:53 PM GMT (113885f)">Diff</a>