### PR TITLE
Make the Background section of Processing model non-normative.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10601,8 +10601,10 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
 <h2 id="processing-model">
 Processing model</h2>
 
-<h3 id="processing-model-background">
+<h3 id="processing-model-background" class="non-normative">
 Background</h3>
+
+<em>This section is non-normative.</em>
 
 Real-time audio systems that require low latency are often
 implemented using <em>callback functions</em>, where the operating
@@ -10610,9 +10612,9 @@ system calls the program back when more audio has to be computed in
 order for the playback to stay uninterrupted. Such a callback is ideally called
 on a high priority thread (often the highest priority on the system).
 This means that a program that deals with audio only executes code
-from this callback, as any buffering between a rendering thread and
-the callback would naturally add latency or make the system less
-resilient to glitches.
+from this callback. Crossing thread boundaries or adding some buffering between
+a rendering thread and the callback would naturally add latency or make the
+system less resilient to glitches.
 
 For this reason, the traditional way of executing asynchronous
 operations on the Web Platform, the event loop, does not work here,


### PR DESCRIPTION
This fixes issue #1903.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1952.html" title="Last updated on Jun 25, 2019, 8:12 PM UTC (4e54798)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1952/9bf1c85...padenot:4e54798.html" title="Last updated on Jun 25, 2019, 8:12 PM UTC (4e54798)">Diff</a>