### PR TITLE
Add an algorithm step to convert an IDL dictionary to an ES object.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10216,51 +10216,54 @@ thread and the rendering thread.
 	1. Let <var>node</var> be the instance being created by the
 		constructor of the {{AudioWorkletNode}} or its subclass.
 
-	2. If <var>nodeName</var> does not exists as a key in the
+	1. If <var>nodeName</var> does not exists as a key in the
 		{{BaseAudioContext}}’s <a>node name to parameter descriptor
 		map</a>, throw a {{NotSupportedError}} exception and abort
 		these steps.
 
-	4. Let <var>messageChannel</var> be a new {{MessageChannel}}.
+	1. Let <var>messageChannel</var> be a new {{MessageChannel}}.
 
-	5. Let <var>nodePort</var> be the value of
+	1. Let <var>nodePort</var> be the value of
 		<var>messageChannel</var>'s {{MessageChannel/port1}} attribute.
 
-	6. Let <var>processorPortOnThisSide</var> be the value of
+	1. Let <var>processorPortOnThisSide</var> be the value of
 		<var>messageChannel</var>'s {{MessageChannel/port2}} attribute.
 
-	7. Let <var>processorPortSerialization</var> be the result of
-			[$StructuredSerializeWithTransfer$](<var>processorPortOnThisSide</var>,
-			« <var>processorPortOnThisSide</var> »).
+	1. Let <var>processorPortSerialization</var> be the result of
+		[$StructuredSerializeWithTransfer$](<var>processorPortOnThisSide</var>,
+		« <var>processorPortOnThisSide</var> »).
 
-	7. Let <var>optionsSerialization</var> be the result of
-		[$StructuredSerialize$](<var>options</var>).
+	1. <a href="https://heycam.github.io/webidl/#dictionary-to-es">Convert</a>
+		<var>options</var> dictionary to <var>optionsObject</var>.
 
-	8. Set <var>node</var>'s {{AudioWorkletNode/port}} to <var>nodePort</var>.
+	1. Let <var>optionsSerialization</var> be the result of
+		[$StructuredSerialize$](<var>optionsObject</var>).
 
-	9. Let <var>parameterDescriptors</var> be the result of retrieval
+	1. Set <var>node</var>'s {{AudioWorkletNode/port}} to <var>nodePort</var>.
+
+	1. Let <var>parameterDescriptors</var> be the result of retrieval
 		of <var>nodeName</var> from <a>node name to parameter descriptor map</a>:
 
 		1. Let <var>audioParamMap</var> be a new {{AudioParamMap}} object.
 
-		2. For each <var>descriptor</var> of <var>parameterDescriptors</var>:
+		1. For each <var>descriptor</var> of <var>parameterDescriptors</var>:
 			1. Let <var>paramName</var> be the value of
 				<var>descriptor</var>'s {{AudioParamDescriptor/name}}.
 
-			2. Let <var>audioParam</var> be a new {{AudioParam}}
+			1. Let <var>audioParam</var> be a new {{AudioParam}}
 				instance.
 
-			3. Append (<var>paramName</var>, <var>audioParam</var>) to
+			1. Append (<var>paramName</var>, <var>audioParam</var>) to
 				<var>audioParamMap</var>'s entries.
 
-		3. For each key-value pair (<var>paramNameInOption</var> to
+		1. For each key-value pair (<var>paramNameInOption</var> to
 			<var>value</var>) of <var>options</var>:
 			1. If there exists an entry with name member equal to
 				<var>paramNameInOption</var> inside
 				<var>audioParamMap</var>, set that {{AudioParam}}'s
 				value to <var>value</var>.
 
-			2. <var>paramNameInOption</var> will be ignored when:
+			1. <var>paramNameInOption</var> will be ignored when:
 				* <var>audioParamMap</var> does not have any entry with
 					the same name member.
 
@@ -10268,13 +10271,13 @@ thread and the rendering thread.
 					or out of the range specified in
 					{{AudioParamDescriptor}}.
 
-		4. Set <var>node</var>'s {{AudioWorkletNode/parameters}} to <var>audioParamMap</var>.
+		1. Set <var>node</var>'s {{AudioWorkletNode/parameters}} to <var>audioParamMap</var>.
 
-	10. <a>Queue a control message</a> to create an
+	1. <a>Queue a control message</a> to create an
 		{{AudioWorkletProcessor}}, given the <var>nodeName</var>,
 		<var>processorPortSerialization</var>, <var>optionsSerialization</var>,  and <var>node</var>.
 
-	11. Return <var>node</var>.
+	1. Return <var>node</var>.
 </div>
 
 <div algorithm="process control message">


### PR DESCRIPTION
Fixes #1971.

This uses the option 2/3 to clarify the object conversion process.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/1996.html" title="Last updated on Jul 12, 2019, 3:47 PM UTC (0b5568f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1996/3cb5b27...hoch:0b5568f.html" title="Last updated on Jul 12, 2019, 3:47 PM UTC (0b5568f)">Diff</a>