### PR TITLE
Fix #1858: Multiline source text loses space

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -854,13 +854,10 @@ Methods</h4>
 		nominal range.</span>
 
 		<pre class=argumentdef for="BaseAudioContext/createBuffer()">
-		numberOfChannels: Determines how many channels the buffer will have. An
-			implementation MUST support at least 32 channels.
+		numberOfChannels: Determines how many channels the buffer will have. An implementation MUST support at least 32 channels.
 		length: Determines the size of the buffer in sample-frames.  This MUST be at
 			least 1.
-		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in
-			the buffer in sample-frames per second. An implementation MUST support
-			sample rates in at least the range 8000 to 96000.
+		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in the buffer in sample-frames per second. An implementation MUST support sample rates in at least the range 8000 to 96000.
 		</pre>
 		<div>
 			<em>Return type:</em> {{AudioBuffer}}
@@ -1935,12 +1932,9 @@ Constructors</h4>
 		were called instead.
 
 		<pre class=argumentdef for="OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)">
-		numberOfChannels: Determines how many channels the buffer will have. See
-			{{BaseAudioContext/createBuffer()}} for the supported number of channels.
+		numberOfChannels: Determines how many channels the buffer will have. See {{BaseAudioContext/createBuffer()}} for the supported number of channels.
 		length: Determines the size of the buffer in sample-frames.
-		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in
-			the buffer in sample-frames per second. See
-			{{BaseAudioContext/createBuffer()}} for valid sample rates.
+		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in the buffer in sample-frames per second. See {{BaseAudioContext/createBuffer()}} for valid sample rates.
 		</pre>
 </dl>
 


### PR DESCRIPTION
Use the workaround and make the paragraph all on one line.  This fixes
the issue.

I only looked through the Description column of parameter descriptions
for methods.  These are all I could find; there could be others or in
other places, but I didn't see any when proofreading the whole spec a
while ago.