### PR TITLE
Make AudioWorklet's output buffer available for reading

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1092,7 +1092,7 @@ Methods</h4>
 
 		Although the primary method of interfacing with this function
 		is via its promise return value, the callback parameters are
-		provided for legacy reasons. 
+		provided for legacy reasons.
 
 		<div algorithm="decodeAudioData()">
 			<span class="synchronous">When <code>decodeAudioData</code> is
@@ -1960,7 +1960,7 @@ Methods</h4>
 	: <dfn>startRendering()</dfn>
 	::
 		Given the current connections and scheduled changes, starts
-		rendering audio. 
+		rendering audio.
 
 		Although the primary method of getting the rendered audio data
 		is via its promise return value, the instance will also fire an
@@ -5941,7 +5941,7 @@ Methods</h4>
 <dl dfn-type=method dfn-for="BiquadFilterNode">
 	: <dfn>getFrequencyResponse(frequencyHz, magResponse, phaseResponse)</dfn>
 	::
-		<span class="synchronous">Given the {{[[current value]]}} 
+		<span class="synchronous">Given the {{[[current value]]}}
 		from each of the filter parameters, synchronously
 		calculates the frequency response for
 		the specified frequencies.</span> The three parameters MUST be
@@ -6236,7 +6236,7 @@ combining channels from multiple audio streams into a single audio
 stream. It has a variable number of inputs (defaulting to 6), but not
 all of them need be connected. There is a single output whose audio
 stream has a number of channels equal to the number of inputs when any
-of the inputs is [=actively processing=].  If none of the inputs are 
+of the inputs is [=actively processing=].  If none of the inputs are
 [=actively processing=], then output is a single channel of silence.
 
 To merge multiple inputs into one stream, each input gets downmixed
@@ -10751,7 +10751,7 @@ in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.
 <div class="note">
 	In practice, the {{AudioContext}} <a>rendering thread</a> is
 	often running off a system-level audio callback, that executes in
-	an isochronous fashion. 
+	an isochronous fashion.
 
 	An {{OfflineAudioContext}} is not required to have a
 	system-level audio callback, but behaves as if it did with the
@@ -10913,7 +10913,11 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 						invoke <var>processFunction</var> to
 						[=Computing a block of audio|compute a block of audio=] with the
 						argument of [=input buffer=], output buffer and
-						[=input AudioParam buffer=].
+						[=input AudioParam buffer=]. A buffer containing copies of the
+            elements of the {{Float32Array}}s passed via the
+            <a href="#dom-audioworkletprocessor-process-inputs-outputs-parameters-outputs">
+            outputs</a> parameter to <var>processFunction</var> is
+            <a href="#available-for-reading">made available for reading</a>.
 
 					1. Else if {{[[callable process]]}} is `false`,
 						<a>Queue a control message</a> to fire `onprocessorerror` event on

--- a/index.bs
+++ b/index.bs
@@ -1092,7 +1092,7 @@ Methods</h4>
 
 		Although the primary method of interfacing with this function
 		is via its promise return value, the callback parameters are
-		provided for legacy reasons.
+		provided for legacy reasons. 
 
 		<div algorithm="decodeAudioData()">
 			<span class="synchronous">When <code>decodeAudioData</code> is
@@ -1960,7 +1960,7 @@ Methods</h4>
 	: <dfn>startRendering()</dfn>
 	::
 		Given the current connections and scheduled changes, starts
-		rendering audio.
+		rendering audio. 
 
 		Although the primary method of getting the rendered audio data
 		is via its promise return value, the instance will also fire an
@@ -5941,7 +5941,7 @@ Methods</h4>
 <dl dfn-type=method dfn-for="BiquadFilterNode">
 	: <dfn>getFrequencyResponse(frequencyHz, magResponse, phaseResponse)</dfn>
 	::
-		<span class="synchronous">Given the {{[[current value]]}}
+		<span class="synchronous">Given the {{[[current value]]}} 
 		from each of the filter parameters, synchronously
 		calculates the frequency response for
 		the specified frequencies.</span> The three parameters MUST be
@@ -6236,7 +6236,7 @@ combining channels from multiple audio streams into a single audio
 stream. It has a variable number of inputs (defaulting to 6), but not
 all of them need be connected. There is a single output whose audio
 stream has a number of channels equal to the number of inputs when any
-of the inputs is [=actively processing=].  If none of the inputs are
+of the inputs is [=actively processing=].  If none of the inputs are 
 [=actively processing=], then output is a single channel of silence.
 
 To merge multiple inputs into one stream, each input gets downmixed
@@ -10751,7 +10751,7 @@ in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.
 <div class="note">
 	In practice, the {{AudioContext}} <a>rendering thread</a> is
 	often running off a system-level audio callback, that executes in
-	an isochronous fashion.
+	an isochronous fashion. 
 
 	An {{OfflineAudioContext}} is not required to have a
 	system-level audio callback, but behaves as if it did with the
@@ -10914,10 +10914,10 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 						[=Computing a block of audio|compute a block of audio=] with the
 						argument of [=input buffer=], output buffer and
 						[=input AudioParam buffer=]. A buffer containing copies of the
-            elements of the {{Float32Array}}s passed via the
-            <a href="#dom-audioworkletprocessor-process-inputs-outputs-parameters-outputs">
-            outputs</a> parameter to <var>processFunction</var> is
-            <a href="#available-for-reading">made available for reading</a>.
+            					elements of the {{Float32Array}}s passed via the
+            					<a href="#dom-audioworkletprocessor-process-inputs-outputs-parameters-outputs">
+            					outputs</a> parameter to <var>processFunction</var> is
+            					<a href="#available-for-reading">made available for reading</a>.
 
 					1. Else if {{[[callable process]]}} is `false`,
 						<a>Queue a control message</a> to fire `onprocessorerror` event on


### PR DESCRIPTION
Fixes #1932 based on @karlt's [comment](https://github.com/WebAudio/web-audio-api/issues/1932#issuecomment-499362087).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1948.html" title="Last updated on Jun 13, 2019, 5:53 PM UTC (2920865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1948/9c0e88b...hoch:2920865.html" title="Last updated on Jun 13, 2019, 5:53 PM UTC (2920865)">Diff</a>