### PR TITLE
Throw in case of non-existent connection in the three-argument version of `AudioNode.disconnect`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3131,7 +3131,7 @@ Methods</h4>
 		destination {{AudioNode}}.
 
 		<pre class=argumentdef for="AudioNode/disconnect(destinationNode, output, input)">
-			destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationNode</code> from the given output, an {{InvalidAccessError}} exception MUST be thrown.</span>
+			destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationNode</code> from the given input to the given output, an {{InvalidAccessError}} exception MUST be thrown.</span>
 			output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to disconnect. <span class="synchronous">If this parameter is out-of-bound, an {{IndexSizeError}} exception MUST be thrown.</span>
 			input: The <code>input</code> parameter is an index describing which input of the destination {{AudioNode}} to disconnect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
 		</pre>


### PR DESCRIPTION
This is what implementations do in practice.

Thanks to Christoph Guttandin for reporting, this fixes. #1852.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1853.html" title="Last updated on May 2, 2019, 1:18 PM UTC (2ba348d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1853/79d5743...padenot:2ba348d.html" title="Last updated on May 2, 2019, 1:18 PM UTC (2ba348d)">Diff</a>