### PR TITLE
Clarify `parameters` argument in AudioWorkletProcessor.process()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10181,7 +10181,7 @@ in the node.
 				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
-				An [[infra#ordered-map|ordered map]] of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>name</var> {{AudioParam}}.
+				An <a spec="infra" lt="map">ordered map</a> of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>name</var> {{AudioParam}}.
 
 				For each array, the array contains the [=computedValue=] of the parameter for all frames in the [=render quantum=]. However, if no automation is scheduled during this render quantum, the array MAY have length 1 with the array element being the constant value of the {{AudioParam}} for the [=render quantum=].
 		</pre>

--- a/index.bs
+++ b/index.bs
@@ -10181,7 +10181,7 @@ in the node.
 				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
-				An <a href="https://infra.spec.whatwg.org/#maps">ordered map</a> of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> corresponds to a {{Float32Array}} object filled with the automation values of the <var>"name"</var> {{AudioParam}}.
+				An <l><a href="https://infra.spec.whatwg.org/#maps">ordered map</a></l> of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>"name"</var> {{AudioParam}}.
 
 				For each array, the array contains the [=computedValue=] of the parameter for all frames in the [=render quantum=]. However, if no automation is scheduled during this render quantum, the array MAY have length 1 with the array element being the constant value of the {{AudioParam}} for the [=render quantum=].
 		</pre>

--- a/index.bs
+++ b/index.bs
@@ -10181,7 +10181,7 @@ in the node.
 				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
-				A map of string keys and associated {{Float32Array}}s. <code>parameters["name"]</code> corresponds to the automation values of the {{AudioParam}} named <code>"name"</code>.
+				An <a href="https://infra.spec.whatwg.org/#maps">ordered map</a> of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> corresponds to a {{Float32Array}} object filled with the automation values of the <var>"name"</var> {{AudioParam}}.
 
 				For each array, the array contains the [=computedValue=] of the parameter for all frames in the [=render quantum=]. However, if no automation is scheduled during this render quantum, the array MAY have length 1 with the array element being the constant value of the {{AudioParam}} for the [=render quantum=].
 		</pre>

--- a/index.bs
+++ b/index.bs
@@ -10325,7 +10325,7 @@ in the node.
 				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
-				An <a spec="infra" lt="map">ordered map</a> of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>name</var> {{AudioParam}}.
+				An <a spec="infra" lt="map">ordered map</a> of <var>name</var> → <var>parameterValues</var>. <code>parameters["<var>name</var>"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>name</var> {{AudioParam}}.
 
 				For each array, the array contains the [=computedValue=] of the parameter for all frames in the [=render quantum=]. However, if no automation is scheduled during this render quantum, the array MAY have length 1 with the array element being the constant value of the {{AudioParam}} for the [=render quantum=].
 		</pre>

--- a/index.bs
+++ b/index.bs
@@ -10181,7 +10181,7 @@ in the node.
 				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
-				An <l><a href="https://infra.spec.whatwg.org/#maps">ordered map</a></l> of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>"name"</var> {{AudioParam}}.
+				An ordered map of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>"name"</var> {{AudioParam}}.
 
 				For each array, the array contains the [=computedValue=] of the parameter for all frames in the [=render quantum=]. However, if no automation is scheduled during this render quantum, the array MAY have length 1 with the array element being the constant value of the {{AudioParam}} for the [=render quantum=].
 		</pre>

--- a/index.bs
+++ b/index.bs
@@ -10181,7 +10181,7 @@ in the node.
 				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
-				An ordered map of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>"name"</var> {{AudioParam}}.
+				An [[infra#ordered-map|ordered map]] of <var>name</var> → <var>parameterValues</var>. <code>parameters["name"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>name</var> {{AudioParam}}.
 
 				For each array, the array contains the [=computedValue=] of the parameter for all frames in the [=render quantum=]. However, if no automation is scheduled during this render quantum, the array MAY have length 1 with the array element being the constant value of the {{AudioParam}} for the [=render quantum=].
 		</pre>


### PR DESCRIPTION
Fixes #2016


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2017.html" title="Last updated on Aug 8, 2019, 7:45 PM UTC (da06137)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2017/c1a359b...hoch:da06137.html" title="Last updated on Aug 8, 2019, 7:45 PM UTC (da06137)">Diff</a>