### PR TITLE
Address #1857: Fix typos thru AudioListener

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4569,7 +4569,7 @@ attribute is <code>false</code>), or when the {{AudioScheduledSourceNode/stop()}
 called and the specified time has been reached. Please see more
 details in the {{AudioScheduledSourceNode/start()}} and
 {{AudioScheduledSourceNode/stop()}}
-description.
+descriptions.
 
 <pre class=include>
 path: audionode.include
@@ -4589,7 +4589,7 @@ or is one channel of silence if {{AudioBufferSourceNode/buffer}} is
 
 In addition, if the buffer has more than one channel,
 then the {{AudioBufferSourceNode}} output must change to a single channel
-of silence at a beginning of render quantum after the time at which any one
+of silence at the beginning of a render quantum after the time at which any one
 of the following conditions holds:
 	* the end of the {{AudioBufferSourceNode/buffer}} has been reached;
 	* the {{AudioBufferSourceNode/start(when, offset, duration)/duration}} has been reached;
@@ -5288,12 +5288,12 @@ objects spatialize in relation to the
 {{BaseAudioContext}}'s {{BaseAudioContext/listener}}. See [[#Spatialization]]
 for more details about spatialization.
 
-The <code>positionX, positionY, positionZ</code> parameters represent
+The {{AudioListener/positionX}}, {{AudioListener/positionY}}, and {{AudioListener/positionZ}} parameters represent
 the location of the listener in 3D Cartesian coordinate space.
 {{PannerNode}} objects use this position relative to
 individual audio sources for spatialization.
 
-The <code>forwardX, forwardY, forwardZ</code> parameters represent a
+The {{AudioListener/forwardX}}, {{AudioListener/forwardY}}, and {{AudioListener/forwardZ}} parameters represent a
 direction vector in 3D space. Both a <code>forward</code> vector and
 an <code>up</code> vector are used to determine the orientation of
 the listener. In simple human terms, the <code>forward</code> vector


### PR DESCRIPTION
* Fix typos
 * Add some links (wanted to add more but bikeshed didn't see to want
   to link to args of a function, which we done elsewhere.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1881.html" title="Last updated on May 14, 2019, 10:06 PM UTC (51e2089)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1881/9fbb06d...rtoy:51e2089.html" title="Last updated on May 14, 2019, 10:06 PM UTC (51e2089)">Diff</a>