### PR TITLE
Use ErrorEvent against AudioWorkletNode.onprocessorerror

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9837,7 +9837,7 @@ Attributes</h5>
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
 		<a>queue a task</a> to fire an
-		<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
+		<a href="https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface">
 		ErrorEvent</a> to the associated {{AudioWorkletNode}}.
 
 		The <code>ErrorEvent</code> is created and initialized

--- a/index.bs
+++ b/index.bs
@@ -9833,7 +9833,7 @@ Attributes</h5>
 <dl dfn-type=attribute dfn-for="AudioWorkletNode">
 	: <dfn>onprocessorerror</dfn>
 	::
-		When an exception is thrown from the processor's
+		When an unhandled exception is thrown from the processor's
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
 		<a>queue a task</a> to fire an

--- a/index.bs
+++ b/index.bs
@@ -9836,10 +9836,17 @@ Attributes</h5>
 		When an exception is thrown from the processor's
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
-		<a>queue a task</a> on the control thread to fire
-		{{onprocessorerror}} event to the node. Note that
-		once an exception is thrown, the processor will output
-		silence throughout its lifetime.
+		<a>queue a task</a> to fire an
+		<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
+		ErrorEvent</a> to the associated {{AudioWorkletNode}}.
+
+		The <code>ErrorEvent</code> is created and initialized
+		appropriately with its <code>message</code>,
+		<code>filename</code>, <code>lineno</code>, <code>colno</code>
+		attributes on the control thread.
+
+		Note that once a unhandled exception is thrown, the processor
+		will output silence throughout its lifetime.
 
 	: <dfn>parameters</dfn>
 	::


### PR DESCRIPTION
Fixes #1984 based on https://github.com/WebAudio/web-audio-api/issues/1984#issuecomment-512516835.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2003.html" title="Last updated on Jul 19, 2019, 3:55 PM UTC (19cb50c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2003/06882c0...hoch:19cb50c.html" title="Last updated on Jul 19, 2019, 3:55 PM UTC (19cb50c)">Diff</a>