### PR TITLE
Make decodeAudioData more precise.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1132,19 +1132,21 @@ Methods</h4>
 			Note: Multiple <em>decoding threads</em> can run in parallel to
 			service multiple calls to <code>decodeAudioData</code>.
 
-			1. Let <var>errored</var> be a boolean flag, initially set to false.
+			1. Let <var>canDecode</var> be a boolean flag, initially set to true.
+
 			2. Attempt to determine the MIME type of
 				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
 				errorCallback)/audioData!!argument}}, using
 				[[mimesniff#matching-an-audio-or-video-type-pattern]]. If the audio or
 				video type pattern matching algorithm returns <code>undefined</code>,
-				set <var>errored</var> to
-				<em>true</em>.
-			3. If <var>errored</var> is <em>false</em>, attempt to decode the encoded
-				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
-				errorCallback)/audioData!!argument}} into linear PCM.
+				set <var>canDecode</var> to <em>false</em>.
 
-			4. If <var>errored</var> is <em>true</em>, <a>queue a task</a> to
+			3. If <var>canDecode</var> is <em>true</em>, attempt to decode the encoded
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
+				errorCallback)/audioData!!argument}} into linear PCM. In case of
+				failure, set <var>canDecode</var> to <em>false</em>.
+
+			4. If <var>canDecode</var> is <em>false</em>, <a>queue a task</a> to
 				execute the following step, on the <a>control thread</a>'s
 				event loop:
 

--- a/index.bs
+++ b/index.bs
@@ -1132,21 +1132,21 @@ Methods</h4>
 			Note: Multiple <em>decoding threads</em> can run in parallel to
 			service multiple calls to <code>decodeAudioData</code>.
 
-			1. Let <var>canDecode</var> be a boolean flag, initially set to true.
+			1. Let <var>can decode</var> be a boolean flag, initially set to true.
 
 			2. Attempt to determine the MIME type of
 				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
 				errorCallback)/audioData!!argument}}, using
 				[[mimesniff#matching-an-audio-or-video-type-pattern]]. If the audio or
 				video type pattern matching algorithm returns <code>undefined</code>,
-				set <var>canDecode</var> to <em>false</em>.
+				set <var>can decode</var> to <em>false</em>.
 
-			3. If <var>canDecode</var> is <em>true</em>, attempt to decode the encoded
+			3. If <var>can decode</var> is <em>true</em>, attempt to decode the encoded
 				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
 				errorCallback)/audioData!!argument}} into linear PCM. In case of
-				failure, set <var>canDecode</var> to <em>false</em>.
+				failure, set <var>can decode</var> to <em>false</em>.
 
-			4. If <var>canDecode</var> is <em>false</em>, <a>queue a task</a> to
+			4. If <var>can decode</var> is <em>false</em>, <a>queue a task</a> to
 				execute the following step, on the <a>control thread</a>'s
 				event loop:
 

--- a/index.bs
+++ b/index.bs
@@ -1132,12 +1132,19 @@ Methods</h4>
 			Note: Multiple <em>decoding threads</em> can run in parallel to
 			service multiple calls to <code>decodeAudioData</code>.
 
-			1. Attempt to decode the encoded {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} into linear
-				PCM.
+			1. Let <var>errored</var> be a boolean flag, initially set to false.
+			2. Attempt to determine the MIME type of
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
+				errorCallback)/audioData!!argument}}, using
+				[[mimesniff#matching-an-audio-or-video-type-pattern]]. If the audio or
+				video type pattern matching algorithm returns <code>undefined</code>,
+				set <var>errored</var> to
+				<em>true</em>.
+			3. If <var>errored</var> is <em>false</em>, attempt to decode the encoded
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
+				errorCallback)/audioData!!argument}} into linear PCM.
 
-			2. If a decoding error is encountered due to the audio format
-				not being recognized or supported, or because of
-				corrupted/unexpected/inconsistent data, then <a>queue a task</a> to
+			4. If <var>errored</var> is <em>true</em>, <a>queue a task</a> to
 				execute the following step, on the <a>control thread</a>'s
 				event loop:
 
@@ -1148,7 +1155,7 @@ Methods</h4>
 
 				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is not missing, invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
 
-			3. Otherwise:
+			5. Otherwise:
 				1. Take the result, representing the decoded linear PCM
 					audio data, and resample it to the sample-rate of the
 					{{AudioContext}} if it is different from


### PR DESCRIPTION
This explicitely refers to the algorithm to use in mimesniff, and
adjusts the algorithm structure to be able to not attempt to decode if
the mimesniff algorithm failed.

This fixes #1563.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1781.html" title="Last updated on Nov 6, 2018, 2:25 PM GMT (9ea0e6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1781/58b5ddd...padenot:9ea0e6b.html" title="Last updated on Nov 6, 2018, 2:25 PM GMT (9ea0e6b)">Diff</a>