### PR TITLE
Fix #1880: setOrientation description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5494,30 +5494,30 @@ Methods</h4>
 		this method is called, a {{NotSupportedError}} MUST be
 		thrown.
 
-		Describes which direction the listener is pointing in the 3D
-		cartesian coordinate space. Both a <b>front</b> vector and an
-		<b>up</b> vector are provided. In simple human terms, the
-		<b>front</b> vector represents which direction the person's
-		nose is pointing. The <b>up</b> vector represents the direction
+		{{AudioListener/setOrientation()}} describes which direction the listener is pointing in the 3D
+		cartesian coordinate space. Both a [=front=] vector and an
+		[=up=] vector are provided. In simple human terms, the
+		<dfn dfn>front</dfn> vector represents which direction the person's
+		nose is pointing. The <dfn dfn>up</dfn> vector represents the direction
 		the top of a person's head is pointing. These two vectors are
 		expected to be linearly independent. For normative requirements
 		of how these values are to be interpreted, see the [[#Spatialization]].
 
-		The <code>x, y, z</code> parameters represent a <b>front</b>
+		The {{AudioListener/setOrientation()/x!!argument}}, {{AudioListener/setOrientation()/y!!argument}}, and {{AudioListener/setOrientation()/z!!argument}} parameters represent a <a>front</a>
 		direction vector in 3D space, with the default value being
 		(0,0,-1).
 
-		The <code>xUp, yUp, zUp</code> parameters represent an
-		<b>up</b> direction vector in 3D space, with the default value
+		The {{AudioListener/setOrientation()/xUp!!argument}}, {{AudioListener/setOrientation()/yUp!!argument}}, and {{AudioListener/setOrientation()/zUp!!argument}} parameters represent an
+		<a>up</a> direction vector in 3D space, with the default value
 		being (0,1,0).
 
 		<pre class=argumentdef for="AudioListener/setOrientation()">
-			x:
-			y:
-			z:
-			xUp:
-			yUp:
-			zUp:
+			x: forward <em>x</em> direction fo the {{AudioListener}}
+			y: forward <em>y</em> direction fo the {{AudioListener}}
+			z: forward <em>z</em> direction fo the {{AudioListener}}
+			xUp: up <em>x</em> direction fo the {{AudioListener}}
+			yUp: up <em>y</em> direction fo the {{AudioListener}}
+			zUp: up <em>z</em> direction fo the {{AudioListener}}
 		</pre>
 
 		<div>
@@ -5540,19 +5540,19 @@ Methods</h4>
 		this method is called, a {{NotSupportedError}} MUST be
 		thrown.
 
-		Sets the position of the listener in a 3D cartesian coordinate
+		{{AudioListener/setPosition()}} sets the position of the listener in a 3D cartesian coordinate
 		space. {{PannerNode}} objects use this position
 		relative to individual audio sources for spatialization.
 
-		The <code>x, y, z</code> parameters represent the coordinates
+		The {{AudioListener/setPosition()/x!!argument}}, {{AudioListener/setPosition()/y!!argument}}, and {{AudioListener/setPosition()/z!!argument}} parameters represent the coordinates
 		in 3D space.
 
 		The default value is (0,0,0).
 
 		<pre class=argumentdef for="AudioListener/setPosition()">
-			x:
-			y:
-			z:
+			x: <em>x</em>-coordinate of the position of the {{AudioListener}}
+			y: <em>y</em>-coordinate of the position of the {{AudioListener}}
+			z: <em>z</em>-coordinate of the position of the {{AudioListener}}
 		</pre>
 </dl>
 


### PR DESCRIPTION
* Apply simple fix to setOrientation and setPosition paragraphs
  * Add some very simple descriptive text for the parameters of the methods
  * Add links to the method parameters in the method descriptions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1885.html" title="Last updated on May 15, 2019, 5:18 PM UTC (e5b8a7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1885/763950c...rtoy:e5b8a7d.html" title="Last updated on May 15, 2019, 5:18 PM UTC (e5b8a7d)">Diff</a>