### PR TITLE
Make MediaStreamAudioSourceNode a bit more precise

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7886,8 +7886,8 @@ macros:
 
 The number of channels of the output corresponds to the number of channels of
 the [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]. When the
-[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] ends, one channel of
-silence is output.
+[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] ends, this
+{{AudioNode}} outputs one channel of silence.
 
 <pre class="idl">
 [Exposed=Window,

--- a/index.bs
+++ b/index.bs
@@ -7908,7 +7908,7 @@ Constructors</h4>
 			2. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
 				<code>options</code> does not reference a
 				[[mediacapture-streams#mediastream|MediaStream]] that has at least one
-				[[mediacapture-streams#mediastreamtrack|MediaStramTrack]] whose
+				[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] whose
 				<code>kind</code> attribute has the value <code>"audio"</code>,
 				throw an {{InvalidStateError}} and abort these steps. Else, let
 				this stream be <var>inputStream</var>.

--- a/index.bs
+++ b/index.bs
@@ -7928,13 +7928,13 @@ Constructors</h4>
 				{{MediaStreamAudioSourceNode}}.
 			7. Return <var>node</var>.
 
-			Changes to the [[mediacapture-streams#mediastream|MediaStream]] that has
-			been passed to the constructor after construction do not affect the
-			underlying output of this {{AudioNode}}.
+			After construction, any change to the
+			[[mediacapture-streams#mediastream|MediaStream]] that was passed to
+			the constructor do not affect the underlying output of this {{AudioNode}}.
 
 			Note: This means that when removing the track chosen by the constructor
 			of the {{MediaStreamAudioSourceNode}} from the
-			[[mediacapture-streams#mediastream|MediaStream]] passed in this
+			[[mediacapture-streams#mediastream|MediaStream]] passed into this
 			constructor, the {{MediaStreamAudioSourceNode}} will still take its input
 			from the same track.
 

--- a/index.bs
+++ b/index.bs
@@ -7885,9 +7885,9 @@ macros:
 </pre>
 
 The number of channels of the output corresponds to the number of channels of
-the [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]. If there is no
-valid audio track, then the number of channels output will be one silent
-channel.
+the [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]. When the
+[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] ends, one channel of
+silence is output.
 
 <pre class="idl">
 [Exposed=Window,

--- a/index.bs
+++ b/index.bs
@@ -7928,6 +7928,16 @@ Constructors</h4>
 				{{MediaStreamAudioSourceNode}}.
 			7. Return <var>node</var>.
 
+			Changes to the [[mediacapture-streams#mediastream|MediaStream]] that has
+			been passed to the constructor after construction do not affect the
+			underlying output of this {{AudioNode}}.
+
+			Note: This means that when removing the track chosen by the constructor
+			of the {{MediaStreamAudioSourceNode}} from the
+			[[mediacapture-streams#mediastream|MediaStream]] passed in this
+			constructor, the {{MediaStreamAudioSourceNode}} will still take its input
+			from the same track.
+
 			Note: The behaviour for picking the track to output is arbitrary for
 			legacy reasons. {{MediaStreamTrackAudioSourceNode}} can be used
 			instead to be explicit about which track to use as input.


### PR DESCRIPTION
This fixes #1824.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1829.html" title="Last updated on Feb 25, 2019, 1:35 PM UTC (b0c5f0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1829/1a6fa79...padenot:b0c5f0f.html" title="Last updated on Feb 25, 2019, 1:35 PM UTC (b0c5f0f)">Diff</a>