### PR TITLE
Remove the reference of `state` in AudioWorkletNode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10087,7 +10087,6 @@ in the node.
 		{{process()}} method, <a href="https://tc39.github.io/ecma262/#sec-toboolean"><code>ToBoolean</code></a> (described in [[!ECMASCRIPT]])
 		is applied to the return value and the result is assigned to the associated AudioWorkletProcessor's <a>active source</a> flag. This in turn affects whether subsequent
 		invocations of {{process()}} occur, and has an impact on the lifetime of the node.
-		To propagate the flag change <a>queue a task</a> on the control thread to update the corresponding {{AudioWorkletNode}}'s <code>state</code> property accordingly.
 
 		<div class="note">
 			This lifetime policy can support a variety of approaches found in


### PR DESCRIPTION
Fixes #1901. 

The `state` doesn't exist any more. This was an oversight.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1921.html" title="Last updated on May 20, 2019, 9:12 PM UTC (0ac3428)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1921/d7b9c7e...hoch:0ac3428.html" title="Last updated on May 20, 2019, 9:12 PM UTC (0ac3428)">Diff</a>