### PR TITLE
Handle the exception the can be thrown when detaching an ArrayBuffer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1106,11 +1106,13 @@ Methods</h4>
 				<code>false</code>, execute the following steps:
 
 				1. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
-						the {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}. This
-						operation is described in [[!ECMASCRIPT]].
+					the {{BaseAudioContext/decodeAudioData(audioData, successCallback,
+					errorCallback)/audioData!!argument}} {{ArrayBuffer}}. This operation is
+					described in [[!ECMASCRIPT]]. If this operations throws, jump to
+					executing the errors steps in 3.
 				2. Queue a decoding operation to be performed on another thread.
 
-			3. Else, execute the following steps:
+			3. Else, execute the following error steps:
 
 				1. Let <var>error</var> be a {{DataCloneError}}.
 				2. Reject <var>promise</var> with <var>error</var>.
@@ -2428,6 +2430,10 @@ invoker.
 	2. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
 		all {{ArrayBuffer}}s for arrays previously returned by
 		{{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
+
+		Note: Because {{AudioBuffer}} can only be created via
+		{{BaseAudioContext/createBuffer()}} or via the {{AudioBuffer}} constructor, this
+		cannot throw.
 
 	3. Retain the underlying {{[[internal data]]}} from those
 		{{ArrayBuffer}}s and return references to them to the

--- a/index.bs
+++ b/index.bs
@@ -1109,7 +1109,7 @@ Methods</h4>
 					the {{BaseAudioContext/decodeAudioData(audioData, successCallback,
 					errorCallback)/audioData!!argument}} {{ArrayBuffer}}. This operation is
 					described in [[!ECMASCRIPT]]. If this operations throws, jump to
-					executing the errors steps in 3.
+					steps 3.
 				2. Queue a decoding operation to be performed on another thread.
 
 			3. Else, execute the following error steps:

--- a/index.bs
+++ b/index.bs
@@ -1109,7 +1109,7 @@ Methods</h4>
 					the {{BaseAudioContext/decodeAudioData(audioData, successCallback,
 					errorCallback)/audioData!!argument}} {{ArrayBuffer}}. This operation is
 					described in [[!ECMASCRIPT]]. If this operations throws, jump to
-					steps 3.
+					the step 3.
 				2. Queue a decoding operation to be performed on another thread.
 
 			3. Else, execute the following error steps:


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1961.html" title="Last updated on Jun 28, 2019, 5:43 PM UTC (3b96ae9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1961/7f11fca...padenot:3b96ae9.html" title="Last updated on Jun 28, 2019, 5:43 PM UTC (3b96ae9)">Diff</a>