### PR TITLE
Add `AudioWorkletProcessorConstructor` in AudioWorkletGlobalScope

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9670,9 +9670,11 @@ for that context. This prevents data races from occurring in global
 scope code running within concurrent threads.
 
 <pre class="idl">
+callback AudioWorkletProcessorConstructor = any (any options);
+
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {
-	void registerProcessor (DOMString name, VoidFunction processorCtor);
+	void registerProcessor (DOMString name, AudioWorkletProcessorConstructor processorCtor);
 	readonly attribute unsigned long long currentFrame;
 	readonly attribute double currentTime;
 	readonly attribute float sampleRate;

--- a/index.bs
+++ b/index.bs
@@ -9670,7 +9670,7 @@ for that context. This prevents data races from occurring in global
 scope code running within concurrent threads.
 
 <pre class="idl">
-callback AudioWorkletProcessorConstructor = any (any options);
+callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object options);
 
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {


### PR DESCRIPTION
Fixes #1839.

cc @karlt


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1843.html" title="Last updated on Mar 26, 2019, 4:31 PM UTC (4c3452c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1843/83cd1ad...hoch:4c3452c.html" title="Last updated on Mar 26, 2019, 4:31 PM UTC (4c3452c)">Diff</a>