### PR TITLE
Fix #1841: UA may warn the user about NaN in filter states

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6087,6 +6087,8 @@ Note: While fixed filters are stable, it is possible to create
 unstable biquad filters using automations of {{AudioParam}}s.  It is
 the developers responsibility to manage this.
 
+Note: The UA may produce a warning to notify the user that NaN values have occurred in the filter state.  This is usually indicative of an unstable filter.
+
 The coefficients in the transfer function above are different for
 each node type. The following intermediate variables are necessary for
 their computation, based on the <a>computedValue</a> of the
@@ -7686,6 +7688,8 @@ $$
 </pre>
 
 The initial filter state is the all-zeroes state.
+
+Note: The UA may produce a warning to notify the user that NaN values have occurred in the filter state.  This is usually indicative of an unstable filter.
 
 
 <!--


### PR DESCRIPTION
Add a note for both the BiquadFilterNode and the IIRFilterNode that
the UA may producing a warning if the filter state contains NaN.  This
is usually indicative of an unstable filter (but not always).