### PR TITLE
Add missing second 'new AudioContext()'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9556,6 +9556,7 @@ registerProcessor('bypass-processor', BypassProcessor);
 // The main global scope
 let context = new AudioContext();
 context.audioWorklet.addModule('bypass-processor.js').then(() =&gt; {
+	let context = new AudioContext();
 	let bypassNode = new AudioWorkletNode(context, 'bypass-processor');
 });
 </pre>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/0joshuaolson1/web-audio-api/pull/1793.html" title="Last updated on Nov 14, 2018, 11:12 PM GMT (22d40c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1793/8b66e51...0joshuaolson1:22d40c6.html" title="Last updated on Nov 14, 2018, 11:12 PM GMT (22d40c6)">Diff</a>