### PR TITLE
Fix #1894: Remove text from orientationX

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8583,9 +8583,6 @@ Attributes</h4>
 	::
 		Describes the \(x\)-component of the vector of the direction the
 		audio source is pointing in 3D Cartesian coordinate space.
-		Depending on how directional the sound is (controlled by the
-		<b>cone</b> attributes), a sound pointing away from the
-		listener can be very quiet or completely silent.
 
 		<pre class=include>
 		path: audioparam.include


### PR DESCRIPTION
The sentences about directional sound and sound cones is removed.
This is all described by the panning/spatialization section, which is
linked to from the PannerNode intro itself.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1939.html" title="Last updated on Jun 3, 2019, 8:03 PM UTC (606ef70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1939/c6bbac2...rtoy:606ef70.html" title="Last updated on Jun 3, 2019, 8:03 PM UTC (606ef70)">Diff</a>