### PR TITLE
Fix #1882: Biquad lowpass/highpass Q is tradtional Q

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5736,8 +5736,6 @@ enum BiquadFilterType {
 			: <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
 			:: Controls how peaked the response will be at the cutoff
 				frequency. A large value makes the response more peaked.
-				Please note that for this filter type, this value is not a
-				traditional Q, but is a resonance value in decibels.
 			: gain
 			:: Not used in this filter type
 	<tr>
@@ -5755,8 +5753,6 @@ enum BiquadFilterType {
 			: <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
 			:: Controls how peaked the response will be at the cutoff
 				frequency. A large value makes the response more peaked.
-				Please note that for this filter type, this value is not a
-				traditional Q, but is a resonance value in decibels.
 			: gain
 			:: Not used in this filter type
 	<tr>


### PR DESCRIPTION
Just remove the sentence that says Q is resonance, not traditional Q. It is a traditional Q.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1892.html" title="Last updated on May 16, 2019, 5:17 PM UTC (970c4fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1892/7285a2e...rtoy:970c4fb.html" title="Last updated on May 16, 2019, 5:17 PM UTC (970c4fb)">Diff</a>