### PR TITLE
Fix typo: MediaStreamTrack instead of MediaStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7908,8 +7908,16 @@ Constructors</h4>
 		<var>node</var>, and return <var>node</var>.
 
 		<pre class=argumentdef for="MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()">
-			context: The {{BaseAudioContext}} this new {{MediaStreamAudioSourceNode}} will be <a href="#associated">associated</a> with.
-			options: Initial parameter values for this {{MediaStreamAudioSourceNode}}. If the {{MediaStreamAudioSourceOptions/mediaStream}} parameter does not reference a [[mediacapture-streams#mediastream|MediaStream]] whose <code>kind</code> attribute has the value <code>"audio"</code>, <span class="synchronous">an {{InvalidStateError}} MUST be thrown</span>.
+			context: The {{BaseAudioContext}} this new {{MediaStreamAudioSourceNode}}
+					will be <a href="#associated">associated</a> with.
+			options: Initial parameter values for this {{MediaStreamAudioSourceNode}}.
+					If the {{MediaStreamAudioSourceOptions/mediaStream}} parameter does
+					not reference a [[mediacapture-streams#mediastream|MediaStream]] that
+					has at least one
+					[[mediacapture-streams#mediastreamtrack|MediaStramTrack]] whose
+					<code>kind</code> attribute has the value <code>"audio"</code>,
+					<span class="synchronous">an {{InvalidStateError}} MUST be
+					thrown</span>.
 		</pre>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -7908,16 +7908,8 @@ Constructors</h4>
 		<var>node</var>, and return <var>node</var>.
 
 		<pre class=argumentdef for="MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()">
-			context: The {{BaseAudioContext}} this new {{MediaStreamAudioSourceNode}}
-					will be <a href="#associated">associated</a> with.
-			options: Initial parameter values for this {{MediaStreamAudioSourceNode}}.
-					If the {{MediaStreamAudioSourceOptions/mediaStream}} parameter does
-					not reference a [[mediacapture-streams#mediastream|MediaStream]] that
-					has at least one
-					[[mediacapture-streams#mediastreamtrack|MediaStramTrack]] whose
-					<code>kind</code> attribute has the value <code>"audio"</code>,
-					<span class="synchronous">an {{InvalidStateError}} MUST be
-					thrown</span>.
+			context: The {{BaseAudioContext}} this new {{MediaStreamAudioSourceNode}} will be <a href="#associated">associated</a> with.
+			options: Initial parameter values for this {{MediaStreamAudioSourceNode}}. If the {{MediaStreamAudioSourceOptions/mediaStream}} parameter does not reference a [[mediacapture-streams#mediastream|MediaStream]] that has at least one [[mediacapture-streams#mediastreamtrack|MediaStramTrack]] whose <code>kind</code> attribute has the value <code>"audio"</code>, <span class="synchronous">an {{InvalidStateError}} MUST be thrown</span>.
 		</pre>
 </dl>
 


### PR DESCRIPTION
Fixes #1798.

cc/ @a2sheppy


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1801.html" title="Last updated on Dec 19, 2018, 12:01 AM UTC (42eba5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1801/9b3b9e2...hoch:42eba5d.html" title="Last updated on Dec 19, 2018, 12:01 AM UTC (42eba5d)">Diff</a>