### PR TITLE
Specify rules to determine the output channel count for AudioNodes that have a tail time, when the input channel count changes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1132,12 +1132,21 @@ Methods</h4>
 			Note: Multiple <em>decoding threads</em> can run in parallel to
 			service multiple calls to <code>decodeAudioData</code>.
 
-			1. Attempt to decode the encoded {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} into linear
-				PCM.
+			1. Let <var>can decode</var> be a boolean flag, initially set to true.
 
-			2. If a decoding error is encountered due to the audio format
-				not being recognized or supported, or because of
-				corrupted/unexpected/inconsistent data, then <a>queue a task</a> to
+			2. Attempt to determine the MIME type of
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
+				errorCallback)/audioData!!argument}}, using
+				[[mimesniff#matching-an-audio-or-video-type-pattern]]. If the audio or
+				video type pattern matching algorithm returns <code>undefined</code>,
+				set <var>can decode</var> to <em>false</em>.
+
+			3. If <var>can decode</var> is <em>true</em>, attempt to decode the encoded
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
+				errorCallback)/audioData!!argument}} into linear PCM. In case of
+				failure, set <var>can decode</var> to <em>false</em>.
+
+			4. If <var>can decode</var> is <em>false</em>, <a>queue a task</a> to
 				execute the following step, on the <a>control thread</a>'s
 				event loop:
 
@@ -1148,7 +1157,7 @@ Methods</h4>
 
 				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is not missing, invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
 
-			3. Otherwise:
+			5. Otherwise:
 				1. Take the result, representing the decoded linear PCM
 					audio data, and resample it to the sample-rate of the
 					{{AudioContext}} if it is different from

--- a/index.bs
+++ b/index.bs
@@ -11290,6 +11290,35 @@ defined below, skipping over those channels not present.
 		<tr><td>17 <td>SPEAKER_TOP_BACK_RIGHT <td> <td> <td> <td>
 </table>
 
+<h3 id="channels-tail-time">
+Implication of tail-time on input and output channel count</h3>
+
+When an {{AudioNode}} has a non-null <a>tail-time</a>, and an output channel
+count that depends on the input channels count, any change in input channel
+count MUST take into account the {{AudioNode}}'s <a>tail-time</a>.
+
+When there is a decrease in input channel count, the change in output channel
+count MUST happen after the <a>tail-time</a> has passed.
+
+When there is an increase in input channel count, the behavious depends on the
+{{AudioNode}} type:
+
+- For a {{ConvolverNode}}, since the number of input channel determines the
+	<a href="#Convolution-channel-configurations"> audio processing algorithm </a>
+	to use, it MUST immediately start outputing two channels.
+
+	Note: this only applies to the case where the {{ConvolverNode}}'s impulse
+	response is mono. Otherwise, the {{ConvolverNode}} always outputs a stereo
+	signal regardless of its input channel count.
+
+- For other {{AudioNode}}s that have a <a>tail-time</a>, the number of output
+	channels MUST increase after the <a>tail-time</a> has passed.
+
+Note: Intuitively, this allows not losing stereo information as part of
+processing: when multiple audio blocks of different channel count contribute to
+an output block, then the output block's channel count is a superset of the
+input channel count of the input blocks.
+
 <h3 id="UpMix-sub">
 Up Mixing Speaker Layouts</h3>
 

--- a/index.bs
+++ b/index.bs
@@ -11305,13 +11305,12 @@ longer affects the output.
 When there is an increase in input channel count, the behavior depends on the
 {{AudioNode}} type:
 
-- For a {{DelayNode}} or a {{DynamicsCompressorNode}},
-	<a>tail-time</a>, the number of output channels MUST increase after the
-	<a>tail-time</a> has passed.
-
-- For other {{AudioNode}}s that have a <a>tail-time</a>, the number of output
+- For a {{DelayNode}} or a {{DynamicsCompressorNode}}, the number of output
 	channels MUST increase when the input that was received with greater channel
 	count begins to affect the output.
+
+- For other {{AudioNode}}s that have a <a>tail-time</a>, the number of output
+	channels MUST increase immediately.
 
 	Note: For a {{ConvolverNode}}, this only applies to the case where the impulse
 	response is mono. Otherwise, the {{ConvolverNode}} always outputs a stereo

--- a/index.bs
+++ b/index.bs
@@ -11293,9 +11293,10 @@ defined below, skipping over those channels not present.
 <h3 id="channels-tail-time">
 Implication of tail-time on input and output channel count</h3>
 
-When an {{AudioNode}} has a non-null <a>tail-time</a>, and an output channel
-count that depends on the input channels count, any change in input channel
-MUST take the {{AudioNode}}'s <a>tail-time</a> into account
+When an {{AudioNode}} has a non-zero <a>tail-time</a>, and an output channel
+count that depends on the input channels count, the {{AudioNode}}'s
+<a>tail-time</a> must be taken into account when the input channel count
+changes.
 
 When there is a decrease in input channel count, the change in output channel
 count MUST happen after the <a>tail-time</a> has passed.
@@ -11303,16 +11304,17 @@ count MUST happen after the <a>tail-time</a> has passed.
 When there is an increase in input channel count, the behavious depends on the
 {{AudioNode}} type:
 
-- For a {{ConvolverNode}}, since the number of input channel determines the
-	<a href="#Convolution-channel-configurations">audio processing algorithm</a>
-	to use, it MUST immediately start outputing two channels.
+- For a {{DelayNode}} or a {{DynamicsCompressorNode}},
+	<a>tail-time</a>, the number of output channels MUST increase after the
+	<a>tail-time</a> has passed.
 
-	Note: this only applies to the case where the {{ConvolverNode}}'s impulse
+- For the other {{AudioNode}}, since the number of input channel determines the
+	audio processing algorithm to use, the increase of the number of channels to
+	match the input channel count MUST happen immediately.
+	
+	Note: For a {{ConvolverNode}}, this only applies to the case where the impulse
 	response is mono. Otherwise, the {{ConvolverNode}} always outputs a stereo
 	signal regardless of its input channel count.
-
-- For other {{AudioNode}}s that have a <a>tail-time</a>, the number of output
-	channels MUST increase after the <a>tail-time</a> has passed.
 
 Note: Intuitively, this allows not losing stereo information as part of
 processing: when multiple input render quantum of different channel count

--- a/index.bs
+++ b/index.bs
@@ -856,9 +856,13 @@ Methods</h4>
 		nominal range.</span>
 
 		<pre class=argumentdef for="BaseAudioContext/createBuffer()">
-		numberOfChannels: Determines how many channels the buffer will have. An implementation MUST support at least 32 channels.
-		length: Determines the size of the buffer in sample-frames.  This MUST be at least 1.
-		sampleRate: Describes the sample-rate of the linear PCM audio data in the buffer in sample-frames per second. An implementation MUST support sample rates in at least the range 8000 to 96000.
+		numberOfChannels: Determines how many channels the buffer will have. An
+			implementation MUST support at least 32 channels.
+		length: Determines the size of the buffer in sample-frames.  This MUST be at
+			least 1.
+		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in
+			the buffer in sample-frames per second. An implementation MUST support
+			sample rates in at least the range 8000 to 96000.
 		</pre>
 		<div>
 			<em>Return type:</em> {{AudioBuffer}}
@@ -1143,7 +1147,7 @@ Methods</h4>
 
 			3. If <var>can decode</var> is <em>true</em>, attempt to decode the encoded
 				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
-				errorCallback)/audioData!!argument}} into linear PCM. In case of
+				errorCallback)/audioData!!argument}} into [=linear PCM=]. In case of
 				failure, set <var>can decode</var> to <em>false</em>.
 
 			4. If <var>can decode</var> is <em>false</em>, <a>queue a task</a> to
@@ -1155,13 +1159,17 @@ Methods</h4>
 
 				2. Reject <var>promise</var> with <var>error</var>.
 
-				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is not missing, invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
+				3. If {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} is
+					not missing, invoke
+					{{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with
+					<var>error</var>.
 
 			5. Otherwise:
-				1. Take the result, representing the decoded linear PCM
+				1. Take the result, representing the decoded [=linear PCM=]
 					audio data, and resample it to the sample-rate of the
 					{{AudioContext}} if it is different from
-					the sample-rate of {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}.
+					the sample-rate of {{BaseAudioContext/decodeAudioData(audioData,
+					successCallback, errorCallback)/audioData!!argument}}.
 
 				2. <a>Queue a task</a> on the <a>control thread</a>'s event loop
 					to execute the following steps:
@@ -1172,8 +1180,10 @@ Methods</h4>
 
 					2. Resolve <var>promise</var> with <var>buffer</var>.
 
-					3. If {{BaseAudioContext/decodeAudioData()/successCallback!!argument}} is not missing,
-						invoke {{BaseAudioContext/decodeAudioData()/successCallback!!argument}} with <var>buffer</var>.
+					3. If {{BaseAudioContext/decodeAudioData()/successCallback!!argument}}
+						is not missing, invoke
+						{{BaseAudioContext/decodeAudioData()/successCallback!!argument}}
+						with <var>buffer</var>.
 		</div>
 
 		<pre class=argumentdef for="BaseAudioContext/decodeAudioData()">
@@ -1923,9 +1933,12 @@ Constructors</h4>
 		were called instead.
 
 		<pre class=argumentdef for="OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)">
-		numberOfChannels: Determines how many channels the buffer will have. See {{BaseAudioContext/createBuffer()}} for the supported number of channels.
+		numberOfChannels: Determines how many channels the buffer will have. See
+			{{BaseAudioContext/createBuffer()}} for the supported number of channels.
 		length: Determines the size of the buffer in sample-frames.
-		sampleRate: Describes the sample-rate of the linear PCM audio data in the buffer in sample-frames per second. See {{BaseAudioContext/createBuffer()}} for valid sample rates.
+		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in
+			the buffer in sample-frames per second. See
+			{{BaseAudioContext/createBuffer()}} for valid sample rates.
 		</pre>
 </dl>
 
@@ -2219,7 +2232,7 @@ The {{AudioBuffer}} Interface</h3>
 
 This interface represents a memory-resident audio asset (for one-shot
 sounds and other short audio clips). Its format is non-interleaved
-32-bit linear floating-point PCM values with a normal range of \([-1,
+32-bit floating-point [=linear PCM=] values with a normal range of \([-1,
 1]\), but values are not limited to this range. It can contain one or
 more channels. Typically, it would be expected that the length of the
 PCM data would be fairly short (usually somewhat less than a minute).
@@ -11396,13 +11409,28 @@ Channel Rules Examples</h3>
 	gain.channelInterpretation = "speakers";
 </pre>
 
-<h2 id="audio-sample-values">
+<h2 id="audio-signal-values">
 Audio Signal Values</h2>
+
+<h3 id="audio-sample-format">
+Audio sample format</h3>
+
+<dfn lt="linear PCM">Linear pulse code modulation</dfn> (linear PCM) describes a
+format where the audio values are sampled at a regular interval, and where the
+quantization levels between two successive values are linearly uniform.
+
+Whenever signal values are exposed to script in this specification, they are in
+linear 32-bit floating point pulse code modulation format (linear 32bits float
+PCM), often in the form of {{Float32Array}} objects.
+
+<h3 id="audio-values-rendering">
+Rendering</h3>
 
 The range of all audio signals at a destination node of any audio graph
 is nominally [-1, 1]. The audio rendition of signal values outside this
 range, or of the values <code>NaN</code>, positive infinity or negative
 infinity, is undefined by this specification.
+
 
 <h2 id="Spatialization">
 Spatialization/Panning</h2>

--- a/index.bs
+++ b/index.bs
@@ -11295,7 +11295,7 @@ Implication of tail-time on input and output channel count</h3>
 
 When an {{AudioNode}} has a non-null <a>tail-time</a>, and an output channel
 count that depends on the input channels count, any change in input channel
-count MUST take into account the {{AudioNode}}'s <a>tail-time</a>.
+MUST take the {{AudioNode}}'s <a>tail-time</a> into account
 
 When there is a decrease in input channel count, the change in output channel
 count MUST happen after the <a>tail-time</a> has passed.
@@ -11304,7 +11304,7 @@ When there is an increase in input channel count, the behavious depends on the
 {{AudioNode}} type:
 
 - For a {{ConvolverNode}}, since the number of input channel determines the
-	<a href="#Convolution-channel-configurations"> audio processing algorithm </a>
+	<a href="#Convolution-channel-configurations">audio processing algorithm</a>
 	to use, it MUST immediately start outputing two channels.
 
 	Note: this only applies to the case where the {{ConvolverNode}}'s impulse
@@ -11315,9 +11315,9 @@ When there is an increase in input channel count, the behavious depends on the
 	channels MUST increase after the <a>tail-time</a> has passed.
 
 Note: Intuitively, this allows not losing stereo information as part of
-processing: when multiple audio blocks of different channel count contribute to
-an output block, then the output block's channel count is a superset of the
-input channel count of the input blocks.
+processing: when multiple input render quantum of different channel count
+contribute to an output render quantum then the output render quantum's channel
+count is a superset of the input channel count of the input render quantums.
 
 <h3 id="UpMix-sub">
 Up Mixing Speaker Layouts</h3>


### PR DESCRIPTION
This fixes #1719.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1787.html" title="Last updated on Nov 14, 2018, 2:27 PM GMT (ee34370)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1787/1d0eec3...padenot:ee34370.html" title="Last updated on Nov 14, 2018, 2:27 PM GMT (ee34370)">Diff</a>