### PR TITLE
Revise the initialization of AudioWorkletProcessor.port

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10320,7 +10320,7 @@ thread and the rendering thread.
 			1. Set {{AudioWorkletProcessor/port}} field to
 				<var>processorPort</var>.
 
-			1. Set {{[[node reference]}} to <var>node</var>.
+			1. Set {{[[node reference]]}} to <var>node</var>.
 
 			1. Set {{[[callable process]]}} to `true`.
 

--- a/index.bs
+++ b/index.bs
@@ -10320,7 +10320,7 @@ thread and the rendering thread.
 			1. Set {{AudioWorkletProcessor/port}} field to
 				<var>processorPort</var>.
 
-			1. Set {{[[node reference}} to <var>node</var>.
+			1. Set {{[[node reference]}} to <var>node</var>.
 
 			1. Set {{[[callable process]]}} to `true`.
 

--- a/index.bs
+++ b/index.bs
@@ -10315,7 +10315,7 @@ thread and the rendering thread.
 	1. Perform Construct(<var>processorCtor</var>, « <var>options</var> »).
 
 		1. During the execution of the AudioWorkletProcessor super class
-		constructor, perform the followings:
+			constructor, perform the followings:
 
 			1. Set {{AudioWorkletProcessor/port}} field to
 				<var>processorPort</var>.

--- a/index.bs
+++ b/index.bs
@@ -10290,11 +10290,12 @@ thread and the rendering thread.
 	{{AudioWorkletProcessor}}, given a string <var>nodeName</var>, a
 	serialization record <var>processorPortSerialization</var>, and an
 	{{AudioWorkletNode}} <var>node</var>, perform the following
-	steps on the <a>rendering thread</a>. If any of these steps throws
-	an exception (either explicitly or implicitly), abort the rest of
-	steps and <a>queue a task</a> on the <a>control thread</a> to fire
-	{{AudioWorkletNode/onprocessorerror}} event to
-	<var>node</var>.
+	steps on the <a>rendering thread</a>.
+
+	If any of these steps throws an exception (either explicitly or
+	implicitly), abort the rest of steps and <a>queue a task</a> on the
+	<a>control thread</a> to fire {{AudioWorkletNode/onprocessorerror}}
+	event to <var>node</var>.
 
 	1. Let <var>processorPort</var> be
 		[$StructuredDeserializeWithTransfer$](<var>processorPortSerialization</var>,
@@ -10311,13 +10312,19 @@ thread and the rendering thread.
 	1. Let <var>processor</var> be the result of
 		Construct(<var>processorCtor</var>, « <var>options</var> »).
 
-	1. Set <var>processor</var>'s {{AudioWorkletProcessor/port}} to
-		<var>processorPort</var>.
+	1. Perform Construct(<var>processorCtor</var>, « <var>options</var> »).
 
-	1. Set <var>processor</var>'s {{[[node reference]]}}to
-		<var>node</var>.
+		1. During the execution of the AudioWorkletProcessor super class
+		constructor, perform the followings:
 
-	1. Set {{[[callable process]]}} to `true`.
+			1. Set {{AudioWorkletProcessor/port}} field to
+				<var>processorPort</var>.
+
+			1. Set {{[[node reference}} to <var>node</var>.
+
+			1. Set {{[[callable process]]}} to `true`.
+
+		1. Let <var>processor</var> be the result of the construction.
 
 	1. Set <var>node</var>'s <a>processor reference</a> to
 		<var>processor</var>.


### PR DESCRIPTION
Fixes #1973.

Break down the processor constructor into two parts:
  1. Describe some implicit initialization in super() constructor. (port, node reference and etc)
  2. Then invoke the user-supplied constructor if it exists.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2000.html" title="Last updated on Jul 17, 2019, 6:22 PM UTC (73c367b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2000/b45b2a7...hoch:73c367b.html" title="Last updated on Jul 17, 2019, 6:22 PM UTC (73c367b)">Diff</a>