### PR TITLE
Fix #1815: handle multiple events of the same type at the same time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3370,6 +3370,10 @@ The following rules will apply when calling these methods:
 	for determining curves and ramps are applied to the exact numerical
 	times given when scheduling events.
 
+* If one of these events is added at a time where there is already an
+	event of the exact same type, then the new event will replace the
+	old one.
+
 * If one of these events is added at a time where there is already
 	one or more events, then it will be placed in the list after them,
 	but before events whose times are after the event.


### PR DESCRIPTION
Put back the bullet item that was somehow removed sometime after the
2015 published draft.