### PR TITLE
Use iterable instead of array for `parameterDescriptors`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9735,7 +9735,7 @@ Methods</h5>
 				{{AudioWorkletGlobalScope}}.
 
 			<li> <a>Queue a task</a> to the <a>control thread</a> to add the
-				key-value pair (<em>name</em> - <em>descriptors</em>) to the
+				key-value pair (<em>name</em> - <var>parameterDescriptorSequence</var>) to the
 				<a>node name to parameter descriptor map</a> of the
 				associated {{BaseAudioContext}}.
 			</ol>

--- a/index.bs
+++ b/index.bs
@@ -9715,13 +9715,19 @@ Methods</h5>
 				P="process"))</code> is false, <span class="synchronous">throw a {{TypeError}} and abort
 				these steps</span>.
 
-			<li> Let <var>descriptors</var> be the result of <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
-				Get</a>(O=<i>processorCtor</i>,
-				P="parameterDescriptors")</code>.
-
-			<li> If <var>descriptors</var> is neither an array nor
+			<li> Let <var>parameterDescriptorsValue</var> be the result of <code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+				Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
+				If <var>parameterDescriptorsValue</var> is neither an iterable nor
 				<code>undefined</code>, <span class="synchronous">throw a
 				{{TypeError}} and abort these steps</span>.
+
+			<li> Let <var>parameterDescriptorSequence</var>,
+				which is <code>sequence&lt;AudioParamDescriptor&gt;</code>,
+				be the result of the
+				<a href="https://heycam.github.io/webidl/#create-sequence-from-iterable">conversion</a>
+				from the iterable <var>parameterDescriptorsValue</var>.
+				<span class="synchronous">Throw a {{TypeError}} and abort these steps if any exeception
+				happens during the conversion.</span>
 
 			<li> Add the key-value pair (<em>name</em> -
 				<em>processorCtor</em>) to the <a>node name to processor


### PR DESCRIPTION
Fixes #1947.

- Uses an iterable instead of array for `parameterDescriptors`.
- Uses the WebIDL pre-defined algorithm to convert an iterable to a `sequence<T>`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1992.html" title="Last updated on Jul 11, 2019, 6:04 PM UTC (fac3dc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1992/3cb5b27...hoch:fac3dc5.html" title="Last updated on Jul 11, 2019, 6:04 PM UTC (fac3dc5)">Diff</a>