### PR TITLE
Replace `var` to `const` or `let` in sample code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -333,10 +333,10 @@ containing a single {{AudioDestinationNode}}:
 Illustrating this simple routing, here's a simple example playing a single sound:
 
 <pre class="example" highlight="js">
-var context = new AudioContext();
+const context = new AudioContext();
 
 function playSound() {
-	var source = context.createBufferSource();
+	const source = context.createBufferSource();
 	source.buffer = dogBarkingBuffer;
 	source.connect(context.destination);
 	source.start(0);
@@ -354,28 +354,28 @@ reverb send with a dynamics compressor at the final output stage:
 </figure>
 
 <pre class="example" highlight="js" line-numbers>
-var context = 0;
-var compressor = 0;
-var reverb = 0;
+const context = 0;
+const compressor = 0;
+const reverb = 0;
 
-var source1 = 0;
-var source2 = 0;
-var source3 = 0;
+const source1 = 0;
+const source2 = 0;
+const source3 = 0;
 
-var lowpassFilter = 0;
-var waveShaper = 0;
-var panner = 0;
+const lowpassFilter = 0;
+const waveShaper = 0;
+const panner = 0;
 
-var dry1 = 0;
-var dry2 = 0;
-var dry3 = 0;
+const dry1 = 0;
+const dry2 = 0;
+const dry3 = 0;
 
-var wet1 = 0;
-var wet2 = 0;
-var wet3 = 0;
+const wet1 = 0;
+const wet2 = 0;
+const wet3 = 0;
 
-var masterDry = 0;
-var masterWet = 0;
+const masterDry = 0;
+const masterWet = 0;
 
 function setupRoutingGraph () {
 	context = new AudioContext();
@@ -462,18 +462,18 @@ input signal.
 
 <pre class="example" highlight="js" line-numbers>
 function setupRoutingGraph() {
-	var context = new AudioContext();
+	const context = new AudioContext();
 
 	// Create the low frequency oscillator that supplies the modulation signal
-	var lfo = context.createOscillator();
+	const lfo = context.createOscillator();
 	lfo.frequency.value = 1.0;
 
 	// Create the high frequency oscillator to be modulated
-	var hfo = context.createOscillator();
+	const hfo = context.createOscillator();
 	hfo.frequency.value = 440.0;
 
 	// Create a gain node whose gain determines the amplitude of the modulation signal
-	var modulationGain = context.createGain();
+	const modulationGain = context.createGain();
 	modulationGain.gain.value = 50;
 
 	// Configure the graph and start the oscillators
@@ -1606,8 +1606,8 @@ Methods</h4>
 
 			<pre highlight="js">
 				function outputPerformanceTime(contextTime) {
-					var timestamp = context.getOutputTimestamp();
-					var elapsedTime = contextTime - timestamp.contextTime;
+					const timestamp = context.getOutputTimestamp();
+					const elapsedTime = contextTime - timestamp.contextTime;
 					return timestamp.performanceTime + elapsedTime * 1000;
 				}
 			</pre>
@@ -3925,21 +3925,21 @@ http://googlechrome.github.io/web-audio-samples/samples/audio/timeline.html -->
 	</figcaption>
 </figure>
 <pre class="example" highlight="js" line-numbers>
-	var curveLength = 44100;
-	var curve = new Float32Array(curveLength);
-	for (var i = 0; i &lt; curveLength; ++i)
+	const curveLength = 44100;
+	const curve = new Float32Array(curveLength);
+	for (const i = 0; i &lt; curveLength; ++i)
 		curve[i] = Math.sin(Math.PI * i / curveLength);
 
-	var t0 = 0;
-	var t1 = 0.1;
-	var t2 = 0.2;
-	var t3 = 0.3;
-	var t4 = 0.325;
-	var t5 = 0.5;
-	var t6 = 0.6;
-	var t7 = 0.7;
-	var t8 = 1.0;
-	var timeConstant = 0.1;
+	const t0 = 0;
+	const t1 = 0.1;
+	const t2 = 0.2;
+	const t3 = 0.3;
+	const t4 = 0.325;
+	const t5 = 0.5;
+	const t6 = 0.6;
+	const t7 = 0.7;
+	const t8 = 1.0;
+	const timeConstant = 0.1;
 
 	param.setValueAtTime(0.2, t0);
 	param.setValueAtTime(0.3, t1);
@@ -4976,10 +4976,10 @@ function playbackSignal(position) {
 // of |numberOfFrames| sample frames to be output.
 function process(numberOfFrames) {
 	let currentTime = context.currentTime; // context time of next rendered frame
-	let output = []; // accumulates rendered sample frames
+	const output = []; // accumulates rendered sample frames
 
 	// Combine the two k-rate parameters affecting playback rate
-	let computedPlaybackRate = playbackRate * Math.pow(2, detune / 1200);
+	const computedPlaybackRate = playbackRate * Math.pow(2, detune / 1200);
 
 	// Determine loop endpoints as applicable
 	let actualLoopStart, actualLoopEnd;
@@ -6663,22 +6663,22 @@ Attributes</h4>
 
 		<pre highlight="js" line-numbers>
 		function calculateNormalizationScale(buffer) {
-			var GainCalibration = 0.00125;
-			var GainCalibrationSampleRate = 44100;
-			var MinPower = 0.000125;
+			const GainCalibration = 0.00125;
+			const GainCalibrationSampleRate = 44100;
+			const MinPower = 0.000125;
 
 			// Normalize by RMS power.
-			var numberOfChannels = buffer.numberOfChannels;
-			var length = buffer.length;
+			const numberOfChannels = buffer.numberOfChannels;
+			const length = buffer.length;
 
-			var power = 0;
+			let power = 0;
 
-			for (var i = 0; i &lt; numberOfChannels; i++) {
-				var channelPower = 0;
-				var channelData = buffer.getChannelData(i);
+			for (let i = 0; i &lt; numberOfChannels; i++) {
+				let channelPower = 0;
+				const channelData = buffer.getChannelData(i);
 
-				for (var j = 0; j &lt; length; j++) {
-					var sample = channelData[j];
+				for (let j = 0; j &lt; length; j++) {
+					const sample = channelData[j];
 					channelPower += sample * sample;
 				}
 
@@ -6691,7 +6691,7 @@ Attributes</h4>
 			if (!isFinite(power) || isNaN(power) || power &lt; MinPower)
 				power = MinPower;
 
-			var scale = 1 / power;
+			let scale = 1 / power;
 
 			// Calibrate to make perceived volume same as unprocessed.
 			scale *= GainCalibration;
@@ -7198,9 +7198,9 @@ special object that behaves like an {{AudioNode}}, described
 below:
 
 <pre>
-	var delay = new DelayNode(context, {delayTime: 0.006});
-	var gain = new GainNode(context);
-	var compression = new EnvelopeFollower();
+	const delay = new DelayNode(context, {delayTime: 0.006});
+	const gain = new GainNode(context);
+	const compression = new EnvelopeFollower();
 
 	input.connect(delay).connect(gain).connect(output);
 	input.connect(compression).connect(gain.gain);
@@ -7711,8 +7711,8 @@ attribute changes, and other aspects of the
 <em>not</em> used with a {{MediaElementAudioSourceNode}}.
 
 <pre class="example" highlight="js">
-	var mediaElement = document.getElementById('mediaElementID');
-	var sourceNode = context.createMediaElementSource(mediaElement);
+	const mediaElement = document.getElementById('mediaElementID');
+	const sourceNode = context.createMediaElementSource(mediaElement);
 	sourceNode.connect(filterNode);
 </pre>
 
@@ -9578,8 +9578,8 @@ instances created from the constructor.
 class BypassProcessor extends AudioWorkletProcessor {
 	process (inputs, outputs) {
 		// Single input, single channel.
-		let input = inputs[0];
-		let output = outputs[0];
+		const input = inputs[0];
+		const output = outputs[0];
 		output[0].set(input[0]);
 
 		// Process only while there are inputs.
@@ -9592,9 +9592,9 @@ registerProcessor('bypass-processor', BypassProcessor);
 
 <pre class="example" highlight="js" title="Importing a script and creating AudioWorkletNode">
 // The main global scope
-let context = new AudioContext();
+const context = new AudioContext();
 context.audioWorklet.addModule('bypass-processor.js').then(() =&gt; {
-	let bypassNode = new AudioWorkletNode(context, 'bypass-processor');
+	const bypassNode = new AudioWorkletNode(context, 'bypass-processor');
 });
 </pre>
 
@@ -10122,9 +10122,9 @@ class MyProcessor extends AudioWorkletProcessor {
 
   process(inputs, outputs, parameters) {
     // Get the first input and output.
-    let input = inputs[0];
-    let output = outputs[0];
-    let myParam = parameters.myParam;
+    const input = inputs[0];
+    const output = outputs[0];
+    const myParam = parameters.myParam;
 
     // A simple amplifier for single input and output. Note that the
     // automationRate is "k-rate", so it will have a single value at index [0]
@@ -10377,16 +10377,16 @@ a lower bit-depth), and by quantizing in time resolution
 {{AudioWorkletProcessor}}.
 
 <pre line-numbers class="example" highlight="js" title="BitCrusher - Global Scope">
-let context = new AudioContext();
+const context = new AudioContext();
 context.audioWorklet.addModule('bitcrusher.js').then(() =&gt; {
-	let osc = new OscillatorNode(context);
-	let amp = new GainNode(context);
+	const osc = new OscillatorNode(context);
+	const amp = new GainNode(context);
 
 	// Create a worklet node. 'BitCrusher' identifies the
 	// AudioWorkletProcessor previously registered when
 	// bitcrusher.js was imported. The options automatically
 	// initialize the correspondingly named AudioParams.
-	let bitcrusher = new AudioWorkletNode(context, 'BitCrusher', {
+	const bitcrusher = new AudioWorkletNode(context, 'BitCrusher', {
 		bitDepth: 8,
 		frequencyReduction: 0.5
 	});
@@ -10528,8 +10528,8 @@ class VUMeterNode extends AudioWorkletNode {
 }
 
 // The application can use the node when this promise resolves.
-let context = new AudioContext();
-let importAudioWorkletNode = context.audioWorklet.addModule('vumeterprocessor.js');
+const context = new AudioContext();
+const importAudioWorkletNode = context.audioWorklet.addModule('vumeterprocessor.js');
 </pre>
 
 <pre line-numbers class="example" highlight="js" title="VUMeterNode - AudioWorkletGlobalScope (vumeterprocessor.js)">
@@ -10594,8 +10594,8 @@ registerProcessor('VUMeter', class extends AudioWorkletProcessor {
 &lt;script src="vumeternode.js">&lt;/script>
 &lt;script>
 	importAudioWorkletNode.then(() =&gt; {
-		let oscillator = new OscillatorNode(context);
-		let vuMeterNode = new VUMeterNode(context, { updatingInterval: 50 });
+		const oscillator = new OscillatorNode(context);
+		const vuMeterNode = new VUMeterNode(context, { updatingInterval: 50 });
 
 		oscillator.connect(vuMeterNode);
 
@@ -11056,10 +11056,10 @@ and will remain connected until it is explicitly disconnected. Here's
 how it might look in JavaScript:
 
 <pre line-numbers class="example" highlight="js">
-var context = 0;
-var compressor = 0;
-var gainNode1 = 0;
-var streamingAudioSource = 0;
+let context = 0;
+let compressor = 0;
+let gainNode1 = 0;
+let streamingAudioSource = 0;
 
 // Initial setup of the "long-lived" part of the routing graph
 function setupAudioContext() {
@@ -11069,7 +11069,7 @@ function setupAudioContext() {
 		gainNode1 = context.createGain();
 
 		// Create a streaming audio source.
-		var audioElement = document.getElementById('audioTagID');
+		const audioElement = document.getElementById('audioTagID');
 		streamingAudioSource = context.createMediaElementSource(audioElement);
 		streamingAudioSource.connect(gainNode1);
 
@@ -11080,13 +11080,13 @@ function setupAudioContext() {
 // Later in response to some user action (typically mouse or key event)
 // a one-shot sound can be played.
 function playSound() {
-		var oneShotSound = context.createBufferSource();
+		const oneShotSound = context.createBufferSource();
 		oneShotSound.buffer = dogBarkingBuffer;
 
 		// Create a filter, panner, and gain node.
-		var lowpass = context.createBiquadFilter();
-		var panner = context.createPanner();
-		var gainNode2 = context.createGain();
+		const lowpass = context.createBiquadFilter();
+		const panner = context.createPanner();
+		const gainNode2 = context.createGain();
 
 		// Make connections
 		oneShotSound.connect(lowpass);
@@ -11429,13 +11429,13 @@ The following algorithm MUST be used to calculate the
 // PannerNode created in |context|.
 
 // Calculate the source-listener vector.
-let listener = context.listener;
-let sourcePosition = new Vec3(panner.positionX.value, panner.positionY.value,
+const listener = context.listener;
+const sourcePosition = new Vec3(panner.positionX.value, panner.positionY.value,
                               panner.positionZ.value);
-let listenerPosition =
+const listenerPosition =
     new Vec3(listener.positionX.value, listener.positionY.value,
              listener.positionZ.value);
-let sourceListener = sourcePosition.diff(listenerPosition).normalize();
+const sourceListener = sourcePosition.diff(listenerPosition).normalize();
 
 if (sourceListener.magnitude == 0) {
   // Handle degenerate case if source and listener are at the same point.
@@ -11445,11 +11445,11 @@ if (sourceListener.magnitude == 0) {
 }
 
 // Align axes.
-let listenerForward = new Vec3(listener.forwardX.value, listener.forwardY.value,
+const listenerForward = new Vec3(listener.forwardX.value, listener.forwardY.value,
                                listener.forwardZ.value);
-let listenerUp =
+const listenerUp =
     new Vec3(listener.upX.value, listener.upY.value, listener.upZ.value);
-let listenerRight = listenerForward.cross(listenerUp);
+const listenerRight = listenerForward.cross(listenerUp);
 
 if (listenerRight.magnitude == 0) {
   // Handle the case where listener's 'up' and 'forward' vectors are linearly
@@ -11460,17 +11460,17 @@ if (listenerRight.magnitude == 0) {
 }
 
 // Determine a unit vector orthogonal to listener's right, forward
-let listenerRightNorm = listenerRight.normalize();
-let listenerForwardNorm = listenerForward.normalize();
-let up = listenerRightNorm.cross(listenerForwardNorm);
+const listenerRightNorm = listenerRight.normalize();
+const listenerForwardNorm = listenerForward.normalize();
+const up = listenerRightNorm.cross(listenerForwardNorm);
 
-let upProjection = sourceListener.dot(up);
-let projectedSource = sourceListener.diff(up.scale(upProjection)).normalize();
+const upProjection = sourceListener.dot(up);
+const projectedSource = sourceListener.diff(up.scale(upProjection)).normalize();
 
 azimuth = 180 * Math.acos(projectedSource.dot(listenerRightNorm)) / Math.PI;
 
 // Source in front or behind the listener.
-let frontBack = projectedSource.dot(listenerForwardNorm);
+const frontBack = projectedSource.dot(listenerForwardNorm);
 if (frontBack &lt; 0)
   azimuth = 360 - azimuth;
 
@@ -11682,10 +11682,10 @@ based on the panner and listener positions according to:
 
 <xmp highlight="js" line-numbers>
 function distance(panner) {
-  let pannerPosition = new Vec3(panner.positionX.value, panner.positionY.value,
+  const pannerPosition = new Vec3(panner.positionX.value, panner.positionY.value,
                                 panner.positionZ.value);
-  let listener = context.listener;
-  let listenerPosition =
+  const listener = context.listener;
+  const listenerPosition =
       new Vec3(listener.positionX.value, listener.positionY.value,
                listener.positionZ.value);
   return pannerPosition.diff(listenerPosition).magnitude;
@@ -11733,31 +11733,31 @@ contribution due to the cone effect, given the source (the
 
 <xmp highlight="js" line-numbers>
 function coneGain() {
-  let sourceOrientation =
+  const sourceOrientation =
       new Vec3(source.orientationX, source.orientationY, source.orientationZ);
   if (sourceOrientation.magnitude == 0 ||
       ((source.coneInnerAngle == 360) &amp;&amp; (source.coneOuterAngle == 360)))
     return 1; // no cone specified - unity gain
 
   // Normalized source-listener vector
-  let sourcePosition = new Vec3(panner.positionX.value, panner.positionY.value,
+  const sourcePosition = new Vec3(panner.positionX.value, panner.positionY.value,
                                 panner.positionZ.value);
-  let listenerPosition =
+  const listenerPosition =
       new Vec3(listener.positionX.value, listener.positionY.value,
                listener.positionZ.value);
-  let sourceToListener = sourcePosition.diff(listenerPosition).normalize();
+  const sourceToListener = sourcePosition.diff(listenerPosition).normalize();
 
-  let normalizedSourceOrientation = sourceOrientation.normalize();
+  const normalizedSourceOrientation = sourceOrientation.normalize();
 
   // Angle between the source orientation vector and the source-listener vector
-  let angle = 180 *
+  const angle = 180 *
               Math.acos(sourceToListener.dot(normalizedSourceOrientation)) /
               Math.PI;
-  let absAngle = Math.abs(angle);
+  const absAngle = Math.abs(angle);
 
   // Divide by 2 here since API is entire angle (not half-angle)
-  let absInnerAngle = Math.abs(source.coneInnerAngle) / 2;
-  let absOuterAngle = Math.abs(source.coneOuterAngle) / 2;
+  const absInnerAngle = Math.abs(source.coneInnerAngle) / 2;
+  const absOuterAngle = Math.abs(source.coneOuterAngle) / 2;
   let gain = 1;
 
   if (absAngle &lt;= absInnerAngle) {
@@ -11769,7 +11769,7 @@ function coneGain() {
   } else {
     // Between inner and outer cones
     // inner -&gt; outer, x goes from 0 -&gt; 1
-    var x = (absAngle - absInnerAngle) / (absOuterAngle - absInnerAngle);
+    const x = (absAngle - absInnerAngle) / (absOuterAngle - absInnerAngle);
     gain = (1 - x) + source.coneOuterGain * x;
   }
 
@@ -12138,7 +12138,7 @@ class Vec3 {
 
 	// Get a normalized copy of this vector.
 	normalize() {
-		let m = magnitude;
+		const m = magnitude;
 		if (m == 0) {
 			return new Vec3(0, 0, 0);
 		}


### PR DESCRIPTION
The modern browsers that can use Web Audio API can also use `const` or `let`.
Therefore, legacy code like `var` avoid as much as possible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Korilakkuma/web-audio-api-1/pull/1999.html" title="Last updated on Jul 17, 2019, 11:16 PM UTC (b295e13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/1999/b45b2a7...Korilakkuma:b295e13.html" title="Last updated on Jul 17, 2019, 11:16 PM UTC (b295e13)">Diff</a>