### PR TITLE
Add the thread state description in 2.2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -818,8 +818,8 @@ Attributes</h4>
 
 	: <dfn>state</dfn>
 	::
-		Describes the current state of the {{AudioContext}}, on the
-		<a>control thread</a>.
+		Describes the current state of the {{AudioContext}}. Its value is identical
+		to <a>control thread state</a>.
 </dl>
 
 <h4 id="BaseAudioContent-methods">

--- a/index.bs
+++ b/index.bs
@@ -1361,9 +1361,9 @@ Constructors</h4>
 			<span class="synchronous">When creating an {{AudioContext}},
 			execute these steps:</span>
 
-			1. Set a <code>control thread state</code> to <code>suspended</code> on the {{AudioContext}}.
+			1. Set a <a>control thread state</a> to <code>suspended</code> on the {{AudioContext}}.
 
-			2. Set a <dfn dfn for>rendering thread state</dfn> to <code>suspended</code> on the {{AudioContext}}.
+			2. Set a <a>rendering thread state</a> to <code>suspended</code> on the {{AudioContext}}.
 
 			3. Let <dfn dfn for>pendingResumePromises</dfn> be an empty ordered list of promises.
 
@@ -1476,7 +1476,7 @@ Methods</h4>
 
 			1. Let <em>promise</em> be a new Promise.
 
-			2. If the <em>control thread state</em> flag on the
+			2. If the <a>control thread state</a> flag on the
 				{{AudioContext}} is <code>closed</code> reject the promise
 				with {{InvalidStateError}}, abort these steps,
 				returning <em>promise</em>.
@@ -1485,7 +1485,7 @@ Methods</h4>
 				of the {{AudioContext}} is already "{{AudioContextState/closed}}",
 				resolve <em>promise</em>, return it, and abort these steps.
 
-			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>closed</code>.
+			4. Set the <a>control thread state</a> flag on the {{AudioContext}} to <code>closed</code>.
 
 			5. <a>Queue a control message</a> to the {{AudioContext}}.
 
@@ -1654,7 +1654,7 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			2. If the <em>control thread state</em> flag on the
+			2. If the <a>control thread state</a> on the
 				{{AudioContext}} is <code>closed</code> reject the
 				promise with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
@@ -1665,7 +1665,7 @@ Methods</h4>
 				<var>promise</var> to <a>pendingResumePromises</a> and abort these
 				steps, returning <var>promise</var>.
 
-			5. Set the <em>control thread state</em> flag on the
+			5. Set the <a>control thread state</a> on the
 				{{AudioContext}} to <code>running</code>.
 
 			6. <a>Queue a control message</a> to resume the {{AudioContext}}.
@@ -1680,7 +1680,7 @@ Methods</h4>
 
 			1. Attempt to <a href="#acquiring">acquire system resources</a>.
 
-			2. Set the <a>rendering thread state</a> flag on the {{AudioContext}} to <code>running</code>.
+			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>running</code>.
 
 			3. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
@@ -1734,14 +1734,14 @@ Methods</h4>
 
 			1. Let <em>promise</em> be a new Promise.
 
-			2. If the <em>control thread state</em> flag on the
+			2. If the <a>control thread state</a> on the
 				{{AudioContext}} is <code>closed</code> reject the promise
 				with {{InvalidStateError}}, abort these steps,
 				returning <em>promise</em>.
 
 			3. Set {{[[suspended by user]]}} to <code>true</code>.
 
-			4. Set the <em>control thread state</em> flag on the {{AudioContext}} to <code>suspended</code>.
+			4. Set the <a>control thread state</a> on the {{AudioContext}} to <code>suspended</code>.
 
 			5. <a>Queue a control message</a> to suspend the {{AudioContext}}.
 
@@ -1905,10 +1905,10 @@ Constructors</h4>
 			Let <var>c</var> be a new {{OfflineAudioContext}} object.
 			Initialize <var>c</var> as follows:
 
-			1. Set the <code>control thread state</code> for <var>c</var>
+			1. Set the <a>control thread state</a> for <var>c</var>
 				to <code>"suspended"</code>.
 
-			2. Set the <code>rendering thread state</code> for
+			2. Set the <a>rendering thread state</a> for
 				<var>c</var> to <code>"suspended"</code>.
 
 			3. Construct an {{AudioDestinationNode}} with its
@@ -2073,17 +2073,17 @@ Methods</h4>
 
 			2. Abort these steps and reject <var>promise</var> with
 				{{InvalidStateError}} when any of following conditions is true:
-				- The <em>control thread state</em> flag on the {{OfflineAudioContext}}
+				- The <a>control thread state</a> on the {{OfflineAudioContext}}
 					is <code>closed</code>.
 				- The {{[[rendering started]]}} slot on the {{OfflineAudioContext}}
 					is <em>false</em>.
 
-			If the <em>control thread state</em> flag on the
+			If the <a>control thread state</a> flag on the
 				{{OfflineAudioContext}} is <code>closed</code> reject the
 				promise with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
 
-			3. Set the <em>control thread state</em> flag on the
+			3. Set the <a>control thread state</a> flag on the
 				{{OfflineAudioContext}} to <code>running</code>.
 
 			4. <a>Queue a control message</a> to resume the {{OfflineAudioContext}}.
@@ -2096,7 +2096,7 @@ Methods</h4>
 			{{OfflineAudioContext}} means running these steps on the
 			<a>rendering thread</a>:
 
-			1. Set the <a>rendering thread state</a> flag on the {{OfflineAudioContext}} to <code>running</code>.
+			1. Set the <a>rendering thread state</a> on the {{OfflineAudioContext}} to <code>running</code>.
 
 			2. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
@@ -4077,7 +4077,7 @@ Methods</h4>
 			4. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">run it in the rendering thread</a> only when
 				the following conditions are met:
-				1. The context's <code>control thread state</code> is
+				1. The context's <a>control thread state</a> is
 					<code>suspended</code>.
 				2. The context is <a>allowed to start</a>.
 				3. {{[[suspended by user]]}} flag is <code>false</code>.
@@ -4769,7 +4769,7 @@ Methods</h4>
 			4. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">run it in the rendering thread</a> only when
 				the following conditions are met:
-				1. The context's <code>control thread state</code> is
+				1. The context's <a>control thread state</a> is
 					<code>suspended</code>.
 				2. The context is <a>allowed to start</a>.
 				3. {{[[suspended by user]]}} flag is <code>false</code>.
@@ -10854,7 +10854,7 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 	3. Process a render quantum.
 
-		1. If the [=rendering thread state=] of the {{BaseAudioContext}} is not
+		1. If the <a>rendering thread state</a> of the {{BaseAudioContext}} is not
 			<code>running</code>, return false.
 
 		2. Order the {{AudioNode}}s of the {{BaseAudioContext}} to be processed.

--- a/index.bs
+++ b/index.bs
@@ -2078,16 +2078,12 @@ Methods</h4>
 				- The {{[[rendering started]]}} slot on the {{OfflineAudioContext}}
 					is <em>false</em>.
 
-<<<<<<< HEAD
 			If the <a>control thread state</a> flag on the
 				{{OfflineAudioContext}} is <code>closed</code> reject the
 				promise with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
 
 			3. Set the <a>control thread state</a> flag on the
-=======
-			1. Set the <em>control thread state</em> flag on the
->>>>>>> master
 				{{OfflineAudioContext}} to <code>running</code>.
 
 			1. <a>Queue a control message</a> to resume the {{OfflineAudioContext}}.

--- a/index.bs
+++ b/index.bs
@@ -10679,7 +10679,7 @@ reaction to the calls from the <a>control thread</a>. It can be a
 real-time, callback-based audio thread, if computing audio for an
 {{AudioContext}}, or a normal thread if computing audio for an {{OfflineAudioContext}}.
 
-Each thread has an internal slot indicates its current state.
+Each thread has an internal slot that indicates its current state.
 <dfn>control thread state</dfn> is the equivalent of {{BaseAudioContext/state}}
 and <dfn>rendering thread state</dfn> in the counterpart from the rendering
 thread. These slots hava a value of {{AudioContextState}}.

--- a/index.bs
+++ b/index.bs
@@ -2078,12 +2078,7 @@ Methods</h4>
 				- The {{[[rendering started]]}} slot on the {{OfflineAudioContext}}
 					is <em>false</em>.
 
-			If the <a>control thread state</a> flag on the
-				{{OfflineAudioContext}} is <code>closed</code> reject the
-				promise with {{InvalidStateError}}, abort these steps,
-				returning <var>promise</var>.
-
-			3. Set the <a>control thread state</a> flag on the
+			1. Set the <a>control thread state</a> flag on the
 				{{OfflineAudioContext}} to <code>running</code>.
 
 			1. <a>Queue a control message</a> to resume the {{OfflineAudioContext}}.

--- a/index.bs
+++ b/index.bs
@@ -10701,6 +10701,11 @@ real-time, callback-based audio thread, if computing audio for an
 {{AudioContext}}, or a normal thread if rendering and audio graph
 offline using an {{OfflineAudioContext}}.
 
+Each thread has an internal slot indicates its current state.
+<dfn>control thread state</dfn> is the equivalent of {{BaseAudioContext/state}}
+and <dfn>rendering thread state</dfn> in the counterpart from the rendering
+thread. These slots hava a value of {{AudioContextState}}.
+
 The <a>control thread</a> uses a traditional event loop, as described
 in [[HTML]].
 


### PR DESCRIPTION
Fixes #1865.

- Define `control thread state` and `rendering thread state` in the graph rendering section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1918.html" title="Last updated on May 23, 2019, 2:52 PM UTC (c334da4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1918/85a872c...hoch:c334da4.html" title="Last updated on May 23, 2019, 2:52 PM UTC (c334da4)">Diff</a>