### PR TITLE
Fix #2001: Put back links to tail-time

### DIFF
--- a/audionode.include
+++ b/audionode.include
@@ -27,7 +27,7 @@
 			<td>"{{ChannelInterpretation/[CC-INTERP]}}"
 			<td>[CC-INTERP-NOTES?]
 		<tr>
-			<td>tail-time
+			<td><a>tail-time</a>
 			<td>[TAIL-TIME]
 			<td>[TAIL-TIME-NOTES?]
 </table>


### PR DESCRIPTION
The link to tail-time in the audio node description block was
removed. Put back the link.