### PR TITLE
Fix #1788: Clarify the value returned by the AudioParam value getter.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3888,27 +3888,32 @@ parameters</dfn> are {{AudioParam}}s that are used with other
 {{AudioParam}}s to compute a value that is then used as an input
 to compute the output of an {{AudioNode}}.
 
-The <dfn>computedValue</dfn> is the final value controlling the
-audio DSP and is computed by the audio rendering thread during each
-rendering time quantum. It MUST be internally computed as follows:
+The computation of the value of an {{AudioParam}} consists of two parts:
+	- the <dfn>intrinsic</dfn> value that is computed from the {{AudioParam/value}}
+		attribute and any <a href="#dfn-automation-event">automation events</a>
+	- the <dfn>computedValue</dfn> that is the final value controlling the
+		audio DSP and is computed by the audio rendering thread during each
+		rendering time quantum.
+
+The <a>computedValue</a>It MUST be internally computed as follows:
 
 <div algorithm="computation-of-value">
-	1. An <em>intrinsic</em> parameter value will be calculated at
+	1. An <a><var>intrinsic</var></a> parameter value will be calculated at
 		each time, which is either the value set directly to the
-		<code>value</code> attribute, or, if there are any <a href="#dfn-automation-event">automation events</a> with times before or
+		{{AudioParam/value}} attribute, or, if there are any <a href="#dfn-automation-event">automation events</a> with times before or
 		at this time, the value as calculated from these events. When read,
-		the <code>value</code> attribute always returns the
-		<em>intrinsic</em> value for the current time. If automation events
-		are removed from a given time range, then the <em>intrinsic</em>
+		the {{AudioParam/value}} attribute always returns the
+		<var>intrinsic</var> value for the current time. If automation events
+		are removed from a given time range, then the <var>intrinsic</var>
 		value will remain unchanged and stay at its previous value until
-		either the <code>value</code> attribute is directly set, or
+		either the {{AudioParam/value}} attribute is directly set, or
 		automation events are added for the time range.
 
-	2. The <em>computedValue</em> is the sum of the <em>intrinsic</em>
+	2. The <a><var>computedValue</var></a> is the sum of the <var>intrinsic</var>
 		value and the value of the <a href="#input-audioparam-buffer">input
 		AudioParam buffer</a>. When read, the
 		<code>value</code> attribute always returns the
-		<em>computedValue</em> for the current time.
+		<var>computedValue</var> for the current time.
 
 	3. If this {{AudioParam}} is a <a>compound parameter</a>,
 		compute its final value with other {{AudioParam}}s.
@@ -10921,7 +10926,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					{{AudioParam}} for this block.
 
 				3. [=Queue a control message=] to set the {{[[current value]]}} slot
-					of this {{AudioParam}} to the last value computed in the preceding
+					of this {{AudioParam}} to the last <a>intrinsic</a> value computed in the preceding
 					step.
 
 			2. If this {{AudioNode}} has any {{AudioNode}}s connected to its input,

--- a/index.bs
+++ b/index.bs
@@ -3859,7 +3859,6 @@ parameters</dfn> are {{AudioParam}}s that are used with other
 {{AudioParam}}s to compute a value that is then used as an input
 to compute the output of an {{AudioNode}}.
 
-
 The <dfn>computedValue</dfn> is the final value controlling the audio
 DSP and is computed by the audio rendering thread during each
 rendering time quantum.
@@ -3867,23 +3866,27 @@ rendering time quantum.
 <div algorithm="computation-of-value">
 The computation of the value of an {{AudioParam}} consists of two parts:
 	- the <var>paramIntrinsicValue</var> value that is computed from the {{AudioParam/value}}
-		attribute and any <a href="#dfn-automation-event">automation events</a>
+		attribute and any <a href="#dfn-automation-event">automation events</a>.
 	- the <var>paramComputedValue</var> that is the final value controlling the
 		audio DSP and is computed by the audio rendering thread during each
-		rendering time quantum.
+		<a>render quantum</a>.
 
 These values MUST be computed as follows:
 
 	1. <var>paramIntrinsicValue</var> will be calculated at
 		each time, which is either the value set directly to the
-		{{AudioParam/value}} attribute, or, if there are any <a href="#dfn-automation-event">automation events</a> with times before or
+		{{AudioParam/value}} attribute, or, if there are any
+		<a href="#dfn-automation-event">automation events</a>
+		with times before or
 		at this time, the value as calculated from these events.  If automation events
 		are removed from a given time range, then the <var>paramIntrinsicValue</var>
 		value will remain unchanged and stay at its previous value until
 		either the {{AudioParam/value}} attribute is directly set, or
 		automation events are added for the time range.
 
-	1. Set {{[[current value]]}} to the value of <var>paramIntrinsicValue</var> at the beginning of this <a>render quantum</a>.
+	1. Set {{[[current value]]}} to the value of
+		<var>paramIntrinsicValue</var> at the beginning of
+		this <a>render quantum</a>.
 
 	2. <var>paramComputedValue</var> is the sum of the <var>paramIntrinsicValue</var>
 		value and the value of the <a href="#input-audioparam-buffer">input

--- a/index.bs
+++ b/index.bs
@@ -3497,7 +3497,7 @@ Attributes</h4>
 
 		Getting this attribute returns the contents of the
 		{{[[current value]]}} slot. See
-intr		[[#computation-of-value]] for the algorithm for the
+		[[#computation-of-value]] for the algorithm for the
 		value that is returned.
 
 		Setting this attribute has the effect of assigning the
@@ -3874,14 +3874,15 @@ The computation of the value of an {{AudioParam}} consists of two parts:
 These values MUST be computed as follows:
 
 	1. <var>paramIntrinsicValue</var> will be calculated at
-		each time, which is either the value set directly to the
-		{{AudioParam/value}} attribute, or, if there are any
-		<a href="#dfn-automation-event">automation events</a>
-		with times before or
-		at this time, the value as calculated from these events.  If automation events
-		are removed from a given time range, then the <var>paramIntrinsicValue</var>
-		value will remain unchanged and stay at its previous value until
-		either the {{AudioParam/value}} attribute is directly set, or
+		each time, which is either the value set directly to
+		the {{AudioParam/value}} attribute, or, if there are
+		any <a href="#dfn-automation-event">automation
+		events</a> with times before or at this time, the
+		value as calculated from these events.  If automation
+		events are removed from a given time range, then the
+		<var>paramIntrinsicValue</var> value will remain
+		unchanged and stay at its previous value until either
+		the {{AudioParam/value}} attribute is directly set, or
 		automation events are added for the time range.
 
 	1. Set {{[[current value]]}} to the value of

--- a/index.bs
+++ b/index.bs
@@ -3496,10 +3496,9 @@ Attributes</h4>
 		initialized to the <code>defaultValue</code>.
 
 		Getting this attribute returns the contents of the
-		{{[[current value]]}} slot, which maintains the value of
-		this parameter at the conclusion of the most recent render
-		quantum on the audio rendering thread, or the most recently
-		assigned value if no rendering has taken place.
+		{{[[current value]]}} slot. See
+intr		[[#computation-of-value]] for the algorithm for the
+		value that is returned.
 
 		Setting this attribute has the effect of assigning the
 		requested value to the {{[[current value]]}} slot, and
@@ -3860,35 +3859,40 @@ parameters</dfn> are {{AudioParam}}s that are used with other
 {{AudioParam}}s to compute a value that is then used as an input
 to compute the output of an {{AudioNode}}.
 
+
+The <dfn>computedValue</dfn> is the final value controlling the audio
+DSP and is computed by the audio rendering thread during each
+rendering time quantum.
+
+<div algorithm="computation-of-value">
 The computation of the value of an {{AudioParam}} consists of two parts:
-	- the <dfn>intrinsic</dfn> value that is computed from the {{AudioParam/value}}
+	- the <var>paramIntrinsicValue</var> value that is computed from the {{AudioParam/value}}
 		attribute and any <a href="#dfn-automation-event">automation events</a>
-	- the <dfn>computedValue</dfn> that is the final value controlling the
+	- the <var>paramComputedValue</var> that is the final value controlling the
 		audio DSP and is computed by the audio rendering thread during each
 		rendering time quantum.
 
-The <a>computedValue</a>It MUST be internally computed as follows:
+These values MUST be computed as follows:
 
-<div algorithm="computation-of-value">
-	1. An <a><var>intrinsic</var></a> parameter value will be calculated at
+	1. <var>paramIntrinsicValue</var> will be calculated at
 		each time, which is either the value set directly to the
 		{{AudioParam/value}} attribute, or, if there are any <a href="#dfn-automation-event">automation events</a> with times before or
-		at this time, the value as calculated from these events. When read,
-		the {{AudioParam/value}} attribute always returns the
-		<var>intrinsic</var> value for the current time. If automation events
-		are removed from a given time range, then the <var>intrinsic</var>
+		at this time, the value as calculated from these events.  If automation events
+		are removed from a given time range, then the <var>paramIntrinsicValue</var>
 		value will remain unchanged and stay at its previous value until
 		either the {{AudioParam/value}} attribute is directly set, or
 		automation events are added for the time range.
 
-	2. The <a><var>computedValue</var></a> is the sum of the <var>intrinsic</var>
+	1. Set {{[[current value]]}} to the value of <var>paramIntrinsicValue</var> at the beginning of this <a>render quantum</a>.
+
+	2. <var>paramComputedValue</var> is the sum of the <var>paramIntrinsicValue</var>
 		value and the value of the <a href="#input-audioparam-buffer">input
-		AudioParam buffer</a>. When read, the
-		<code>value</code> attribute always returns the
-		<var>computedValue</var> for the current time.
+		AudioParam buffer</a>.
 
 	3. If this {{AudioParam}} is a <a>compound parameter</a>,
 		compute its final value with other {{AudioParam}}s.
+
+	4. Set <a>computedValue</a> to <var>paramComputedValue</var>.  
 </div>
 
 The <dfn>nominal range</dfn> for a <a>computedValue</a> are the
@@ -10926,8 +10930,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 					{{AudioParam}} for this block.
 
 				3. [=Queue a control message=] to set the {{[[current value]]}} slot
-					of this {{AudioParam}} to the last <a>intrinsic</a> value computed in the preceding
-					step.
+					of this {{AudioParam}} according to [[#computation-of-value]].
 
 			2. If this {{AudioNode}} has any {{AudioNode}}s connected to its input,
 				[[#SummingJunction|sum]] the buffers


### PR DESCRIPTION
Define the intrinsic value and update the algorithm a little bit for
that.

Then update the rendering algorith so that the [[current value]] is
the intrinsic value, not the computed value (that consists of the
automation and any inputs to the param).

I think this could be simplified a bit more, but I didn't really do
that.  Perhaps all references to intrinsic value could be replaced by
[[current value]]?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1838.html" title="Last updated on May 13, 2019, 10:31 PM UTC (305cae1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1838/f47c7f5...rtoy:305cae1.html" title="Last updated on May 13, 2019, 10:31 PM UTC (305cae1)">Diff</a>