### PR TITLE
Fix #1481: ABSN outputs mono silence when stopped

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4558,11 +4558,10 @@ The number of channels of the output always equals the number of
 channels of the AudioBuffer assigned to the {{AudioBufferSourceNode/buffer}} attribute, or is one
 channel of silence if {{AudioBufferSourceNode/buffer}} is <code>null</code>.
 In addition, the {{AudioBufferSourceNode}} must output a single
-channel of silence when the end of the
-{{AudioBufferSourceNode/buffer}} has been reached; the
-{{AudioBufferSourceNode/start(when, offset, duration)/duration}} has
-been reached; or the {{AudioScheduledSourceNode/stop(when)/when|stop}}
-time has been reached.
+channel of silence at a rendering quantum boundary after the time at which any one of the following conditions holds:
+	* the end of the {{AudioBufferSourceNode/buffer}} has been reached;
+	* the {{AudioBufferSourceNode/start(when, offset, duration)/duration}} has been reached;
+	* the {{AudioScheduledSourceNode/stop(when)/when|stop}} time has been reached.
 
 A <dfn>playhead position</dfn> for an {{AudioBufferSourceNode}} is
 defined as any quantity representing a time offset in seconds,
@@ -5048,7 +5047,7 @@ function process(numberOfFrames) {
 
 	if (currentTime >= stop) {
 		// End playback state of this node.  No further invocations of process()
-		// will occur.  Set the number of output channels to 1.
+		// will occur.  Schedule a change to set the number of output channels to 1.
 	}
 
 	return output;

--- a/index.bs
+++ b/index.bs
@@ -4557,6 +4557,12 @@ macros:
 The number of channels of the output always equals the number of
 channels of the AudioBuffer assigned to the {{AudioBufferSourceNode/buffer}} attribute, or is one
 channel of silence if {{AudioBufferSourceNode/buffer}} is <code>null</code>.
+In addition, the {{AudioBufferSourceNode}} must output a single
+channel of silence when the end of the
+{{AudioBufferSourceNode/buffer}} has been reached; the
+{{AudioBufferSourceNode/start(when, offset, duration)/duration}} has
+been reached; or the {{AudioScheduledSourceNode/stop(when)/when|stop}}
+time has been reached.
 
 A <dfn>playhead position</dfn> for an {{AudioBufferSourceNode}} is
 defined as any quantity representing a time offset in seconds,
@@ -5041,8 +5047,8 @@ function process(numberOfFrames) {
 	} // End of render quantum loop
 
 	if (currentTime >= stop) {
-		// end playback state of this node.
-		// no further invocations of process() will occur.
+		// End playback state of this node.  No further invocations of process()
+		// will occur.  Set the number of output channels to 1.
 	}
 
 	return output;

--- a/index.bs
+++ b/index.bs
@@ -4555,11 +4555,15 @@ macros:
 	tail-time: No
 </pre>
 
-The number of channels of the output always equals the number of
-channels of the AudioBuffer assigned to the {{AudioBufferSourceNode/buffer}} attribute, or is one
-channel of silence if {{AudioBufferSourceNode/buffer}} is <code>null</code>.
-In addition, the {{AudioBufferSourceNode}} must output a single
-channel of silence at a rendering quantum boundary after the time at which any one of the following conditions holds:
+The number of channels of the output equals the number of channels of the
+AudioBuffer assigned to the {{AudioBufferSourceNode/buffer}} attribute,
+or is one channel of silence if {{AudioBufferSourceNode/buffer}} is
+<code>null</code>.
+
+In addition, if the buffer has more than one channel,
+then the {{AudioBufferSourceNode}} output must change to a single channel
+of silence at a beginning of render quantum after the time at which any one
+of the following conditions holds:
 	* the end of the {{AudioBufferSourceNode/buffer}} has been reached;
 	* the {{AudioBufferSourceNode/start(when, offset, duration)/duration}} has been reached;
 	* the {{AudioScheduledSourceNode/stop(when)/when|stop}} time has been reached.


### PR DESCRIPTION
Specify that when an ABSN is done playing, the number of channels in
the output is one, instead of the number of channels in the
`AudioBuffer`.  Update the playback algorithm as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1776.html" title="Last updated on Oct 19, 2018, 6:06 AM GMT (952bcac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1776/f840c41...rtoy:952bcac.html" title="Last updated on Oct 19, 2018, 6:06 AM GMT (952bcac)">Diff</a>