### PR TITLE
Fix #1897: WaveShaper curve setter allows multiple sets

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9440,8 +9440,7 @@ Attributes</h4>
 		When this attribute is set, an internal copy of the curve is
 		created by the {{WaveShaperNode}}. Subsequent
 		modifications of the contents of the array used to set the
-		attribute therefore have no effect: the attribute MUST be set
-		again in order to change the curve.
+		attribute therefore have no effect.
 
 		<div algorithm="WaveShaperNode.curve">
 			To set the {{WaveShaperNode/curve}} attribute, execute these steps:


### PR DESCRIPTION
Just delete the sentence that implies the curve can be set more than once.  The algorithm is clear that you can only set it once.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1922.html" title="Last updated on May 21, 2019, 5:37 PM UTC (7ff7675)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1922/7de58c8...rtoy:7ff7675.html" title="Last updated on May 21, 2019, 5:37 PM UTC (7ff7675)">Diff</a>