### PR TITLE
Address #1857: Fix phrasing and add some links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3263,7 +3263,7 @@ Dictionary {{AudioNodeOptions}} Members</h5>
 The {{AudioParam}} Interface</h3>
 
 {{AudioParam}} controls an individual aspect of an
-{{AudioNode}}'s functioning, such as volume. The
+{{AudioNode}}'s functionality, such as volume. The
 parameter can be set immediately to a particular value using the
 <code>value</code> attribute. Or, value changes can be scheduled to
 happen at very precise times (in the coordinate system of
@@ -3433,7 +3433,7 @@ Attributes</h4>
 	::
 		The automation rate for the {{AudioParam}}.  The
 		default value depends on the actual {{AudioParam}};
-		see the description of the {{AudioParam}} for the
+		see the description of each individual {{AudioParam}} for the
 		default value.
 
 		Some nodes have additional <dfn dfn>automation rate constraints</dfn> as follows:
@@ -3518,8 +3518,8 @@ Methods</h4>
 	::
 		This is similar to {{AudioParam/cancelScheduledValues()}} in that it cancels all
 		scheduled parameter changes with times greater than or equal to
-		<code>cancelTime</code>. However, in addition, the automation
-		value that would have happened at <code>cancelTime</code> is
+		{{AudioParam/cancelAndHoldAtTime()/cancelTime!!argument}}. However, in addition, the automation
+		value that would have happened at {{AudioParam/cancelAndHoldAtTime()/cancelTime!!argument}} is
 		then proprogated for all future time until other automation
 		events are introduced.
 
@@ -3527,12 +3527,12 @@ Methods</h4>
 		{{AudioParam/cancelAndHoldAtTime()}} when automations are running
 		and can be introduced at any time after calling
 		{{AudioParam/cancelAndHoldAtTime()}} and before
-		<code>cancelTime</code> is reached is quite complicated. The
+		{{AudioParam/cancelAndHoldAtTime()/cancelTime!!argument}} is reached is quite complicated. The
 		behavior of {{AudioParam/cancelAndHoldAtTime()}} is therefore
 		specified in the following algorithm.
 
 		<div algorithm="cancel and hold">
-			Let \(t_c\) be the value of <code>cancelTime</code>. Then
+			Let \(t_c\) be the value of {{AudioParam/cancelAndHoldAtTime()/cancelTime!!argument}}. Then
 
 			1. Let \(E_1\) be the event (if any) at time \(t_1\) where
 				\(t_1\) is the largest number satisfying \(t_1 \le t_c\).
@@ -3599,15 +3599,15 @@ Methods</h4>
 	: <dfn>cancelScheduledValues(cancelTime)</dfn>
 	::
 		Cancels all scheduled parameter changes with times greater than
-		or equal to <code>cancelTime</code>. Cancelling a scheduled
+		or equal to {{AudioParam/cancelScheduledValues()/cancelTime!!argument}}. Cancelling a scheduled
 		parameter change means removing the scheduled event from the
 		event list. Any active automations whose <a>automation event time</a> is less
-		than <code>cancelTime</code> are also cancelled, and such
+		than {{AudioParam/cancelScheduledValues()/cancelTime!!argument}} are also cancelled, and such
 		cancellations may cause discontinuities because the original
 		value (from before such automation) is restored immediately. Any
 		hold values scheduled by {{AudioParam/cancelAndHoldAtTime()}}
 		are also removed if the hold time occurs after
-		<code>cancelTime</code>.
+		{{AudioParam/cancelScheduledValues()/cancelTime!!argument}}.
 
 		<pre class=argumentdef for="AudioParam/cancelScheduledValues()">
 			cancelTime: The time after which any previously scheduled parameter changes will be cancelled. It is a time in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>cancelTime</code> is negative or is not a finite number.</span> If <code>cancelTime</code> is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
@@ -3627,7 +3627,7 @@ Methods</h4>
 
 		The value during the time interval \(T_0 \leq t &lt; T_1\)
 		(where \(T_0\) is the time of the previous event and \(T_1\) is
-		the <code>endTime</code> parameter passed into this method)
+		the {{AudioParam/exponentialRampToValueAtTime()/endTime!!argument}} parameter passed into this method)
 		will be calculated as:
 
 		<pre nohighlight>
@@ -3637,7 +3637,7 @@ Methods</h4>
 		</pre>
 
 		where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is
-		the <code>value</code> parameter passed into this method. If
+		the {{AudioParam/exponentialRampToValueAtTime()/value!!argument}} parameter passed into this method. If
 		\(V_0\) and \(V_1\) have opposite signs or if \(V_0\) is zero,
 		then \(v(t) = V_0\) for \(T_0 \le t \lt T_1\).
 
@@ -3649,11 +3649,11 @@ Methods</h4>
 		event then for \(t \geq T_1\), \(v(t) = V_1\).
 
 		If there is no event preceding this event, the exponential ramp
-		behaves as if <code>setValueAtTime(value, currentTime)</code>
+		behaves as if {{AudioParam/setValueAtTime()|setValueAtTime(value, currentTime)}}
 		were called where <code>value</code> is the current value of
 		the attribute and <code>currentTime</code> is the context
 		{{BaseAudioContext/currentTime}} at the time
-		<code>exponentialRampToValueAtTime</code> is called.
+		{{AudioParam/exponentialRampToValueAtTime()}} is called.
 
 		If the preceding event is a <code>SetTarget</code> event, \(T_0\)
 		and \(V_0\) are chosen from the current time and value of
@@ -3684,7 +3684,7 @@ Methods</h4>
 
 		The value during the time interval \(T_0 \leq t &lt; T_1\)
 		(where \(T_0\) is the time of the previous event and \(T_1\) is
-		the <code>endTime</code> parameter passed into this method)
+		the {{AudioParam/linearRampToValueAtTime()/endTime!!argument}} parameter passed into this method)
 		will be calculated as:
 
 		<pre nohighlight>
@@ -3694,17 +3694,17 @@ Methods</h4>
 		</pre>
 
 		Where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is
-		the <code>value</code> parameter passed into this method.
+		the {{AudioParam/linearRampToValueAtTime()/value!!argument}} parameter passed into this method.
 
 		If there are no more events after this <em>LinearRampToValue</em> event
 		then for \(t \geq T_1\), \(v(t) = V_1\).
 
 		If there is no event preceding this event, the linear ramp
-		behaves as if <code>setValueAtTime(value, currentTime)</code>
+		behaves as if {{AudioParam/setValueAtTime()|setValueAtTime(value, currentTime)}}
 		were called where <code>value</code> is the current value of
 		the attribute and <code>currentTime</code> is the context
 		{{BaseAudioContext/currentTime}} at the time
-		<code>linearRampToValueAtTime</code> is called.
+		{{AudioParam/linearRampToValueAtTime()}} is called.
 
 		If the preceding event is a <code>SetTarget</code> event, \(T_0\)
 		and \(V_0\) are chosen from the current time and value of
@@ -3738,7 +3738,7 @@ Methods</h4>
 		given time, but instead gradually changes to the target value.
 
 		During the time interval: \(T_0 \leq t\), where \(T_0\) is the
-		<code>startTime</code> parameter:
+		{{AudioParam/setTargetAtTime()/startTime!!argument}} parameter:
 
 		<pre nohighlight>
 		$$
@@ -3746,10 +3746,10 @@ Methods</h4>
 		$$
 		</pre>
 
-		where \(V_0\) is the initial value (the <code>.value</code>
-		attribute) at \(T_0\) (the <code>startTime</code> parameter),
-		\(V_1\) is equal to the <code>target</code> parameter, and
-		\(\tau\) is the <code>timeConstant</code> parameter.
+		where \(V_0\) is the initial value (the {{[[current value]]}}
+		attribute) at \(T_0\) (the {{AudioParam/setTargetAtTime()/startTime!!argument}} parameter),
+		\(V_1\) is equal to the {{AudioParam/setTargetAtTime()/target!!argument}} parameter, and
+		\(\tau\) is the {{AudioParam/setTargetAtTime()/timeConstant!!argument}} parameter.
 
 		If a <code>LinearRampToValue</code> or
 		<code>ExponentialRampToValue</code> event follows this event, the
@@ -3774,8 +3774,8 @@ Methods</h4>
 
 		If there are no more events after this <code>SetValue</code> event,
 		then for \(t \geq T_0\), \(v(t) = V\), where \(T_0\) is the
-		<code>startTime</code> parameter and \(V\) is the
-		<code>value</code> parameter. In other words, the value will
+		{{AudioParam/setValueAtTime()/startTime!!argument}} parameter and \(V\) is the
+		{{AudioParam/setValueAtTime()/value!!argument}} parameter. In other words, the value will
 		remain constant.
 
 		If the next event (having time \(T_1\)) after this
@@ -3813,9 +3813,9 @@ Methods</h4>
 		given time for the given duration. The number of values will be
 		scaled to fit into the desired duration.
 
-		Let \(T_0\) be <code>startTime</code>, \(T_D\) be
-		<code>duration</code>, \(V\) be the <code>values</code> array,
-		and \(N\) be the length of the <code>values</code> array. Then,
+		Let \(T_0\) be {{AudioParam/setValueCurveAtTime()/startTime!!argument}}, \(T_D\) be
+		{{AudioParam/setValueCurveAtTime()/duration!!argument}}, \(V\) be the {{AudioParam/setValueCurveAtTime()/values!!argument}} array,
+		and \(N\) be the length of the {{AudioParam/setValueCurveAtTime()/values!!argument}} array. Then,
 		during the time interval: \(T_0 \le t &lt; T_0 + T_D\), let
 
 		<pre nohighlight>


### PR DESCRIPTION
A few changes in phrasing and some links to the arguments of the
automation methods were added.  I think this makes the algorithm
description a bit clearer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1874.html" title="Last updated on May 14, 2019, 6:21 PM UTC (9d44c22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1874/d7b9c7e...rtoy:9d44c22.html" title="Last updated on May 14, 2019, 6:21 PM UTC (9d44c22)">Diff</a>