### PR TITLE
Fix Media{Element,Stream}* ctors to spec the order in which the exceptions are to be thrown.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7707,13 +7707,15 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaElementAudioSourceNode">
 	: <dfn>MediaElementAudioSourceNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{MediaElementAudioSourceNode}}
-		object. <a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+		1. If <var>context</var> is not an {{AudioContext}}, throw an
+			{{NotSupportedError}} exception and abort these steps.
+		2. Let <var>node</var> be a new {{MediaElementAudioSourceNode}} object.
+			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
+			return <var>node</var>.
 
 		<pre class=argumentdef for="MediaElementAudioSourceNode/MediaElementAudioSourceNode()">
-			context: The {{BaseAudioContext}} this new {{MediaElementAudioSourceNode}} will be <a href="#associated">associated</a> with.
-			options: Parameter value for this {{MediaElementAudioSourceNode}}.
+			context: The {{AudioContext}} this new {{MediaElementAudioSourceNode}} will be <a href="#associated">associated</a> with.
+			options: Initial parameter value for this {{MediaElementAudioSourceNode}}.
 		</pre>
 </dl>
 
@@ -7836,9 +7838,11 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaStreamAudioDestinationNode">
 	: <dfn>MediaStreamAudioDestinationNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new
-		{{MediaStreamAudioDestinationNode}} object. <a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
-		and return <var>node</var>.
+		1. If <code>context</code> is not an {{AudioContext}}, throw an
+			{{NotSupportedError}} and abort these steps.
+		2. Let <var>node</var> be a new {{MediaStreamAudioDestinationNode}} object.
+			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
+			return <var>node</var>.
 
 		<pre class=argumentdef for="MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode()">
 			context: The {{BaseAudioContext}} this new {{MediaStreamAudioDestinationNode}} will be <a href="#associated">associated</a> with.
@@ -7903,13 +7907,21 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaStreamAudioSourceNode">
 	: <dfn>MediaStreamAudioSourceNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{MediaStreamAudioSourceNode}}
-		object. <a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
-
+			1. If <var>context</var> is not an {{AudioContext}}, throw an
+				{{NotSupportedError}} exception and abort these steps.
+			2. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
+				<code>options</code> does not reference a
+				[[mediacapture-streams#mediastream|MediaStream]] that has at least one
+				[[mediacapture-streams#mediastreamtrack|MediaStramTrack]] whose
+				<code>kind</code> attribute has the value <code>"audio"</code>,
+				throw an {{InvalidStateError}} and abort these steps.
+			3. Let <var>node</var> be a new {{MediaStreamAudioSourceNode}}
+				object. <a href="#audionode-constructor-init">Initialize</a>
+				<var>node</var>, and return <var>node</var>.
 		<pre class=argumentdef for="MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()">
-			context: The {{BaseAudioContext}} this new {{MediaStreamAudioSourceNode}} will be <a href="#associated">associated</a> with.
-			options: Initial parameter values for this {{MediaStreamAudioSourceNode}}. If the {{MediaStreamAudioSourceOptions/mediaStream}} parameter does not reference a [[mediacapture-streams#mediastream|MediaStream]] that has at least one [[mediacapture-streams#mediastreamtrack|MediaStramTrack]] whose <code>kind</code> attribute has the value <code>"audio"</code>, <span class="synchronous">an {{InvalidStateError}} MUST be thrown</span>.
+			context: The {{AudioContext}} this new {{MediaStreamAudioSourceNode}} will be <a href="#associated">associated</a> with.
+			options: Initial parameter value for this {{MediaStreamAudioSourceNode}}.
+		</pre>
 		</pre>
 </dl>
 
@@ -7973,12 +7985,17 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaStreamTrackAudioSourceNode">
 	: <dfn>MediaStreamTrackAudioSourceNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new
-		{{MediaStreamTrackAudioSourceNode}} object. <a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
-		and return <var>node</var>.
+		1. If <var>context</var> is not an {{AudioContext}}, throw an
+			{{NotSupportedError}} exception and abort these steps.
+		2. If the {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}}'s
+			<code>kind</code> attribute is not <code>"audio"</code>, throw an
+			{{InvalidStateError}} and abort these steps.
+		3. Let <var>node</var> be a new {{MediaStreamTrackAudioSourceNode}} object.
+			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
+			return <var>node</var>.
 
 		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode()">
-			context: The {{BaseAudioContext}} this new {{MediaStreamTrackAudioSourceNode}} will be <a href="#associated">associated</a> with.
+			context: The {{AudioContext}} this new {{MediaStreamTrackAudioSourceNode}} will be <a href="#associated">associated</a> with.
 			options: Initial parameter value for this {{MediaStreamTrackAudioSourceNode}}.
 		</pre>
 </dl>


### PR DESCRIPTION
This fixes #1805.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1808.html" title="Last updated on Jan 11, 2019, 1:32 PM UTC (0db12cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1808/93d1edc...padenot:0db12cb.html" title="Last updated on Jan 11, 2019, 1:32 PM UTC (0db12cb)">Diff</a>