### PR TITLE
Fix #1762: Convolver buffer can be set more than once

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6586,22 +6586,11 @@ Attributes</h4>
 		impulse response having the given normalization. The initial
 		value of this attribute is null.
 
-		<div algorithm="ConvolverNode.buffer">
-			To set the {{ConvolverNode/buffer}} attribute, execute these steps:
-
-			1. Let <var>new buffer</var> be an {{AudioBuffer}} to be
-				assigned to {{ConvolverNode/buffer}} or <code>null</code> .
-
-			2. If <var>new buffer</var> is not <code>null</code> and
-				{{ConvolverNode/[[buffer set]]}} is true, <span class="synchronous">throw an {{InvalidStateError}} and abort
-				these steps</span>.
-
-			3. If <var>new buffer</var> is not <code>null</code>, set
-				{{ConvolverNode/[[buffer set]]}} to true.
-
-			4. Assign <var>new buffer</var> to the {{ConvolverNode/buffer}}
-				attribute.
-		</div>
+		Note: If the {{ConvolverNode/buffer}} is set to an new
+		buffer, audio may glitch.  If this is undesirable, it
+		is recommended to create a new {{ConvolverNode}} to
+		replace the old, possibly cross-fading between the
+		two.
 
 		Note: The {{ConvolverNode}} produces a mono output only in the
 		single case where there is a single input channel and a


### PR DESCRIPTION
Remove the algorithm that disallowed setting the convolver buffer to a
non-null value more than once.  Instead, just add a note that setting
a new buffer may cause audio to glitch.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1774.html" title="Last updated on Sep 28, 2018, 8:00 PM GMT (1d47882)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1774/ed70a83...rtoy:1d47882.html" title="Last updated on Sep 28, 2018, 8:00 PM GMT (1d47882)">Diff</a>