### PR TITLE
Address #1857:  Fix typos up through AudioNodes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1338,7 +1338,7 @@ interface AudioContext : BaseAudioContext {
 </xmp>
 
 An {{AudioContext}} is said to be <dfn>allowed to start</dfn> if the user agent
-allows the context state to transition from "suspended" to "running". A user
+allows the context state to transition from "{{AudioContextState/suspended}}" to "{{AudioContextState/running}}". A user
 agent may require the actual audio production from an {{AudioContext}} to be
 <a>triggered by user activation</a> (as described in [[HTML]]).
 
@@ -1465,7 +1465,7 @@ Methods</h4>
 	: <dfn>close()</dfn>
 	::
 		Closes the {{AudioContext}}, [=release system resources|releasing the system
-		resources=] it's using. This will not automatically release
+		resources=] being used. This will not automatically release
 		all {{AudioContext}}-created objects, but will suspend the
 		progression of the {{AudioContext}}'s
 		{{BaseAudioContext/currentTime}}, and stop
@@ -1530,8 +1530,8 @@ Methods</h4>
 	: <dfn>createMediaElementSource(mediaElement)</dfn>
 	::
 		Creates a {{MediaElementAudioSourceNode}}
-		given an HTMLMediaElement. As a consequence of calling this
-		method, audio playback from the HTMLMediaElement will be
+		given an {{HTMLMediaElement}}. As a consequence of calling this
+		method, audio playback from the {{HTMLMediaElement}} will be
 		re-routed into the processing graph of the
 		{{AudioContext}}.
 
@@ -1583,8 +1583,8 @@ Methods</h4>
 	: <dfn>getOutputTimestamp()</dfn>
 	::
 		Returns a new {{AudioTimestamp}} instance
-		containing two correlated context's audio stream position
-		values: the {{AudioTimestamp/contextTime}} member contains
+		containing two related audio stream position
+		values for the context: the {{AudioTimestamp/contextTime}} member contains
 		the time of the sample frame which is currently being rendered
 		by the audio output device (i.e., output audio stream
 		position), in the same units and origin as context's
@@ -1598,7 +1598,7 @@ Methods</h4>
 
 		If the context's rendering graph has not yet processed a block
 		of audio, then {{getOutputTimestamp}} call
-		returns an <code>AudioTimestamp</code> instance with both
+		returns an {{AudioTimestamp}} instance with both
 		members containing zero.
 
 		After the context's rendering graph has started processing of
@@ -1906,10 +1906,10 @@ Constructors</h4>
 			Initialize <var>c</var> as follows:
 
 			1. Set the <code>control thread state</code> for <var>c</var>
-				to <code>"suspended"</code>.
+				to <code>suspended</code>.
 
 			2. Set the <code>rendering thread state</code> for
-				<var>c</var> to <code>"suspended"</code>.
+				<var>c</var> to <code>suspended</code>.
 
 			3. Construct an {{AudioDestinationNode}} with its
 				{{AudioNode/channelCount}} set to
@@ -1922,7 +1922,7 @@ Constructors</h4>
 
 	: <dfn>OfflineAudioContext(numberOfChannels, length, sampleRate)</dfn>
 	::
-		The {{OfflineAudioContext}} can constructed with the same arguments
+		The {{OfflineAudioContext}} can be constructed with the same arguments
 		as AudioContext.createBuffer. <span class="synchronous">A
 		{{NotSupportedError}} exception MUST be thrown if any
 		of the arguments is negative, zero, or outside its nominal
@@ -2029,7 +2029,7 @@ Methods</h4>
 				rendering <code>length</code> sample-frames of audio into
 				{{[[rendered buffer]]}}
 
-				<li>For every <a>render quantum</a>, check and suspend the
+				<li>For every <a>render quantum</a>, check and suspend
 				rendering if necessary.
 
 				<li>If a suspended context is resumed, continue to render the
@@ -2145,10 +2145,10 @@ Methods</h4>
 		precise suspension.
 
 		<pre class=argumentdef for="OfflineAudioContext/suspend()">
-		suspendTime: Schedules a suspension of the rendering at the specified time, which is quantized and rounded down to the <a>render quantum</a> size. If the quantized frame number <ol> <li>is negative or <li>is less than or equal to the current time or <li>is greater than or equal to the total render duration or <li>is scheduled by another suspend for the same time, </ol>then the promise is rejected with {{InvalidStateError}}.
+		suspendTime: Schedules a suspension of the rendering at the specified time, which is quantized and rounded up to the <a>render quantum</a> size. If the quantized frame number <ol> <li>is negative or <li>is less than or equal to the current time or <li>is greater than or equal to the total render duration or <li>is scheduled by another suspend for the same time, </ol>then the promise is rejected with {{InvalidStateError}}.
 		</pre>
 
-		<div>
+ 		<div>
 			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
 		</div>
 </dl>
@@ -2266,7 +2266,7 @@ An {{AudioBuffer}} may be used by one or more
 
 	: <dfn>[[sample rate]]</dfn>
 	::
-		The sample-rate, in Hz, of this {{AudioBuffer}}, a float
+		The sample-rate, in Hz, of this {{AudioBuffer}}, a float.
 
 	: <dfn>[[internal data]]</dfn>
 	::
@@ -2365,7 +2365,7 @@ Methods</h4>
 
 		<pre class=argumentdef for="AudioBuffer/copyFromChannel()">
 		destination: The array the channel data will be copied to.
-		channelNumber: The index of the channel to copy the data from. If <code>channelNumber</code> is greater or equal than the number of channel of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
+		channelNumber: The index of the channel to copy the data from. If <code>channelNumber</code> is greater or equal than the number of channels of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
 		startInChannel: An optional offset to copy the data from. If <code>startInChannel</code> is greater than the <code>length</code> of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
 		</pre>
 
@@ -2394,7 +2394,7 @@ Methods</h4>
 
 		<pre class=argumentdef for="AudioBuffer/copyToChannel()">
 		source: The array the channel data will be copied from.
-		channelNumber: The index of the channel to copy the data to. If <code>channelNumber</code> is greater or equal than the number of channel of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
+		channelNumber: The index of the channel to copy the data to. If <code>channelNumber</code> is greater or equal than the number of channels of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
 		startInChannel: An optional offset to copy the data to. If <code>startInChannel</code> is greater than the <code>length</code> of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
 		</pre>
 
@@ -2415,7 +2415,7 @@ Methods</h4>
 		created.
 
 		<pre class=argumentdef for="AudioBuffer/getChannelData()">
-		channel: This parameter is an index representing the particular channel to get data for. An index value of 0 represents the first channel. <span class="synchronous">This index value MUST be less than <code>numberOfChannels</code> or an {{IndexSizeError}} exception MUST be thrown.</span>
+		channel: This parameter is an index representing the particular channel to get data for. An index value of 0 represents the first channel. <span class="synchronous">This index value MUST be less than {{[[number of channels]]}} or an {{IndexSizeError}} exception MUST be thrown.</span>
 		</pre>
 
 		<div>
@@ -2462,13 +2462,13 @@ invoker.
 
 The [=acquire the contents of an AudioBuffer=] operation is invoked in the following cases:
 
-* When <code>AudioBufferSourceNode.start</code> is called, it
+* When {{AudioBufferSourceNode/start()|AudioBufferSourceNode.start}}  is called, it
 	<a href="#acquire-the-content">acquires the contents</a> of the
 	node's {{AudioBufferSourceNode/buffer}}. If the operation fails, nothing is
 	played.
 
 * When the {{AudioBufferSourceNode/buffer}} of an {{AudioBufferSourceNode}}
-	is set and <code>AudioBufferSourceNode.start</code> has been
+	is set and {{AudioBufferSourceNode/start()|AudioBufferSourceNode.start}} has been
 	previously called, the setter <a href="#acquire-the-content">acquires
 	the content</a> of the {{AudioBuffer}}. If the operation fails,
 	nothing is played.
@@ -2571,8 +2571,8 @@ connections then it has one channel which is silent.
 For each <a>input</a>, an {{AudioNode}} performs a
 mixing (usually an up-mixing) of all connections to that input.
 Please see <a href="#mixer-gain-structure"></a> for more informative
-details, and the <a href="#channel-up-mixing-and-down-mixing"></a>
-section for normative requirements.
+details, and <a href="#channel-up-mixing-and-down-mixing"></a>
+for normative requirements.
 
 The processing of inputs and the internal operations of an
 {{AudioNode}} take place continuously with respect to
@@ -2711,7 +2711,7 @@ object that can be passed to the constructor for this interface.
 
 {{AudioNode}}s are {{EventTarget}}s, as described in [[!DOM]].
 This means that it is possible to dispatch events to
-{{AudioNode}}s the same way that other EventTargets
+{{AudioNode}}s the same way that other {{EventTarget}}s
 accept events.
 
 <pre class="idl">
@@ -3061,7 +3061,7 @@ Methods</h4>
 	::
 		Connects the {{AudioNode}} to an
 		{{AudioParam}}, controlling the parameter value
-		with an audio-rate signal.
+		with an <a>a-rate</a> signal.
 
 		It is possible to connect an {{AudioNode}}
 		output to more than one {{AudioParam}} with
@@ -3107,7 +3107,7 @@ Methods</h4>
 		</div>
 
 		<pre class=argumentdef for="AudioNode/connect(destinationParam, output)">
-			destinationParam: The <code>destination</code> parameter is the {{AudioParam}} to connect to. This method does not return <code>destination</code> {{AudioParam}} object. <span class="synchronous">If {{AudioNode/connect(destinationParam, output)/destinationParam}} belongs to an {{AudioNode}} that belongs to a {{BaseAudioContext}} that is different from the {{BaseAudioContext}} that has created the {{AudioNode}} on which this method was called, an {{InvalidAccessError}} MUST be thrown.</span>
+			destinationParam: The <code>destination</code> parameter is the {{AudioParam}} to connect to. This method does not return the <code>destination</code> {{AudioParam}} object. <span class="synchronous">If {{AudioNode/connect(destinationParam, output)/destinationParam}} belongs to an {{AudioNode}} that belongs to a {{BaseAudioContext}} that is different from the {{BaseAudioContext}} that has created the {{AudioNode}} on which this method was called, an {{InvalidAccessError}} MUST be thrown.</span>
 			output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to connect. <span class="synchronous">If the <code>parameter</code> is out-of-bound, an {{IndexSizeError}} exception MUST be thrown.</span>
 		</pre>
 
@@ -3158,7 +3158,7 @@ Methods</h4>
 	: <dfn>disconnect(destinationNode, output)</dfn>
 	::
 		Disconnects a specific output of the
-		{{AudioNode}} from a specific input of some
+		{{AudioNode}} from any and all inputs of some
 		destination {{AudioNode}}.
 
 		<pre class=argumentdef for="AudioNode/disconnect(destinationNode, output)">

--- a/index.bs
+++ b/index.bs
@@ -1906,10 +1906,10 @@ Constructors</h4>
 			Initialize <var>c</var> as follows:
 
 			1. Set the <code>control thread state</code> for <var>c</var>
-				to <code>suspended</code>.
+				to <code>"suspended"</code>.
 
 			2. Set the <code>rendering thread state</code> for
-				<var>c</var> to <code>suspended</code>.
+				<var>c</var> to <code>"suspended"</code>.
 
 			3. Construct an {{AudioDestinationNode}} with its
 				{{AudioNode/channelCount}} set to
@@ -2148,7 +2148,7 @@ Methods</h4>
 		suspendTime: Schedules a suspension of the rendering at the specified time, which is quantized and rounded up to the <a>render quantum</a> size. If the quantized frame number <ol> <li>is negative or <li>is less than or equal to the current time or <li>is greater than or equal to the total render duration or <li>is scheduled by another suspend for the same time, </ol>then the promise is rejected with {{InvalidStateError}}.
 		</pre>
 
- 		<div>
+		<div>
 			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
 		</div>
 </dl>


### PR DESCRIPTION
Fixes typos and things up to and including all of the AudioNode section. (1.5.6.1).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1871.html" title="Last updated on May 10, 2019, 7:17 PM UTC (ca65a4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1871/f47c7f5...rtoy:ca65a4a.html" title="Last updated on May 10, 2019, 7:17 PM UTC (ca65a4a)">Diff</a>