### PR TITLE
Consistently use 'forward' instead of 'front' when talking about vectors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5464,15 +5464,15 @@ Methods</h4>
 		thrown.</span>
 
 		{{AudioListener/setOrientation()}} describes which direction the listener is pointing in the 3D
-		cartesian coordinate space. Both a [=front=] vector and an
+		cartesian coordinate space. Both a [=forward=] vector and an
 		[=up=] vector are provided. In simple human terms, the
-		<dfn dfn>front</dfn> vector represents which direction the person's
+		<dfn dfn>forward</dfn> vector represents which direction the person's
 		nose is pointing. The <dfn dfn>up</dfn> vector represents the direction
 		the top of a person's head is pointing. These two vectors are
 		expected to be linearly independent. For normative requirements
 		of how these values are to be interpreted, see the [[#Spatialization]].
 
-		The {{AudioListener/setOrientation()/x!!argument}}, {{AudioListener/setOrientation()/y!!argument}}, and {{AudioListener/setOrientation()/z!!argument}} parameters represent a <a>front</a>
+		The {{AudioListener/setOrientation()/x!!argument}}, {{AudioListener/setOrientation()/y!!argument}}, and {{AudioListener/setOrientation()/z!!argument}} parameters represent a <a>forward</a>
 		direction vector in 3D space, with the default value being
 		(0,0,-1).
 
@@ -11382,7 +11382,7 @@ example, the sound could be omnidirectional, in which case it would
 be heard anywhere regardless of its orientation, or it can be more
 directional and heard only if it is facing the listener.
 {{AudioListener}} objects (representing a person's
-ears) have [=front|forward=] and [=up=] vectors
+ears) have [=forward=] and [=up=] vectors
 representing in which direction the person is facing.
 
 The coordinate system for spatialization is shown in the diagram
@@ -11461,7 +11461,7 @@ let frontBack = projectedSource.dot(listenerForwardNorm);
 if (frontBack < 0)
   azimuth = 360 - azimuth;
 
-// Make azimuth relative to "front" and not "right" listener vector.
+// Make azimuth relative to "forward" and not "right" listener vector.
 if ((azimuth >= 0) && (azimuth <= 270))
   azimuth = 90 - azimuth;
 else


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1960.html" title="Last updated on Jun 27, 2019, 6:00 PM UTC (d2fd3db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1960/7f11fca...padenot:d2fd3db.html" title="Last updated on Jun 27, 2019, 6:00 PM UTC (d2fd3db)">Diff</a>