### PR TITLE
Fix #1896: Fix WaveShaperNode constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9397,7 +9397,7 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="WaveShaperNode">
 	: <dfn>WaveShaperNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{WaveShaperNode}} object. Initialize <var>node</var>. Set an internal boolean slot <dfn attribute for="WaveShaperNode">[[curve set]]</dfn>, and initialize it to false. Return <var>node</var>.
+		Let <var>node</var> be a new {{WaveShaperNode}} object, and let <dfn attribute for="WaveShaperNode">[[curve set]]</dfn> be an internal slot of the <var>node</var>, initialized to <code>false</code>.  <a href="#audionode-constructor-init">Initialize</a> <var>node</var>. If {{WaveShaperNode/WaveShaperNode()/options!!argument}} is given and specifies a {{WaveShaperOptions/curve}}, set {{[[curve set]]}} to <code>true</code>. Return <var>node</var>.
 
 		<pre class=argumentdef for="WaveShaperNode/WaveShaperNode()">
 			context: The {{BaseAudioContext}} this new {{WaveShaperNode}} will be <a href="#associated">associated</a> with.


### PR DESCRIPTION
* Make `[[curve set]]` initialize appropriately depending on whether the options specifies a curve or not
 * Add link to Initialize algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1923.html" title="Last updated on May 21, 2019, 6:16 PM UTC (cefc9cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1923/7de58c8...rtoy:cefc9cf.html" title="Last updated on May 21, 2019, 6:16 PM UTC (cefc9cf)">Diff</a>