### PR TITLE
Use the algorithm "get a reference to the bytes" when copying into the typed array, in the AnalyserNode methods

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4257,13 +4257,15 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AnalyserNode">
 	: <dfn>getByteFrequencyData(array)</dfn>
 	::
-		Copies the <a>current frequency data</a> into the passed
-		unsigned byte array. If the array has fewer elements than the
-		{{frequencyBinCount}}, the excess elements will
-		be dropped. If the array has more elements than the
-		{{frequencyBinCount}}, the excess elements will
-		be ignored. The most recent {{AnalyserNode/fftSize}} frames are used in
-		computing the frequency data.
+		Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the [[WebIDL#idl-Uint8Array|Uint8Array]]
+		passed as an argument.  Copies the <a>current frequency data</a> to those
+		bytes. If the array has fewer elements than the {{frequencyBinCount}}, the
+		excess elements will be dropped. If the array has more elements than the
+		{{frequencyBinCount}}, the excess elements will be ignored. The most
+		recent {{AnalyserNode/fftSize}} frames are used in computing the frequency
+		data.
 
 		If another call to {{AnalyserNode/getByteFrequencyData()}} or
 		{{AnalyserNode/getFloatFrequencyData()}} occurs within the same
@@ -4300,13 +4302,14 @@ Methods</h4>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
 	::
-		Copies the <a>current time-domain data</a> (waveform data) into
-		the passed unsigned byte array. If the array has fewer elements
-		than the value of {{AnalyserNode/fftSize}}, the excess elements
-		will be dropped. If the array has more elements than
-		{{AnalyserNode/fftSize}}, the
-		excess elements will be ignored. The most recent
-		{{AnalyserNode/fftSize}} frames
+		Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the [[WebIDL#idl-Uint8Array|Uint8Array]]
+		passed as an argument.  Copies the <a>current time-domain data</a>
+		(waveform data) into those bytes. If the array has fewer elements than the
+		value of {{AnalyserNode/fftSize}}, the excess elements will be dropped. If
+		the array has more elements than {{AnalyserNode/fftSize}}, the excess
+		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
 		are used in computing the byte data.
 
 		The values stored in the unsigned byte array are computed in
@@ -4332,13 +4335,15 @@ Methods</h4>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
 	::
-		Copies the <a>current frequency data</a> into the passed
-		floating-point array. If the array has fewer elements than the
-		{{frequencyBinCount}}, the excess elements will
-		be dropped. If the array has more elements than the
-		{{frequencyBinCount}}, the excess elements will
-		be ignored. The most recent {{AnalyserNode/fftSize}} frames are used in
-		computing the frequency data.
+		Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the
+		[[WebIDL#idl-Float32Array|Float32Array]] passed as an argument.  Copies
+		the <a>current frequency data</a> into those bytes.  If the array has
+		fewer elements than the {{frequencyBinCount}}, the excess elements will be
+		dropped. If the array has more elements than the {{frequencyBinCount}},
+		the excess elements will be ignored. The most recent
+		{{AnalyserNode/fftSize}} frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getFloatFrequencyData()}} or
 		{{AnalyserNode/getByteFrequencyData()}} occurs within the same
@@ -4358,14 +4363,15 @@ Methods</h4>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
 	::
-		Copies the <a>current time-domain data</a> (waveform data) into
-		the passed floating-point array. If the array has fewer
-		elements than the value of {{AnalyserNode/fftSize}}, the excess elements
-		will be dropped. If the array has more elements than
-		{{AnalyserNode/fftSize}}, the
-		excess elements will be ignored. The most recent
-		{{AnalyserNode/fftSize}} frames
-		are returned (after downmixing).
+		Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the
+		[[WebIDL#idl-Float32Array|Float32Array]] passed as an argument.  Copy the
+		<a>current time-domain data</a> (waveform data) into those bytes. If the
+		array has fewer elements than the value of {{AnalyserNode/fftSize}}, the
+		excess elements will be dropped. If the array has more elements than
+		{{AnalyserNode/fftSize}}, the excess elements will be ignored. The most
+		recent {{AnalyserNode/fftSize}} frames are returned (after downmixing).
 
 		<pre class=argumentdef for="AnalyserNode/getFloatTimeDomainData()">
 			array: This parameter is where the time-domain sample data will be copied.


### PR DESCRIPTION
This fixes #1804.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1813.html" title="Last updated on Jan 16, 2019, 2:21 PM UTC (f334d98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1813/615bbec...padenot:f334d98.html" title="Last updated on Jan 16, 2019, 2:21 PM UTC (f334d98)">Diff</a>