### PR TITLE
Fix #1851: getFrequencyResponse uses the [[current value]]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5954,8 +5954,9 @@ Methods</h4>
 <dl dfn-type=method dfn-for="BiquadFilterNode">
 	: <dfn>getFrequencyResponse(frequencyHz, magResponse, phaseResponse)</dfn>
 	::
-		<span class="synchronous">Given the current filter parameter
-		settings, synchronously calculates the frequency response for
+		<span class="synchronous">Given the {{[[current value]]}} 
+		from each of the filter parameters, synchronously
+		calculates the frequency response for
 		the specified frequencies.</span> The three parameters MUST be
 		{{Float32Array}}s of the same length, or an
 		{{InvalidAccessError}} MUST be thrown.


### PR DESCRIPTION
Specify that the frequency response uses the `[[current value]]` slot of each `AudioParam` to compute the response.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1936.html" title="Last updated on May 31, 2019, 7:46 PM UTC (410f5ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1936/c6bbac2...rtoy:410f5ef.html" title="Last updated on May 31, 2019, 7:46 PM UTC (410f5ef)">Diff</a>