### PR TITLE
Fix typo and rephrase the intro for `cancelAndHoldAtTime`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3545,12 +3545,12 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AudioParam">
 	: <dfn>cancelAndHoldAtTime(cancelTime)</dfn>
 	::
-		This is similar to {{AudioParam/cancelScheduledValues()}} in that it cancels all
-		scheduled parameter changes with times greater than or equal to
-		<code>cancelTime</code>. However, in addition, the automation
-		value that would have happened at <code>cancelTime</code> is
-		then propagated for all future time until other automation
-		events are introduced.
+		This is similar to {{AudioParam/cancelScheduledValues()}} in that it can
+		remove events from the timeline after <code>cancelTime</code>.  However,
+		instead of just removing the events, the automation values leading to
+		<code>cancelTime</code> are not affected, and the value at
+		<code>cancelTime</code> is then propagated for all future time until other
+		automation events are introduced.
 
 		The behavior of the timeline in the face of
 		{{AudioParam/cancelAndHoldAtTime()}} when automations are running

--- a/index.bs
+++ b/index.bs
@@ -3549,7 +3549,7 @@ Methods</h4>
 		scheduled parameter changes with times greater than or equal to
 		<code>cancelTime</code>. However, in addition, the automation
 		value that would have happened at <code>cancelTime</code> is
-		then proprogated for all future time until other automation
+		then propagated for all future time until other automation
 		events are introduced.
 
 		The behavior of the timeline in the face of


### PR DESCRIPTION
It does not change much, but the introduction was really imprecise and borderline incorrect.

This fixes #1791.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1795.html" title="Last updated on Nov 16, 2018, 12:33 PM GMT (8e578ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1795/b5f65b3...padenot:8e578ab.html" title="Last updated on Nov 16, 2018, 12:33 PM GMT (8e578ab)">Diff</a>