### PR TITLE
Clarify Audio Worklet section: constructor and instantiation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10293,7 +10293,8 @@ thread and the rendering thread.
 			3. Append (<var>paramName</var>, <var>audioParam</var>) to
 				<var>audioParamMap</var>'s entries.
 
-		3. For each <var>paramNameInOption</var> → <var>value</var> of <var>options</var>:
+		3. For each key-value pair (<var>paramNameInOption</var> to
+			<var>value</var>) of <var>options</var>:
 			1. If there exists an entry with name member equal to
 				<var>paramNameInOption</var> inside
 				<var>audioParamMap</var>, set that {{AudioParam}}'s
@@ -10514,9 +10515,8 @@ registerProcessor('BitCrusher', class extends AudioWorkletProcessor {
 
 Note: In the definition of {{AudioWorkletProcessor}} class, an
 {{InvalidStateError}} will be thrown if the
-author-supplied constructor uses JavaScript's return-override
-feature, or does not properly call <code>super()</code>.
-
+author-supplied constructor has an explicit return value that is not
+<code>this</code> or does not properly call <code>super()</code>.
 
 <h5 id="vu-meter-mode">
 VU Meter Node</h5>


### PR DESCRIPTION
Fixes #1907.

- Expand the description of "return-override" and remove the term.
- Expand the arrow notation for key-value pair.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1920.html" title="Last updated on May 22, 2019, 7:59 PM UTC (37caf2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1920/85a872c...hoch:37caf2e.html" title="Last updated on May 22, 2019, 7:59 PM UTC (37caf2e)">Diff</a>