### PR TITLE
Remove redundant validity check in AudioWorkletNode instantiation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10264,8 +10264,7 @@ thread and the rendering thread.
 				* <var>audioParamMap</var> does not have any entry with
 					the same name member.
 
-				* <var>value</var> is not a type of <code>Number</code>
-					or out of the range specified in
+				* <var>value</var> is out of the range specified in
 					{{AudioParamDescriptor}}.
 
 		4. Set <var>node</var>'s {{AudioWorkletNode/parameters}} to <var>audioParamMap</var>.


### PR DESCRIPTION
Fixes #1972: `value` here is already an IDL type `double`, so we don't need to check its validity as a number. We only need a range check so we don't blow up the AudioParam value.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1995.html" title="Last updated on Jul 11, 2019, 9:35 PM UTC (29b99fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1995/3cb5b27...hoch:29b99fc.html" title="Last updated on Jul 11, 2019, 9:35 PM UTC (29b99fc)">Diff</a>