### PR TITLE
Fix #1841: Add note that unstable biquads can be created

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6060,8 +6060,13 @@ $$
 
 
 The initial filter state is 0.
+
+Note: While fixed filters are stable, it is possible to create
+unstable biquad filters using automations of {{AudioParam}}s.  It is
+the developers responsibility to manage this.
+
 The coefficients in the transfer function above are different for
-each node type. The following intermediate variable are necessary for
+each node type. The following intermediate variables are necessary for
 their computation, based on the <a>computedValue</a> of the
 {{AudioParam}}s of the
 {{BiquadFilterNode}}.


### PR DESCRIPTION
It's the developers responsbility to handle this.  The spec does not
require anything be done.

Also fixed one minor typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1847.html" title="Last updated on Mar 28, 2019, 8:57 PM UTC (2c36024)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1847/ff93d57...rtoy:2c36024.html" title="Last updated on Mar 28, 2019, 8:57 PM UTC (2c36024)">Diff</a>