### PR TITLE
Put the example for queuing a control message next to the definition of the context

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10672,6 +10672,11 @@ thread</a>.
 means adding the message to the end of the <a>control message queue</a> of an
 {{BaseAudioContext}}.
 
+Note: For example, successfuly calling <code>start()</code> on an
+{{AudioBufferSourceNode}} <code>source</code> adds a <a>control
+message</a> to the <a href="#control-message-queue">control message
+queue</a> of the associated {{BaseAudioContext}}.
+
 <a>Control messages</a> in a <a>control message queue</a> are ordered
 by time of insertion. The <dfn>oldest message</dfn> is therefore the
 one at the front of the <a>control message queue</a>.
@@ -10692,11 +10697,6 @@ one at the front of the <a>control message queue</a>.
 
 	4. Move all the <a>control messages</a> <var>Q<sub>C</sub></var> to
 		<var>Q<sub>B</sub></var>.
-
-	Note: For example, successfuly calling <code>start()</code> on an
-	{{AudioBufferSourceNode}} <code>source</code> adds a <a>control
-	message</a> to the <a href="#control-message-queue">control message
-	queue</a> of the associated {{BaseAudioContext}}.
 </div>
 
 <h3 id="asynchronous-operations">


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1956.html" title="Last updated on Jun 26, 2019, 8:09 PM UTC (3c72fd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1956/7f11fca...padenot:3c72fd0.html" title="Last updated on Jun 26, 2019, 8:09 PM UTC (3c72fd0)">Diff</a>