### PR TITLE
Update the WebIDL interfaces for the new optional dictionnary defaulting

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4138,7 +4138,7 @@ macros:
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional AnalyserOptions options)]
+ Constructor (BaseAudioContext context, optional AnalyserOptions options = {})]
 interface AnalyserNode : AudioNode {
 	void getFloatFrequencyData (Float32Array array);
 	void getByteFrequencyData (Uint8Array array);
@@ -4594,7 +4594,7 @@ slot <dfn attribute for="AudioBufferSourceNode">[[buffer set]]</dfn>, initially 
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional AudioBufferSourceOptions options)]
+ Constructor (BaseAudioContext context, optional AudioBufferSourceOptions options = {})]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
 	attribute AudioBuffer? buffer;
 	readonly attribute AudioParam playbackRate;
@@ -5832,7 +5832,7 @@ All attributes of the {{BiquadFilterNode}} are <a>a-rate</a> {{AudioParam}}s.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional BiquadFilterOptions options)]
+ Constructor (BaseAudioContext context, optional BiquadFilterOptions options = {})]
 interface BiquadFilterNode : AudioNode {
 	attribute BiquadFilterType type;
 	readonly attribute AudioParam frequency;
@@ -6271,7 +6271,7 @@ output channels.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelMergerOptions options)]
+ Constructor (BaseAudioContext context, optional ChannelMergerOptions options = {})]
 interface ChannelMergerNode : AudioNode {
 };
 </pre>
@@ -6383,7 +6383,7 @@ desired.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelSplitterOptions options)]
+ Constructor (BaseAudioContext context, optional ChannelSplitterOptions options = {})]
 interface ChannelSplitterNode : AudioNode {
 };
 </pre>
@@ -6464,7 +6464,7 @@ macros:
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional ConstantSourceOptions options)]
+ Constructor (BaseAudioContext context, optional ConstantSourceOptions options = {})]
 interface ConstantSourceNode : AudioScheduledSourceNode {
 	readonly attribute AudioParam offset;
 };
@@ -6569,7 +6569,7 @@ input to the node is either mono or stereo.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional ConvolverOptions options)]
+ Constructor (BaseAudioContext context, optional ConvolverOptions options = {})]
 interface ConvolverNode : AudioNode {
 	attribute AudioBuffer? buffer;
 	attribute boolean normalize;
@@ -6834,7 +6834,7 @@ latency equal to the amount of the delay.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional DelayOptions options)]
+ Constructor (BaseAudioContext context, optional DelayOptions options = {})]
 interface DelayNode : AudioNode {
 	readonly attribute AudioParam delayTime;
 };
@@ -6990,7 +6990,7 @@ macros:
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional DynamicsCompressorOptions options)]
+ Constructor (BaseAudioContext context, optional DynamicsCompressorOptions options = {})]
 interface DynamicsCompressorNode : AudioNode {
 	readonly attribute AudioParam threshold;
 	readonly attribute AudioParam knee;
@@ -7440,7 +7440,7 @@ Each sample of each channel of the input data of the
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional GainOptions options)]
+ Constructor (BaseAudioContext context, optional GainOptions options = {})]
 interface GainNode : AudioNode {
 	readonly attribute AudioParam gain;
 };
@@ -7824,7 +7824,7 @@ The number of channels of the input is by default 2 (stereo).
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (AudioContext context, optional AudioNodeOptions options)]
+ Constructor (AudioContext context, optional AudioNodeOptions options = {})]
 interface MediaStreamAudioDestinationNode : AudioNode {
 	readonly attribute MediaStream stream;
 };
@@ -8133,7 +8133,7 @@ enum OscillatorType {
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional OscillatorOptions options)]
+ Constructor (BaseAudioContext context, optional OscillatorOptions options = {})]
 interface OscillatorNode : AudioScheduledSourceNode {
 	attribute OscillatorType type;
 	readonly attribute AudioParam frequency;
@@ -8501,7 +8501,7 @@ enum DistanceModelType {
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional PannerOptions options)]
+ Constructor (BaseAudioContext context, optional PannerOptions options = {})]
 interface PannerNode : AudioNode {
 	attribute PanningModelType panningModel;
 	readonly attribute AudioParam positionX;
@@ -8894,7 +8894,7 @@ up to at least 8192 elements.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional PeriodicWaveOptions options)]
+ Constructor (BaseAudioContext context, optional PeriodicWaveOptions options = {})]
 interface PeriodicWave {
 };
 </pre>
@@ -9238,7 +9238,7 @@ cannot be configured.
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional StereoPannerOptions options)]
+ Constructor (BaseAudioContext context, optional StereoPannerOptions options = {})]
 interface StereoPannerNode : AudioNode {
 	readonly attribute AudioParam pan;
 };
@@ -9368,7 +9368,7 @@ enum OverSampleType {
 
 <pre class="idl">
 [Exposed=Window,
- Constructor (BaseAudioContext context, optional WaveShaperOptions options)]
+ Constructor (BaseAudioContext context, optional WaveShaperOptions options = {})]
 interface WaveShaperNode : AudioNode {
 	attribute Float32Array? curve;
 	attribute OverSampleType oversample;
@@ -9792,7 +9792,7 @@ This interface has "entries", "forEach", "get", "has", "keys",
 [Exposed=Window,
  SecureContext,
  Constructor (BaseAudioContext context, DOMString name,
-              optional AudioWorkletNodeOptions options)]
+              optional AudioWorkletNodeOptions options = {})]
 interface AudioWorkletNode : AudioNode {
 	readonly attribute AudioParamMap parameters;
 	readonly attribute MessagePort port;
@@ -9949,7 +9949,7 @@ only be instantiated by the construction of an
 
 <pre class="idl">
 [Exposed=AudioWorklet,
-Constructor (optional AudioWorkletNodeOptions options)]
+Constructor (optional AudioWorkletNodeOptions options = {})]
 interface AudioWorkletProcessor {
 	readonly attribute MessagePort port;
 };


### PR DESCRIPTION
This was done by running:

```
sed -i 's/optional\(.*\)Options options)/optional\1Options options = {})/' index.bs
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/1993.html" title="Last updated on Jul 11, 2019, 6:16 PM UTC (9db2458)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1993/43ec51e...padenot:9db2458.html" title="Last updated on Jul 11, 2019, 6:16 PM UTC (9db2458)">Diff</a>