### PR TITLE
Revise sanity checks on AudioWorkletProcessor.process() method

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9848,7 +9848,8 @@ custom audio node. {{AudioWorkletProcessor}} can
 only be instantiated by the construction of an
 {{AudioWorkletNode}} instance. Every
 {{AudioWorkletProcessor}} has an associated <dfn>node
-reference</dfn>, initially null.
+reference</dfn> and <dfn>callable process</dfn> that are
+initially null and false respectively.
 
 <pre class="idl">
 [Exposed=AudioWorklet,
@@ -9918,8 +9919,7 @@ algorithm and may have a valid static property named
 of {{AudioParamDescriptor}} that is looked up by the
 {{AudioWorkletProcessor}} constructor to create instances of
 {{AudioParam}} in the <code>parameters</code> maplike storage
-in the node. The <a href="#check-prototype-type">prototype type check step</a> and the <a href="#check-is-callable">process method is callable step</a> of <a data-link-for="AudioWorkletGlobalScope">registerProcessor()</a> ensure the
-validity of a given {{AudioWorkletProcessor}} subclass.
+in the node.
 
 <dl dfn-type=method dfn-for="AudioWorkletProcessor">
 	: <dfn>process(inputs, outputs, parameters)</dfn>
@@ -9929,13 +9929,17 @@ validity of a given {{AudioWorkletProcessor}} subclass.
 
 		The {{process()}} method is called
 		synchronously by the audio <a>rendering thread</a> at
-		every <a>render quantum</a>, if ANY of the following
-		<dfn dfn>active processing conditions</dfn> are true:
+		every <a>render quantum</a>, if both conditions are met:
 
-		1. The associated {{AudioWorkletProcessor}}'s
-			<a>active source</a> flag is equal to `true`.
+		1. {{callable process}} is `true`.
 
-		2. There are one or more connected inputs to the {{AudioWorkletNode}}.
+		1. <dfn>active processing conditions</dfn> are `true`, meaning
+			ANY of the following states are met:
+
+			* The associated {{AudioWorkletProcessor}}'s
+				<a>active source</a> flag is equal to `true`.
+
+			* There are one or more connected inputs to the {{AudioWorkletNode}}.
 
 		The return value of this method controls the lifetime of the
 		{{AudioWorkletProcessor}}'s associated
@@ -10210,12 +10214,10 @@ thread and the rendering thread.
 	1. Set <var>processor</var>'s <a>node reference</a> to
 		<var>node</var>.
 
+	1. Set {{callable process}} to `true`.
+
 	1. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.
-
-	1. <a>Queue a task</a> to the <a>control thread</a> to set the associated
-		{{AudioWorkletNode}}'s state to <code>running</code>, then fire
-		a <code>statechange</code> event.
 </div>
 
 <h4 id="AudioWorklet-Sequence">
@@ -10795,28 +10797,30 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these steps:
 
+			  1. If {{callable process}} is `false`, abort the following sub steps.
+
 				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
 					instance.
 
-				2. Let <var>processFunction</var> be the result of
+				1. Let <var>processFunction</var> be the result of
 					<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
 					Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
 
-				3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
+				1. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
 					IsCallable</a>(argument=<i><var>processFunction</var></i>)</code> is
 					false, execute the following:
 
 					1. Queue a control message to fire `onprocessorerror` event on the
 						associated AudioWorkletNode.
 
-					2. Output silence to output buffer.
+					1. Set {{callable process}} to `false`.
 
-				4. Invoke <var>processFunction</var> to
+				1. Invoke <var>processFunction</var> to
 					[=Computing a block of audio|compute a block of audio=] with the
 					argument of [=input buffer=], output buffer and
 					[=input AudioParam buffer=].
 
-				5. Any {{Promise}} resolved within the execution of process method will
+				1. Any {{Promise}} resolved within the execution of process method will
 					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.
 
 			5. Else, if this {{AudioNode}} is a <a>destination node</a>,

--- a/index.bs
+++ b/index.bs
@@ -9865,8 +9865,8 @@ interface AudioWorkletProcessor {
 
 	: <dfn>[[callable process]]</dfn>
 	::
-		A boolean flag represents whether {{AudioWorkletProcessor/process()}} is
-		a valid function that can ba invoked.
+		A boolean flag representing whether {{AudioWorkletProcessor/process()}} is
+		a valid function that can be invoked.
 </dl>
 
 <h5 id="AudioWorketProcessor-constructors">
@@ -9943,7 +9943,7 @@ in the node.
 		synchronously by the audio <a>rendering thread</a> at
 		every <a>render quantum</a>, if both conditions are met:
 
-		* {{{[[callable process]]}} is `true`.
+		* {{[[callable process]]}} is `true`.
 
 		* <dfn dfn>active processing conditions</dfn> are `true`, meaning
 			ANY of the following states are met:

--- a/index.bs
+++ b/index.bs
@@ -10196,29 +10196,25 @@ thread and the rendering thread.
 		  [$StructuredDeserialize$](<code>optionsSerialization</code>, the
 		  current Realm).
 
-	2. Let <var>processorConstructor</var> be the result of looking up
+	1. Let <var>processorConstructor</var> be the result of looking up
 		<var>nodeName</var> on the {{AudioWorkletGlobalScope}}'s <a>node
 		name to processor definition map</a>.
 
-	3. If <var>processorConstructor</var> is <code>undefined</code>,
+	1. If <var>processorConstructor</var> is <code>undefined</code>,
 		throw a {{NotSupportedError}} DOMException.
 
-	4. Let <var>processor</var> be the result of
+	1. Let <var>processor</var> be the result of
 		Construct(<var>processorConstructor</var>, « <var>options</var> »).
 
-	5. If <var>processor</var> does not implement the
-		{{AudioWorkletProcessor}} interface, throw an
-		{{InvalidStateError}} DOMException.
+	1. Set <var>processor</var>'s {{AudioWorkletProcessor/port}} to <var>processorPort</var>.
 
-	6. Set <var>processor</var>'s {{AudioWorkletProcessor/port}} to <var>processorPort</var>.
-
-	7. Set <var>processor</var>'s <a>node reference</a> to
+	1. Set <var>processor</var>'s <a>node reference</a> to
 		<var>node</var>.
 
-	8. Set <var>node</var>'s <a>processor reference</a> to
+	1. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.
 
-	9. <a>Queue a task</a> the <a>control thread</a> to set the associated
+	1. <a>Queue a task</a> the <a>control thread</a> to set the associated
 		{{AudioWorkletNode}}'s state to <code>running</code>, then fire
 		a <code>statechange</code> event.
 </div>
@@ -10798,11 +10794,23 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 				[=Computing a block of audio|compute a block of audio=], and
 				[=Making a buffer available for reading|make it available for reading=].
 
-			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, invoke associated
-				{{AudioWorkletProcessor}}'s {{AudioWorkletProcessor/process()}} method
-				to [=Computing a block of audio|compute a block of audio=] with
-				the argument of [=input buffer=], output buffer and
-				[=input AudioParam buffer=].
+			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these step:
+
+				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
+				  instance.
+
+				2. Let <var>processFunction</var> be the result of
+				  <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+					Get</a>(O=<i>processor</i>, P="process")</code>.
+
+			  3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
+					IsCallable</a>(argument=<i>processFunction</i>)</code> is false, throw a
+					{{TypeError}}.
+
+				4. Invoke <var>processFunction</var> to
+				  [=Computing a block of audio|compute a block of audio=] with the
+					argument of [=input buffer=], output buffer and
+					[=input AudioParam buffer=].
 
 				1. Any {{Promise}} resolved within the execution of process method will
 					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.

--- a/index.bs
+++ b/index.bs
@@ -10803,7 +10803,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
 					Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
 
-			  3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
+				3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
 					IsCallable</a>(argument=<i><var>processFunction</var></i>)</code> is
 					false, throw a {{TypeError}}.
 
@@ -10812,7 +10812,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					argument of [=input buffer=], output buffer and
 					[=input AudioParam buffer=].
 
-				1. Any {{Promise}} resolved within the execution of process method will
+				5. Any {{Promise}} resolved within the execution of process method will
 					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.
 
 			5. Else, if this {{AudioNode}} is a <a>destination node</a>,

--- a/index.bs
+++ b/index.bs
@@ -9933,7 +9933,7 @@ in the node.
 
 		1. {{callable process}} is `true`.
 
-		1. <dfn>active processing conditions</dfn> are `true`, meaning
+		1. <dfn dfn>active processing conditions</dfn> are `true`, meaning
 			ANY of the following states are met:
 
 			* The associated {{AudioWorkletProcessor}}'s

--- a/index.bs
+++ b/index.bs
@@ -9943,7 +9943,7 @@ in the node.
 		synchronously by the audio <a>rendering thread</a> at
 		every <a>render quantum</a>, if both conditions are met:
 
-		* <a>callable process</a> is `true`.
+		* {{{[[callable process]]}} is `true`.
 
 		* <dfn dfn>active processing conditions</dfn> are `true`, meaning
 			ANY of the following states are met:

--- a/index.bs
+++ b/index.bs
@@ -9931,9 +9931,9 @@ in the node.
 		synchronously by the audio <a>rendering thread</a> at
 		every <a>render quantum</a>, if both conditions are met:
 
-		1. <a>callable process</a> is `true`.
+		* <a>callable process</a> is `true`.
 
-		1. <dfn dfn>active processing conditions</dfn> are `true`, meaning
+		* <dfn dfn>active processing conditions</dfn> are `true`, meaning
 			ANY of the following states are met:
 
 			* The associated {{AudioWorkletProcessor}}'s
@@ -10795,35 +10795,42 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 				[=Computing a block of audio|compute a block of audio=], and
 				[=Making a buffer available for reading|make it available for reading=].
 
-			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these steps:
-
-			  1. If <a>callable process</a> is `false`, abort the following sub steps.
+			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these
+				substeps:
 
 				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
-					instance.
+					instance of {{AudioWorkletNode}}.
 
-				1. Let <var>processFunction</var> be the result of
-					<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
-					Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
+				1. If <a>callable process</a> of <var>processor</var> is `true`,
+					execute the following steps:
 
-				1. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
-					IsCallable</a>(argument=<i><var>processFunction</var></i>)</code> is
-					false, execute the following:
+					1. Let <var>processFunction</var> be the result of
+						<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+						Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
 
-					1. Queue a control message to fire `onprocessorerror` event on the
-						associated AudioWorkletNode.
+					1. Set <a>callable process</a> to be the return value of
+						<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
+						IsCallable</a>(argument=<i><var>processFunction</var></i>)</code>.
 
-					1. Set <a>callable process</a> to `false`.
+					1. If <a>callable process</a> is `true`,
+						invoke <var>processFunction</var> to
+						[=Computing a block of audio|compute a block of audio=] with the
+						argument of [=input buffer=], output buffer and
+						[=input AudioParam buffer=].
 
-				1. Invoke <var>processFunction</var> to
-					[=Computing a block of audio|compute a block of audio=] with the
-					argument of [=input buffer=], output buffer and
-					[=input AudioParam buffer=].
+					1. Else if <a>callable process</a> is `false`,
+						<a>Queue a control message</a> to fire `onprocessorerror` event on
+						the associated {{AudioWorkletNode}}.
+
+				1. If <a>callable process</a> of <var>processor</var> is `false`,
+					execute the following steps:
+
+					1. [=Making a buffer available for reading|Make a silent output buffer available for reading=].
 
 				1. Any {{Promise}} resolved within the execution of process method will
 					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.
 
-			5. Else, if this {{AudioNode}} is a <a>destination node</a>,
+			5. If this {{AudioNode}} is a <a>destination node</a>,
 				[=Recording the input|record the input=] of this {{AudioNode}}.
 
 			6. Else, <a>process</a> the <a>input buffer</a>, and

--- a/index.bs
+++ b/index.bs
@@ -9846,10 +9846,7 @@ audio <a>rendering thread</a>. It lives in an
 the class manifests the actual audio processing mechanism of a
 custom audio node. {{AudioWorkletProcessor}} can
 only be instantiated by the construction of an
-{{AudioWorkletNode}} instance. Every
-{{AudioWorkletProcessor}} has an associated <dfn>node
-reference</dfn> and <dfn>callable process</dfn> that are
-initially null and false respectively.
+{{AudioWorkletNode}} instance.
 
 <pre class="idl">
 [Exposed=AudioWorklet,
@@ -9858,6 +9855,19 @@ interface AudioWorkletProcessor {
 	readonly attribute MessagePort port;
 };
 </pre>
+
+{{AudioWorkletProcessor}} has two internal slots:
+
+<dl dfn-type=attribute dfn-for="AudioWorkletProcessor">
+	: <dfn>[[node reference]]</dfn>
+	::
+		A reference to the associated {{AudioWorkletNode}}.
+
+	: <dfn>[[callable process]]</dfn>
+	::
+		A boolean flag represents whether {{AudioWorkletProcessor/process()}} is
+		a valid function that can ba invoked.
+</dl>
 
 <h5 id="AudioWorketProcessor-constructors">
 Constructors</h5>
@@ -9875,7 +9885,7 @@ Constructors</h5>
 				directly from JavaScript. The interface object may only
 				be called internally by the UA.
 
-			  1. Initialize the {{AudioWorkletProcessor}} using the
+			1. Initialize the {{AudioWorkletProcessor}} using the
 				contents of the <code>options</code> dictionary that was
 				passed to the constructor for {{AudioWorkletNode}}. The
 				contents of this dictionary will have been serialized and
@@ -9888,6 +9898,9 @@ Constructors</h5>
 				{{AudioWorkletProcessor}} will use this dictionary to
 				initialize themselves based on the options relevant to
 				their specific node type.
+
+			1. Set {{[[node reference]]}} to `null` and {{[[callable process]]}} to
+				`false`.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">
@@ -9895,8 +9908,7 @@ Constructors</h5>
 		</pre>
 </dl>
 
-<h5 id="AudioWorkletProcessor-attributes">
-Attributes</h5>
+<h5 id="AudioWorkletProcessor-attributes">Attributes</h5>
 
 <dl dfn-type=attribute dfn-for="AudioWorkletProcessor">
 	: <dfn>port</dfn>
@@ -10211,10 +10223,10 @@ thread and the rendering thread.
 	1. Set <var>processor</var>'s {{AudioWorkletProcessor/port}} to
 		<var>processorPort</var>.
 
-	1. Set <var>processor</var>'s <a>node reference</a> to
+	1. Set <var>processor</var>'s {{[[node reference]]}}to
 		<var>node</var>.
 
-	1. Set <a>callable process</a> to `true`.
+	1. Set {{[[callable process]]}} to `true`.
 
 	1. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.
@@ -10801,28 +10813,28 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
 					instance of {{AudioWorkletNode}}.
 
-				1. If <a>callable process</a> of <var>processor</var> is `true`,
+				1. If {{[[callable process]]}} of <var>processor</var> is `true`,
 					execute the following steps:
 
 					1. Let <var>processFunction</var> be the result of
 						<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
 						Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
 
-					1. Set <a>callable process</a> to be the return value of
+					1. Set {{[[callable process]]}} to be the return value of
 						<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
 						IsCallable</a>(argument=<i><var>processFunction</var></i>)</code>.
 
-					1. If <a>callable process</a> is `true`,
+					1. If {{[[callable process]]}} is `true`,
 						invoke <var>processFunction</var> to
 						[=Computing a block of audio|compute a block of audio=] with the
 						argument of [=input buffer=], output buffer and
 						[=input AudioParam buffer=].
 
-					1. Else if <a>callable process</a> is `false`,
+					1. Else if {{[[callable process]]}} is `false`,
 						<a>Queue a control message</a> to fire `onprocessorerror` event on
 						the associated {{AudioWorkletNode}}.
 
-				1. If <a>callable process</a> of <var>processor</var> is `false`,
+				1. If {{[[callable process]]}} of <var>processor</var> is `false`,
 					execute the following steps:
 
 					1. [=Making a buffer available for reading|Make a silent output buffer available for reading=].

--- a/index.bs
+++ b/index.bs
@@ -9931,9 +9931,9 @@ in the node.
 		synchronously by the audio <a>rendering thread</a> at
 		every <a>render quantum</a>, if both conditions are met:
 
-		1. {{callable process}} is `true`.
+		1. <a>callable process</a> is `true`.
 
-		1. <dfn dfn>active processing conditions</dfn> are `true`, meaning
+		1. <dfn>active processing conditions</dfn> are `true`, meaning
 			ANY of the following states are met:
 
 			* The associated {{AudioWorkletProcessor}}'s
@@ -9985,7 +9985,7 @@ in the node.
 		</div>
 
 		If {{process()}} is not called during some rendering
-		quantum due to the lack of any applicable [=active processing conditions=], the result is as if the processor emitted
+		quantum due to the lack of any applicable <a>active processing conditions</a>, the result is as if the processor emitted
 		silence for this period.
 
 		<pre class=argumentdef for="AudioWorkletProcessor/process(inputs, outputs, parameters))">
@@ -10214,7 +10214,7 @@ thread and the rendering thread.
 	1. Set <var>processor</var>'s <a>node reference</a> to
 		<var>node</var>.
 
-	1. Set {{callable process}} to `true`.
+	1. Set <a>callable process</a> to `true`.
 
 	1. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.
@@ -10797,7 +10797,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these steps:
 
-			  1. If {{callable process}} is `false`, abort the following sub steps.
+			  1. If <a>callable process</a> is `false`, abort the following sub steps.
 
 				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
 					instance.
@@ -10813,7 +10813,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					1. Queue a control message to fire `onprocessorerror` event on the
 						associated AudioWorkletNode.
 
-					1. Set {{callable process}} to `false`.
+					1. Set <a>callable process</a> to `false`.
 
 				1. Invoke <var>processFunction</var> to
 					[=Computing a block of audio|compute a block of audio=] with the

--- a/index.bs
+++ b/index.bs
@@ -10206,7 +10206,8 @@ thread and the rendering thread.
 	1. Let <var>processor</var> be the result of
 		Construct(<var>processorConstructor</var>, « <var>options</var> »).
 
-	1. Set <var>processor</var>'s {{AudioWorkletProcessor/port}} to <var>processorPort</var>.
+	1. Set <var>processor</var>'s {{AudioWorkletProcessor/port}} to
+		<var>processorPort</var>.
 
 	1. Set <var>processor</var>'s <a>node reference</a> to
 		<var>node</var>.
@@ -10214,7 +10215,7 @@ thread and the rendering thread.
 	1. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.
 
-	1. <a>Queue a task</a> the <a>control thread</a> to set the associated
+	1. <a>Queue a task</a> to the <a>control thread</a> to set the associated
 		{{AudioWorkletNode}}'s state to <code>running</code>, then fire
 		a <code>statechange</code> event.
 </div>
@@ -10794,7 +10795,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 				[=Computing a block of audio|compute a block of audio=], and
 				[=Making a buffer available for reading|make it available for reading=].
 
-			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these step:
+			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these steps:
 
 				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
 					instance.
@@ -10805,7 +10806,12 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 				3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
 					IsCallable</a>(argument=<i><var>processFunction</var></i>)</code> is
-					false, throw a {{TypeError}}.
+					false, execute the following:
+
+					1. Queue a control message to fire `onprocessorerror` event on the
+						associated AudioWorkletNode.
+
+					2. Output silence to output buffer.
 
 				4. Invoke <var>processFunction</var> to
 					[=Computing a block of audio|compute a block of audio=] with the

--- a/index.bs
+++ b/index.bs
@@ -9933,7 +9933,7 @@ in the node.
 
 		1. <a>callable process</a> is `true`.
 
-		1. <dfn>active processing conditions</dfn> are `true`, meaning
+		1. <dfn dfn>active processing conditions</dfn> are `true`, meaning
 			ANY of the following states are met:
 
 			* The associated {{AudioWorkletProcessor}}'s
@@ -9985,7 +9985,7 @@ in the node.
 		</div>
 
 		If {{process()}} is not called during some rendering
-		quantum due to the lack of any applicable <a>active processing conditions</a>, the result is as if the processor emitted
+		quantum due to the lack of any applicable [=active processing conditions=], the result is as if the processor emitted
 		silence for this period.
 
 		<pre class=argumentdef for="AudioWorkletProcessor/process(inputs, outputs, parameters))">

--- a/index.bs
+++ b/index.bs
@@ -10801,11 +10801,11 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 				2. Let <var>processFunction</var> be the result of
 					<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
-					Get</a>(O=<i>processor</i>, P="process")</code>.
+					Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
 
 			  3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
-					IsCallable</a>(argument=<i>processFunction</i>)</code> is false, throw a
-					{{TypeError}}.
+					IsCallable</a>(argument=<i><var>processFunction</var></i>)</code> is
+					false, throw a {{TypeError}}.
 
 				4. Invoke <var>processFunction</var> to
 					[=Computing a block of audio|compute a block of audio=] with the

--- a/index.bs
+++ b/index.bs
@@ -10797,10 +10797,10 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 			4. If this {{AudioNode}} is an {{AudioWorkletNode}}, execute these step:
 
 				1. Let <var>processor</var> be the associated {{AudioWorkletProcessor}}
-				  instance.
+					instance.
 
 				2. Let <var>processFunction</var> be the result of
-				  <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+					<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
 					Get</a>(O=<i>processor</i>, P="process")</code>.
 
 			  3. If <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
@@ -10808,7 +10808,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					{{TypeError}}.
 
 				4. Invoke <var>processFunction</var> to
-				  [=Computing a block of audio|compute a block of audio=] with the
+					[=Computing a block of audio|compute a block of audio=] with the
 					argument of [=input buffer=], output buffer and
 					[=input AudioParam buffer=].
 


### PR DESCRIPTION
Fixes: #1767

- Removes the `process` function check in AudioWorkletProcessor instantiation.
- Introduce the new `callable process` internal slot to AudioWorkletProcessor.
- Revise "Rendering an Audio Graph" section to add a new check on `process` function.
- Minor editorial fixes. (numbering ordered list)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1773.html" title="Last updated on Oct 10, 2018, 4:16 PM GMT (6e98edd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1773/f9b883c...hoch:6e98edd.html" title="Last updated on Oct 10, 2018, 4:16 PM GMT (6e98edd)">Diff</a>