### PR TITLE
Fix #1884: No errors from copyFromChannel/copyToChannel

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2263,8 +2263,8 @@ interface AudioBuffer {
 	readonly attribute double duration;
 	readonly attribute unsigned long numberOfChannels;
 	Float32Array getChannelData (unsigned long channel);
-	void copyFromChannel (Float32Array destination, unsigned long channelNumber, optional unsigned long startInChannel = 0);
-	void copyToChannel (Float32Array source, unsigned long channelNumber, optional unsigned long startInChannel = 0);
+	void copyFromChannel (Float32Array destination, unsigned long channelNumber, optional unsigned long bufferOffset = 0);
+	void copyToChannel (Float32Array source, unsigned long channelNumber, optional unsigned long bufferOffset = 0);
 };
 </pre>
 
@@ -2329,7 +2329,7 @@ Attributes</h4>
 Methods</h4>
 
 <dl dfn-type=method dfn-for="AudioBuffer">
-	: <dfn>copyFromChannel(destination, channelNumber, startInChannel)</dfn>
+	: <dfn>copyFromChannel(destination, channelNumber, bufferOffset)</dfn>
 	::
 		The {{AudioBuffer/copyFromChannel()}} method copies the samples from
 		the specified channel of the {{AudioBuffer}} to the
@@ -2338,23 +2338,23 @@ Methods</h4>
 		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		{{AudioBuffer/copyFromChannel()/destination}} array, and \(k\) be the value of
-		{{AudioBuffer/copyFromChannel()/startInChannel}}. Then the number of frames copied
+		{{AudioBuffer/copyFromChannel()/bufferOffset}}. Then the number of frames copied
 		from <code>buffer</code> to {{AudioBuffer/copyFromChannel()/destination}} is
-		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
+		\(\max(0, \min(N_b - k, N_f))\). If this is less than \(N_f\), then the
 		remaining elements of {{AudioBuffer/copyFromChannel()/destination}} are not
 		modified.
 
 		<pre class=argumentdef for="AudioBuffer/copyFromChannel()">
 		destination: The array the channel data will be copied to.
 		channelNumber: The index of the channel to copy the data from. If <code>channelNumber</code> is greater or equal than the number of channels of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
-		startInChannel: An optional offset to copy the data from. If <code>startInChannel</code> is greater than the <code>length</code> of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
+		bufferOffset: An optional offset in to the {{AudioBuffer}} to copy the data from.
 		</pre>
 
 		<div>
 			<em>Return type:</em> <code>void</code>
 		</div>
 
-	: <dfn>copyToChannel(source, channelNumber, startInChannel)</dfn>
+	: <dfn>copyToChannel(source, channelNumber, bufferOffset)</dfn>
 	::
 		The {{AudioBuffer/copyToChannel()}} method copies the samples to
 		the specified channel of the {{AudioBuffer}} from the
@@ -2367,16 +2367,16 @@ Methods</h4>
 		Let <code>buffer</code> be the {{AudioBuffer}} with
 		\(N_b\) frames, let \(N_f\) be the number of elements in the
 		{{AudioBuffer/copyToChannel()/source}} array, and \(k\) be the value of
-		{{AudioBuffer/copyToChannel()/startInChannel}}. Then the number of frames copied
+		{{AudioBuffer/copyToChannel()/bufferOffset}}. Then the number of frames copied
 		from {{AudioBuffer/copyToChannel()/source}} to the <code>buffer</code> is
-		\(\min(N_b - k, N_f)\). If this is less than \(N_f\), then the
+		\(\max(0, \min(N_b - k, N_f))\). If this is less than \(N_f\), then the
 		remaining elements of <code>buffer</code> are not
 		modified.
 
 		<pre class=argumentdef for="AudioBuffer/copyToChannel()">
 		source: The array the channel data will be copied from.
 		channelNumber: The index of the channel to copy the data to. If <code>channelNumber</code> is greater or equal than the number of channels of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
-		startInChannel: An optional offset to copy the data to. If <code>startInChannel</code> is greater than the <code>length</code> of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
+		bufferOffset: An optional offset in to the {{AudioBuffer}} to copy the data to.
 		</pre>
 
 		<div>

--- a/index.bs
+++ b/index.bs
@@ -2347,7 +2347,7 @@ Methods</h4>
 		<pre class=argumentdef for="AudioBuffer/copyFromChannel()">
 		destination: The array the channel data will be copied to.
 		channelNumber: The index of the channel to copy the data from. If <code>channelNumber</code> is greater or equal than the number of channels of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
-		bufferOffset: An optional offset in to the {{AudioBuffer}} to copy the data from.
+		bufferOffset: An optional offset, defaulting to 0.  Data from the {{AudioBuffer}} starting at this offset is copied to the {{AudioBuffer/copyFromChannel()/destination}}.
 		</pre>
 
 		<div>
@@ -2376,7 +2376,7 @@ Methods</h4>
 		<pre class=argumentdef for="AudioBuffer/copyToChannel()">
 		source: The array the channel data will be copied from.
 		channelNumber: The index of the channel to copy the data to. If <code>channelNumber</code> is greater or equal than the number of channels of the {{AudioBuffer}}, <span class="synchronous">an {{IndexSizeError}} MUST be thrown</span>.
-		bufferOffset: An optional offset in to the {{AudioBuffer}} to copy the data to.
+		bufferOffset: An optional offset, defaulting to 0.  Data from the {{AudioBuffer/copyToChannel()/source}} is copied to the {{AudioBuffer}} starting at this offset.
 		</pre>
 
 		<div>


### PR DESCRIPTION
No errors are thrown in copyFromChannel/copyToChannel if the index
lies outside the `AudioBuffer`.  In this case, nothing is copied.

Also renamed `startInChannel` to `bufferOffset`. Hopefully that's
clearer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2010.html" title="Last updated on Jul 24, 2019, 7:56 PM UTC (9e80549)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2010/31a8116...rtoy:9e80549.html" title="Last updated on Jul 24, 2019, 7:56 PM UTC (9e80549)">Diff</a>