### PR TITLE
Fix #1879: ABSN playback algorithm offset

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4897,15 +4897,15 @@ Playback of AudioBuffer Contents</h4>
 
 This normative section specifies the playback of the contents of
 the buffer, accounting for the fact that playback is influenced by
-the following factors working in combination, which can vary
-dynamically during playback:
+the following factors working in combination:
 
 * A starting offset, which can expressed with sub-sample precision.
 
-* Loop points, which can expressed with sub-sample precision.
+* Loop points, which can expressed with sub-sample precision and can
+	 vary dynamically during playback.
 
 * Playback rate and detuning parameters, which combine to yield a
-	single computed playback rate that can assume non-infinite values
+	single <a>computedPlaybackRate</a> that can assume finite values
 	which may be positive or negative.
 
 The algorithm to be followed internally to generate output from an


### PR DESCRIPTION
Basically move the phrase from the paragraph into the second item,
with a few minor changes for grammar and flow.

Added a link to computedPlaybackRate.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1926.html" title="Last updated on May 23, 2019, 12:16 AM UTC (dc3b545)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1926/85a872c...rtoy:dc3b545.html" title="Last updated on May 23, 2019, 12:16 AM UTC (dc3b545)">Diff</a>