### PR TITLE
Remove 'nullalble' type and default 'null' value from AudioWorkletNodeOptions.processorOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9951,6 +9951,7 @@ Dictionary {{AudioWorkletNodeOptions}} Members</h6>
 		{{AudioWorkletNode}}. If the string key of an entry in the
 		list does not match the name of any {{AudioParam}} objects in
 		the node, it is ignored.
+
 	: <dfn>processorOptions</dfn>
 	::
 		This holds any additional user-defined data that may be used to

--- a/index.bs
+++ b/index.bs
@@ -9913,7 +9913,7 @@ dictionary AudioWorkletNodeOptions : AudioNodeOptions {
 	unsigned long numberOfOutputs = 1;
 	sequence<unsigned long> outputChannelCount;
 	record<DOMString, double> parameterData;
-	object? processorOptions = null;
+	object processorOptions;
 };
 </xmp>
 
@@ -9953,7 +9953,9 @@ Dictionary {{AudioWorkletNodeOptions}} Members</h6>
 		the node, it is ignored.
 	: <dfn>processorOptions</dfn>
 	::
-		 This holds any additional user-defined data that may be used to initialize the corresponding {{AudioWorkletProcessor}} for this {{AudioWorkletNode}}.
+		This holds any additional user-defined data that may be used to
+		initialize the corresponding {{AudioWorkletProcessor}} for this
+		{{AudioWorkletNode}}.
 </dl>
 
 <h6 id="configuring-channels-with-audioworkletnodeoptions">


### PR DESCRIPTION
Fixes #2011, plus minor clean up.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2013.html" title="Last updated on Jul 25, 2019, 10:46 PM UTC (4d83069)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2013/31a8116...hoch:4d83069.html" title="Last updated on Jul 25, 2019, 10:46 PM UTC (4d83069)">Diff</a>