### PR TITLE
Fix #2007: Fix typo in MediaStreamAudioSourceNode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7925,7 +7925,7 @@ Constructors</h4>
 			[[mediacapture-streams#mediastream|MediaStream]] that was passed to
 			the constructor do not affect the underlying output of this {{AudioNode}}.
 
-			The slot {{}}[[input track]]}} is only used to keep a reference to the
+			The slot {{[[input track]]}} is only used to keep a reference to the
 			[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]].
 
 			Note: This means that when removing the track chosen by the constructor


### PR DESCRIPTION
Remove the extraneous `{{}}`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2015.html" title="Last updated on Jul 29, 2019, 3:31 PM UTC (71aadbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2015/20afa4e...rtoy:71aadbf.html" title="Last updated on Jul 29, 2019, 3:31 PM UTC (71aadbf)">Diff</a>