### PR TITLE
Explain why the MediaStreamAudioSourceNode has a slot

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7916,6 +7916,9 @@ Constructors</h4>
 			[[mediacapture-streams#mediastream|MediaStream]] that was passed to
 			the constructor do not affect the underlying output of this {{AudioNode}}.
 
+			The slot {{}}[[input track]]}} is only used to keep a reference to the
+			[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]].
+
 			Note: This means that when removing the track chosen by the constructor
 			of the {{MediaStreamAudioSourceNode}} from the
 			[[mediacapture-streams#mediastream|MediaStream]] passed into this


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1958.html" title="Last updated on Jun 26, 2019, 8:10 PM UTC (22678e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1958/7f11fca...padenot:22678e9.html" title="Last updated on Jun 26, 2019, 8:10 PM UTC (22678e9)">Diff</a>