### PR TITLE
Fix #1893: active processing for panner/convolver/merger

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6241,7 +6241,9 @@ This interface represents an {{AudioNode}} for
 combining channels from multiple audio streams into a single audio
 stream. It has a variable number of inputs (defaulting to 6), but not
 all of them need be connected. There is a single output whose audio
-stream has a number of channels equal to the number of inputs.
+stream has a number of channels equal to the number of inputs when any
+of the inputs is [=actively processing=].  If none of the inputs are 
+[=actively processing=], then output is a single channel of silence.
 
 To merge multiple inputs into one stream, each input gets downmixed
 into one channel (mono) based on the specified mixing rule. An
@@ -6761,6 +6763,10 @@ Developers desiring more complex and arbitrary matrixing can use a
 {{ChannelSplitterNode}}, multiple single-channel
 {{ConvolverNode}}s and a
 {{ChannelMergerNode}}.
+
+If this node is not [=actively processing=], the output is a single
+channel of silence, even if the diagrams below show two channels of
+output.
 
 <figure id="convolver-diagram">
 	<img alt="reverb matrixing" src="images/convolver-diagram.png">
@@ -8361,8 +8367,10 @@ channels) and cannot be increased. Connections from nodes with fewer
 or more channels will be <a href="#channel-up-mixing-and-down-mixing">up-mixed or down-mixed
 appropriately</a>.
 
-The output of this node is hard-coded to stereo (2 channels) and
-cannot be configured.
+If the node is [=actively processing=], the output of this node is
+hard-coded to stereo (2 channels) and cannot be configured.  If the node
+is not [=actively processing=], then the output is a single channel of
+silence.
 
 The {{PanningModelType}} enum determines which
 spatialization algorithm will be used to position the audio in 3D

--- a/index.bs
+++ b/index.bs
@@ -6765,8 +6765,9 @@ Developers desiring more complex and arbitrary matrixing can use a
 {{ChannelMergerNode}}.
 
 If this node is not [=actively processing=], the output is a single
-channel of silence, even if the diagrams below show two channels of
-output.
+channel of silence.
+
+Note: The diagrams below show the outputs when [=actively processing=].
 
 <figure id="convolver-diagram">
 	<img alt="reverb matrixing" src="images/convolver-diagram.png">


### PR DESCRIPTION
State that the number of chanels in the output is 1 if the node is not
actively processing any inputs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/1941.html" title="Last updated on Jun 4, 2019, 5:15 PM UTC (d073d57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1941/5fb8063...rtoy:d073d57.html" title="Last updated on Jun 4, 2019, 5:15 PM UTC (d073d57)">Diff</a>