### PR TITLE
Delete references of the term "block-size"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2580,14 +2580,6 @@ The processing of inputs and the internal operations of an
 connected outputs, and regardless of whether these outputs ultimately
 reach an {{AudioContext}}'s {{AudioDestinationNode}}.
 
-For performance reasons, practical implementations will need to use
-block processing, with each {{AudioNode}} processing
-a fixed number of sample-frames of size <em>block-size</em>. In order
-to get uniform behavior across implementations, we will define this
-value explicitly. <em>block-size</em> is defined to be 128
-sample-frames which corresponds to roughly 3ms at a sample-rate of
-44.1 kHz.
-
 <pre class="idl">
 [Exposed=Window]
 interface AudioNode : EventTarget {


### PR DESCRIPTION
Fixes #1870.

We decided to remove the whole paragraph because it doesn't add any value. This is the only place where "block-size" exists, and also we have a dedicated section for render quantum.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1916.html" title="Last updated on May 20, 2019, 8:21 PM UTC (86cb770)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1916/d7b9c7e...hoch:86cb770.html" title="Last updated on May 20, 2019, 8:21 PM UTC (86cb770)">Diff</a>