### PR TITLE
Address #1857: Fix typos through MediaStreamTrackAudioSourceNode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7215,7 +7215,7 @@ The following {{AudioNode}} graph is used internally,
 <code>input</code> and <code>output</code> respectively being the
 input and output {{AudioNode}}, <code>context</code> the
 {{BaseAudioContext}} for this {{DynamicsCompressorNode}}, and
-new class, <dfn>EnvelopeFollower</dfn>, that instantiate a
+a new class, <dfn>EnvelopeFollower</dfn>, that instantiates a
 special object that behaves like an {{AudioNode}}, described
 below:
 
@@ -7284,7 +7284,7 @@ values. Those values persist accros invocation of this algorithm.
 			<a href="#detector-curve">detector curve</a> to
 			<var>attenuation</var>.
 
-		4. Substract <var>detector average</var> to
+		4. Subtract <var>detector average</var> from
 			<var>attenuation</var>, and multiply the result by
 			<var>detector rate</var>. Add this new result to <var>detector average</var>.
 
@@ -7293,8 +7293,8 @@ values. Those values persist accros invocation of this algorithm.
 		6. Let <var>envelope rate</var> be the result of <a>computing the envelope rate</a> based on values of <var>attack</var> and <var>release</var>.
 
 		7. If <var>releasing</var> is `true`, set
-			<var>compressor gain</var> to the multiplication of
-			<var>compressor gain</var> by <var>envelope rate</var>, clamped
+			<var>compressor gain</var> to be the product of
+			<var>compressor gain</var> and <var>envelope rate</var>, clamped
 			to a maximum of 1.0.
 
 		8. Else, if <var>releasing</var> is <code>false</code>, let
@@ -7334,10 +7334,10 @@ the compressor so it is comparable to the input level.
 	1. Let <var>full range gain</var> be the value returned by
 		applying the <a>compression curve</a> to the value 1.0.
 
-	2. Let <var>full range makeup gain</var> the inverse of <var>full
+	2. Let <var>full range makeup gain</var> be the inverse of <var>full
 		range gain</var>.
 
-	3. Return the result of taking 0.6 power of <var>full range makeup
+	3. Return the result of taking the 0.6 power of <var>full range makeup
 		gain</var>.
 </div>
 
@@ -7389,7 +7389,7 @@ of the same shape.
 		values of {{DynamicsCompressorNode/threshold}} and
 		{{DynamicsCompressorNode/knee}}, respectively,
 		[=decibels to linear gain unit|converted to linear
-		units=] sampled at the time of processing of this
+		units=] and sampled at the time of processing of this
 		block (as [=k-rate=] parameters).
 
 	1. Let <var>ratio</var> have the value of the
@@ -7418,12 +7418,12 @@ of the same shape.
 
 	1. If \(v\) is equal to zero, return -1000.
 
-	2. Else, return \( 20 \, \log_{10}{v} \)
+	2. Else, return \( 20 \, \log_{10}{v} \).
 </div>
 
 <div algorithm="convert db to linear">
 	Converting a value \(v\) in <dfn>decibels to
-	linear gain unit</dfn> means returning \(10^\frac{v}{20}\)
+	linear gain unit</dfn> means returning \(10^{v/20}\).
 </div>
 
 
@@ -7541,7 +7541,7 @@ Dictionary {{GainOptions}} Members</h5>
 The {{IIRFilterNode}} Interface</h3>
 
 {{IIRFilterNode}} is an {{AudioNode}}
-processor implementing a general IIR Filter. In general, it is best
+processor implementing a general <a href="https://en.wikipedia.org/wiki/Infinite_impulse_response">IIR Filter</a>. In general, it is best
 to use {{BiquadFilterNode}}'s to implement
 higher-order filters for the following reasons:
 
@@ -7605,8 +7605,8 @@ Methods</h4>
 		{{InvalidAccessError}} MUST be thrown.
 
 		<pre class=argumentdef for="IIRFilterNode/getFrequencyResponse()">
-			frequencyHz: This parameter specifies an array of frequencies at which the response values will be calculated.
-			magResponse: This parameter specifies an output array receiving the linear magnitude response values. If a value in the <code>frequencyHz</code> parameter is not within [0; sampleRate/2], where <code>sampleRate</code> is the value of the {{BaseAudioContext/sampleRate}} property of the {{AudioContext}}, the corresponding value at the same index of the <code>magResponse</code> array MUST be <code>NaN</code>.
+			frequencyHz: This parameter specifies an array of frequencies, in Hz, at which the response values will be calculated.
+			magResponse: This parameter specifies an output array receiving the linear magnitude response values. If a value in the <code>frequencyHz</code> parameter is not within [0, sampleRate/2], where <code>sampleRate</code> is the value of the {{BaseAudioContext/sampleRate}} property of the {{AudioContext}}, the corresponding value at the same index of the <code>magResponse</code> array MUST be <code>NaN</code>.
 			phaseResponse: This parameter specifies an output array receiving the phase response values in radians. If a value in the <code>frequencyHz</code> parameter is not within [0; sampleRate/2], where <code>sampleRate</code> is the value of the {{BaseAudioContext/sampleRate}} property of the {{AudioContext}}, the corresponding value at the same index of the <code>phaseResponse</code> array MUST be <code>NaN</code>.
 		</pre>
 
@@ -7877,7 +7877,7 @@ Attributes</h4>
 <dl dfn-type=attribute dfn-for="MediaStreamAudioDestinationNode">
 	: <dfn>stream</dfn>
 	::
-		A MediaStream containing a single MediaStreamTrack with the same
+		A [[mediacapture-streams#mediastream|MediaStream]] containing a single [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] with the same
 		number of channels as the node itself, and whose
 		<code>kind</code> attribute has the value <code>"audio"</code>.
 </dl>
@@ -7921,7 +7921,7 @@ Constructors</h4>
 			1. If <var>context</var> is not an {{AudioContext}}, throw an
 				{{NotSupportedError}} exception and abort these steps.
 			2. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
-				<code>options</code> does not reference a
+				{{MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()/options!!argument}} does not reference a
 				[[mediacapture-streams#mediastream|MediaStream]] that has at least one
 				[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] whose
 				<code>kind</code> attribute has the value <code>"audio"</code>,
@@ -7937,7 +7937,7 @@ Constructors</h4>
 			5. Let <var>node</var> be a new {{MediaStreamAudioSourceNode}}
 				object. <a href="#audionode-constructor-init">Initialize</a>
 				<var>node</var>.
-			6. Set an internal slot [[input track]] on this
+			6. Set an internal slot <dfn attribute for="MediaStreamAudioSourceNode">[[input track]]</dfn> on this
 				{{MediaStreamAudioSourceNode}} to be the first element of
 				<var>tracks</var>.  This is the track used as the input audio for this
 				{{MediaStreamAudioSourceNode}}.


### PR DESCRIPTION
* Fix some phrasing
  * Fix typos
  * Make formula a bit clearer (by not have a tiny fraction as the exponent).
  * Add some links to other specs
  * Add some links to method parameters
  * Make [[input track]] an actual dfn.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1890.html" title="Last updated on May 15, 2019, 11:16 PM UTC (4170987)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1890/763950c...rtoy:4170987.html" title="Last updated on May 15, 2019, 11:16 PM UTC (4170987)">Diff</a>