### PR TITLE
Remove superfluous AudioContext constructions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10360,7 +10360,6 @@ a lower bit-depth), and by quantizing in time resolution
 <pre line-numbers class="example" highlight="js" title="BitCrusher - Global Scope">
 let context = new AudioContext();
 context.audioWorklet.addModule('bitcrusher.js').then(() =&gt; {
-	let context = new AudioContext();
 	let osc = new OscillatorNode(context);
 	let amp = new GainNode(context);
 
@@ -10575,7 +10574,6 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
 &lt;script src="vumeternode.js">&lt;/script>
 &lt;script>
 	importAudioWorkletNode.then(() =&gt; {
-		let context = new AudioContext();
 		let oscillator = new Oscillator(context);
 		let vuMeterNode = new VUMeterNode(context, { updatingInterval: 50 });
 


### PR DESCRIPTION
They aren't intended, according to discussion in https://github.com/WebAudio/web-audio-api/pull/1793.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/0joshuaolson1/web-audio-api/pull/1794.html" title="Last updated on Nov 15, 2018, 1:39 PM GMT (b45e28a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1794/816eff2...0joshuaolson1:b45e28a.html" title="Last updated on Nov 15, 2018, 1:39 PM GMT (b45e28a)">Diff</a>