### PR TITLE
Fix #1866: Remove references to garbage collection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1095,10 +1095,7 @@ Methods</h4>
 
 		Although the primary method of interfacing with this function
 		is via its promise return value, the callback parameters are
-		provided for legacy reasons. The system shall ensure that the
-		{{AudioContext}} is not garbage collected before the promise
-		is resolved or rejected and any callback function is called and
-		completes.
+		provided for legacy reasons. 
 
 		<div algorithm="decodeAudioData()">
 			<span class="synchronous">When <code>decodeAudioData</code> is
@@ -1969,11 +1966,7 @@ Methods</h4>
 	: <dfn>startRendering()</dfn>
 	::
 		Given the current connections and scheduled changes, starts
-		rendering audio. The system shall ensure that the
-		<code>OfflineAudioContext</code> is not garbage collected until
-		either the promise is resolved and any callback function is
-		called and completes, or until the <code>suspend</code>
-		function is called.
+		rendering audio. 
 
 		Although the primary method of getting the rendered audio data
 		is via its promise return value, the instance will also fire an


### PR DESCRIPTION
Removes the two sentences that mention garbage collection.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1938.html" title="Last updated on May 31, 2019, 8:25 PM UTC (8659142)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1938/c6bbac2...rtoy:8659142.html" title="Last updated on May 31, 2019, 8:25 PM UTC (8659142)">Diff</a>