### PR TITLE
Remove redundant notes from AudioBuffer interface description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2238,8 +2238,7 @@ Dictionary {{OfflineAudioCompletionEventInit}} Members</h6>
 <h3 id="AudioBuffer">
 The {{AudioBuffer}} Interface</h3>
 
-This interface represents a memory-resident audio asset (for one-shot
-sounds and other short audio clips). Its format is non-interleaved
+This interface represents a memory-resident audio asset. Its format is non-interleaved
 32-bit floating-point [=linear PCM=] values with a normal range of \([-1,
 1]\), but values are not limited to this range. It can contain one or
 more channels. Typically, it would be expected that the length of the


### PR DESCRIPTION
Fixes #1869.

This PR removes the parenthetical part about one-shot sounds and short clips.

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1919.html" title="Last updated on May 20, 2019, 8:49 PM UTC (da720ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1919/d7b9c7e...hoch:da720ad.html" title="Last updated on May 20, 2019, 8:49 PM UTC (da720ad)">Diff</a>