### PR TITLE
Fix type on AudioWorkletProcessor.port description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10242,9 +10242,9 @@ Constructors</h5>
 	: <dfn>port</dfn>
 	::
 		Every {{AudioWorkletProcessor}} has an associated
-		<code>port</code> which is a {{MessagePort}}. It is connected to the port on the
-		corresponding {{AudioWorkletProcessor}} object allowing
-		bidirectional communication between an
+		<code>port</code> which is a {{MessagePort}}. It is connected to
+		the port on the corresponding {{AudioWorkletNode}} object
+		allowing bidirectional communication between an
 		{{AudioWorkletNode}} and its {{AudioWorkletProcessor}}.
 </dl>
 


### PR DESCRIPTION
Fixes #1964.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2019.html" title="Last updated on Aug 8, 2019, 8:05 PM UTC (6127ad9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2019/e71554e...hoch:6127ad9.html" title="Last updated on Aug 8, 2019, 8:05 PM UTC (6127ad9)">Diff</a>