### PR TITLE
Revise AWN/AWP construction process

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9827,10 +9827,6 @@ Methods</h5>
 <h5 id="AudioWorkletProcessor-instantiation">
 The instantiation of AudioWorkletProcessor</h5>
 
-The construction of an {{AudioWorkletNode}} is followed by the construction
-of a corresponding {{AudioWorkletProcessor}} instance in the
-{{AudioWorkletGlobalScope}}.
-
 At the end of the {{AudioWorkletNode}} construction,
 <dfn>processor construction data</dfn> will be prepared for the cross-thread
 transfer. This data contains:
@@ -9838,8 +9834,9 @@ transfer. This data contains:
 <dl>
 	: <dfn dfn>nodeName</dfn>
 	::
-		A {{DOMString}} of the {{AudioWorkletProcessor}} name that is to
-		be looked up <a>node name to processor constructor map</a>.
+		A {{DOMString}} which is the {{AudioWorkletProcessor}} name
+		that is to be looked up in the <a>node name to processor
+		constructor map</a>.
 	: <dfn dfn>nodePort</dfn>
 	::
 		A serialized {{MessagePort}} that is paired with
@@ -10237,24 +10234,24 @@ Constructors</h5>
 				invocation of the constructor throw a
 				{{TypeError}}.
 
-			1. Let <var>processor</var> be a new
+			1. Let <var>this</var> be a new
 				{{AudioWorkletProcessor}} instance.
 
-			1. Let <var>processorPort</var> be [$StructuredDeserializeWithTransfer$](
+			1. Let <var>processorPort</var> be
+				[$StructuredDeserializeWithTransfer$](
 				[=nodePort=], the current Realm).
 
-			1. Set <var>processor</var>’s {{AudioWorkletProcessor/port}}
+			1. Set <var>this</var>’s {{AudioWorkletProcessor/port}}
 				to <var>processorPort</var>.
 
-			1. Set <var>processor</var>'s {{[[node reference]]}} to
+			1. Set <var>this</var>'s {{[[node reference]]}} to
 				<var>node</var>.
 
-			1. Set <var>processor</var>'s {{[[callable process]]}} to `true`.
+			1. Set <var>this</var>'s {{[[callable process]]}} to
+				`true`.
 
 			1. Set <var>node</var>'s <a>processor reference</a> to
-				<var>processor</var>.
-
-			1. Return <var>processor</var>.
+				<var>this</var>.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">

--- a/index.bs
+++ b/index.bs
@@ -9825,12 +9825,12 @@ Methods</h5>
 </dl>
 
 <h5 id="AudioWorkletProcessor-instantiation">
-The instantiation of AudioWorkletProcessor</h5>
+The instantiation of {{AudioWorkletProcessor}}</h5>
 
 At the end of the {{AudioWorkletNode}} construction,
 A [=struct=] named
 <dfn>processor construction data</dfn>
-will be prepared for the cross-thread transfer. This
+will be prepared for cross-thread transfer. This
 <a spec="infra" lt="struct">struct</a> contains the following
 <a spec="infra" for="struct" lt="item">items</a>:
 
@@ -9854,15 +9854,13 @@ the <a>rendering thread</a> will invoke the algorithm below:
 			[=processor construction data=] transferred from the
 			[=control thread=].
 
-		1. Let <var>processorName</var> be <var>constructionData</var>'s
-			[=processor construction data/name=].
+		1. Let <var>processorName</var>, <var>nodeReference</var> and
+			<var>serializedPort</var> be
+			<var>constructionData</var>'s
+			[=processor construction data/name=],
+			[=processor construction data/node=], and
+			[=processor construction data/port=] respectively.
 
-		1. Let <var>nodeReference</var> be <var>constructionData</var>'s
-			[=processor construction data/node=].
-
-		1. Let <var>serializedPort</var> be <var>constructionData</var>'s
-			[=processor construction data/port=].
-		
 		1. Let <var>serializedOptions</var> be
 			<var>constructionData</var>'s
 			[=processor construction data/options=].
@@ -9950,7 +9948,7 @@ Constructors</h5>
 			options: Optional initial parameters value for this {{AudioWorkletNode}}.
 		</pre>
 
-		When the constructor was called, the user agent MUST perform the
+		When the constructor is called, the user agent MUST perform the
 		following steps on the control thread:
 
 		<div algorithm="AudioWorkletNode()">

--- a/index.bs
+++ b/index.bs
@@ -9824,6 +9824,45 @@ Methods</h5>
 		</div>
 </dl>
 
+<h5 id="AudioWorkletProcessor-instantiation">
+Instantiation of AudioWorkletProcessor</h5>
+
+The construction of an {{AudioWorkletNode}} is followed by the construction
+of a corresponding {{AudioWorkletProcessor}} instance in the
+{{AudioWorkletGlobalScope}}.
+
+At the end of the {{AudioWorkletNode}} construction,
+<dfn>processor construction data</dfn> will be prepared for the cross-thread
+transfer. This data contains:
+
+<dl dfn-type=attribute dfn-for="processor-construction-data">
+	:<dfn>nodeName</dfn>
+	::
+		A {{DOMString}} of the {{AudioWorkletProcessr}} name that is to
+		be looked up <a>node name to processor constructor map</a>.
+	:<dfn>nodePort</dfn>
+	::
+		A serialized {{MessagePort}} that is paired with
+		the associated {{AudioWorkletNode}}'s {{AudioWorkletNode/port}}.
+	:<dfn>nodeOptions</dfn>
+	::
+		A serialzied {{AudioWorkletNodeOptions}} dictionary that is
+		given to the {{AudioWorkletNode}}
+		{{AudioWorkletNode()|constructor}}.
+</dl>
+
+This is transferred to
+the {{AudioWorkletGlobalScope}} to invoke {{AudioWorkletProcessor()|constructor}}.
+
+	<div algorithm="AudioWorkletProcessor-instantiation">
+	If the instantiation is invoked without a valid processor construction data
+	abort the following step, and fire error event on no.onprocessorerror
+
+		1. processor construction data -> nodeName
+		1. find a constructor from the AWGS
+		1. invoke constructor with processor construction data (port, options)
+	</div>
+
 <h4 interface lt="AudioWorkletNode">
 The {{AudioWorkletNode}} Interface</h4>
 
@@ -9887,14 +9926,6 @@ Constructors</h5>
 			name: A string that is a key for the {{BaseAudioContext}}’s <a>node name to parameter descriptor map</a>.
 			options: Optional initial parameters value for this {{AudioWorkletNode}}.
 		</pre>
-
-		Once the construction of the node is completed,
-		<dfn dfn>processor construction data</dfn> will be created and
-		transferred to the matching {{AudioWorkletProcessor}}'s
-		{{AudioWorkletProcessor()|constructor}}. This data contains
-		a set of objects and references that is required for
-		{{AudioWorkletProcessor}}'s construction. See the step 12 in
-		the algorithm below.
 
 		When the constructor was called, the user agent MUST perform the
 		following steps on the control thread:
@@ -10006,12 +10037,6 @@ Constructors</h5>
 
 			1. Return <var>node</var>.
 		</div>
-
-		During the construction of an {{AudioWorkletNode}}, a
-		corresponding {{AudioWorkletProcessor}} instance is also
-		automatically created in the {{AudioWorkletGlobalScope}}.
-		Note that the instantiation of these object pairs spans the
-		control thread and the rendering thread.
 </dl>
 
 <h5 id="AudioWorkletNode-attributes">

--- a/index.bs
+++ b/index.bs
@@ -9880,9 +9880,10 @@ the <a>rendering thread</a> will invoke the algorithm below:
 			{{AudioWorkletGlobalScope}}'s
 			<a>node name to processor constructor map</a>.
 		
-		1. Make <var>nodeReference</var>, <var>deserializedPort</var>,
-			<var>deserializedOptions</var> available for the
-			execution of <var>processorCtor</var>.
+		1. Make <dfn><var>nodeReference</var></dfn>,
+			<dfn><var>deserializedPort</var></dfn>, and
+			<var>deserializedOptions</var> available
+			for the execution of <var>processorCtor</var>.
 
 		1. Invoke the <var>processorCtor</var> with the argument of
 			<var>deserializedOptions</var>.
@@ -10248,17 +10249,17 @@ Constructors</h5>
 		the following steps are performed on the <a>rendering thread</a>.
 
 		<div algorithm="AudioWorkletProcessor()">
-			1. Find <var>nodeReference</var> that is made available
-				for this constructor. Throw a {{TypeError}}
-				exception if not found.
+			1. Find <var>[=nodeReference=]</var> that is made
+				available for this constructor. Throw a
+				{{TypeError}} exception if not found.
 			
-			If any of following steps throws any exception,
-			abort the rest of steps and <a>queue a task</a> to the
-			<a>control thread</a> to
-			<a spec="dom" lt="fire an event">fire</a> an
-			<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-			named <code>processorerror</code> on
-			<var>nodeReference</var>.
+			1. If any of following steps throws any exception,
+				abort the rest of steps and <a>queue a task</a>
+				to the <a>control thread</a> to
+				<a spec="dom" lt="fire an event">fire</a> an
+				<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
+				named <code>processorerror</code> on
+				<var>nodeReference</var>.
 
 			1. Let <var>processor</var> be
 				<a spec="webidl" lt="this">this</a> value.
@@ -10269,7 +10270,7 @@ Constructors</h5>
 			1. Set <var>processor</var>'s {{[[callable process]]}}
 				to `true`.
 
-			1. Find <var>deserializedPort</var> that is made
+			1. Find <var>[=deserializedPort=]</var> that is made
 				available for this constructor. Throw
 				{{TypeError}} exception if not found.
 

--- a/index.bs
+++ b/index.bs
@@ -10237,6 +10237,9 @@ Constructors</h5>
 				invocation of the constructor throw a
 				{{TypeError}}.
 
+			1. Let <var>processor</var> be a new
+				{{AudioWorkletProcessor}} instance.
+
 			1. Let <var>processorPort</var> be [$StructuredDeserializeWithTransfer$](
 				[=nodePort=], the current Realm).
 
@@ -10250,6 +10253,8 @@ Constructors</h5>
 
 			1. Set <var>node</var>'s <a>processor reference</a> to
 				<var>processor</var>.
+
+			1. Return <var>processor</var>.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">

--- a/index.bs
+++ b/index.bs
@@ -10234,24 +10234,24 @@ Constructors</h5>
 				invocation of the constructor throw a
 				{{TypeError}}.
 
-			1. Let <var>this</var> be a new
-				{{AudioWorkletProcessor}} instance.
+			1. Let <var>processor</var> be
+				<a spec="webidl" lt="this">this</a> value.
 
 			1. Let <var>processorPort</var> be
 				[$StructuredDeserializeWithTransfer$](
 				[=nodePort=], the current Realm).
 
-			1. Set <var>this</var>’s {{AudioWorkletProcessor/port}}
+			1. Set <var>processor</var>’s {{AudioWorkletProcessor/port}}
 				to <var>processorPort</var>.
 
-			1. Set <var>this</var>'s {{[[node reference]]}} to
+			1. Set <var>processor</var>'s {{[[node reference]]}} to
 				<var>node</var>.
 
-			1. Set <var>this</var>'s {{[[callable process]]}} to
+			1. Set <var>processor</var>'s {{[[callable process]]}} to
 				`true`.
 
 			1. Set <var>node</var>'s <a>processor reference</a> to
-				<var>this</var>.
+				<var>processor</var>.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">

--- a/index.bs
+++ b/index.bs
@@ -9825,7 +9825,7 @@ Methods</h5>
 </dl>
 
 <h5 id="AudioWorkletProcessor-instantiation">
-Instantiation of AudioWorkletProcessor</h5>
+The instantiation of AudioWorkletProcessor</h5>
 
 The construction of an {{AudioWorkletNode}} is followed by the construction
 of a corresponding {{AudioWorkletProcessor}} instance in the
@@ -9835,32 +9835,50 @@ At the end of the {{AudioWorkletNode}} construction,
 <dfn>processor construction data</dfn> will be prepared for the cross-thread
 transfer. This data contains:
 
-<dl dfn-type=attribute dfn-for="processor-construction-data">
-	:<dfn>nodeName</dfn>
+<dl>
+	: <dfn dfn>nodeName</dfn>
 	::
-		A {{DOMString}} of the {{AudioWorkletProcessr}} name that is to
+		A {{DOMString}} of the {{AudioWorkletProcessor}} name that is to
 		be looked up <a>node name to processor constructor map</a>.
-	:<dfn>nodePort</dfn>
+	: <dfn dfn>nodePort</dfn>
 	::
 		A serialized {{MessagePort}} that is paired with
 		the associated {{AudioWorkletNode}}'s {{AudioWorkletNode/port}}.
-	:<dfn>nodeOptions</dfn>
+	: <dfn dfn>nodeOptions</dfn>
 	::
-		A serialzied {{AudioWorkletNodeOptions}} dictionary that is
+		A serialized {{AudioWorkletNodeOptions}} dictionary that is
 		given to the {{AudioWorkletNode}}
 		{{AudioWorkletNode()|constructor}}.
 </dl>
 
-This is transferred to
-the {{AudioWorkletGlobalScope}} to invoke {{AudioWorkletProcessor()|constructor}}.
+Upon the arrival of the transferred data on the {{AudioWorkletGlobalScope}},
+the <a>rendering thread</a> will trigger the algorithm below:
 
-	<div algorithm="AudioWorkletProcessor-instantiation">
-	If the instantiation is invoked without a valid processor construction data
-	abort the following step, and fire error event on no.onprocessorerror
+	<div id="invoking-processor-constructor" algorithm="invoking processor constructor">
+		Upon the arrival of <a>processor construction data</a>
+		<var>constructionData</var>, perform the following steps. If
+		any step throws an exception, abort the remaining steps and
+		<a>queue a task</a> to fire an
+		<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
+		ErrorEvent</a> named <code>processorerror</code> at the
+		{{AudioWorkletNode}} on the <a>control thread</a> with the
+		relevant information about the error.
 
-		1. processor construction data -> nodeName
-		1. find a constructor from the AWGS
-		1. invoke constructor with processor construction data (port, options)
+		1. Let <var>name</var> be the [=nodeName=] member of
+			<var>constructionData</var>.
+
+		1. Let <var>options</var> be the [=nodeOptions=] member of
+			<var>constructionData</var>.
+
+		1. Let <var>port</var> be the [=nodePort=] member of
+			<var>constructionData</var>.
+
+		1. Let <var>processorCtor</var> be the result of looking
+			up <var>name</var> on the {{AudioWorkletGlobalScope}}'s
+			<a>node name to processor constructor map</a>.
+
+		1. Perform Construct(<var>processorCtor</var>,
+			« <var>options</var> ») with the given <var>port</var>.
 	</div>
 
 <h4 interface lt="AudioWorkletNode">
@@ -9883,10 +9901,6 @@ macros:
 	tail-time: See notes
 	tail-time-notes:  Any <a>tail-time</a> is handled by the node itself
 </pre>
-
-Every {{AudioWorkletNode}} has an associated <dfn>processor
-reference</dfn>, initially null, which refers to the
-{{AudioWorkletProcessor}} handling the processing for this node.
 
 Every {{AudioWorkletProcessor}} has an associated <dfn>active source</dfn> flag, initially `true`. This flag causes
 the node to be retained in memory and perform audio processing in
@@ -10026,14 +10040,14 @@ Constructors</h5>
 
 				1. Set <var>node</var>'s {{AudioWorkletNode/parameters}} to <var>audioParamMap</var>.
 
-			1. <a>Queue a control message</a> to invoke the
-				{{AudioWorkletProcessor()|constructor}} of
+			1. <a>Queue a control message</a> to
+				<a href="#invoking-processor-constructor">invoke</a>
+				the {{AudioWorkletProcessor()|constructor}} of
 				the corresponding {{AudioWorkletProcessor}} with
 				the [=processor construction data=] that consists of:
 				<var>nodeName</var>,
 				<var>serializedProcessorPort</var>,
-				<var>serializedOptions</var>,
-				and <var>node</var>.
+				<var>serializedOptions</var>.
 
 			1. Return <var>node</var>.
 		</div>
@@ -10208,16 +10222,6 @@ Constructors</h5>
 		the following steps are performed on the <a>rendering thread</a>.
 
 		<div algorithm="AudioWorkletProcessor()">
-			This constructor is invoked by processing a control
-			message queued by the {{AudioWorkletNode()|constructor}}
-			of the associated {{AudioWorkletNode}}. This control
-			message carries the [=processor construction data=] that
-			consists of:
-			<var>nodeName</var>,
-			<var>serializedProcessorPort</var>,
-			<var>serializedOptions</var>,
-			and <var>node</var>.
-
 			If any of these steps throws an exception, abort the rest of
 			steps and <a>queue a task</a> to fire an
 			<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
@@ -10225,35 +10229,17 @@ Constructors</h5>
 			on the <a>control thread</a> with the relevant information about
 			the error.
 
-			1. If there is no [=processor construction data=]
-				passed from the associated {{AudioWorkletNode}},
-				throw a {{TypeError}}.
+			1. If there is no provided [=nodePort=] at the
+				invocation of the constructor throw a
+				{{TypeError}}.
 
-			1. Let <var>processorPort</var> be
-				[$StructuredDeserializeWithTransfer$](<var>serializedProcessorPort</var>,
-				the current Realm).
+			1. Let <var>processorPort</var> be [$StructuredDeserializeWithTransfer$](
+				[=nodePort=], the current Realm).
 
-			1. Let <var>options</var> be
-				[$StructuredDeserialize$](<var>serializedOptions</var>,
-				the current Realm).
-
-			1. Let <var>processorCtor</var> be the result of looking
-				up <var>nodeName</var> on the
-				{{AudioWorkletGlobalScope}}'s
-				<a>node name to processor constructor map</a>.
-
-			1. Let <var>processor</var> be the result of
-				Construct(<var>processorCtor</var>, « <var>options</var> »).
-
-			1. Set <var>processor</var>’s port to <var>processorPort</var>.
-
-			1. Set <var>processor</var>'s {{[[node reference]]}} to
-				<var>node</var>.
+			1. Set <var>processor</var>’s {{AudioWorkletProcessor/port}}
+				to <var>processorPort</var>.
 
 			1. Set <var>processor</var>'s {{[[callable process]]}} to `true`.
-
-			1. Set <var>node</var>'s <a>processor reference</a> to
-				<var>processor</var>.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">

--- a/index.bs
+++ b/index.bs
@@ -9902,6 +9902,10 @@ macros:
 	tail-time-notes:  Any <a>tail-time</a> is handled by the node itself
 </pre>
 
+Every {{AudioWorkletNode}} has an associated <dfn>processor
+reference</dfn>, initially null, which refers to the
+{{AudioWorkletProcessor}} handling the processing for this node.
+
 Every {{AudioWorkletProcessor}} has an associated <dfn>active source</dfn> flag, initially `true`. This flag causes
 the node to be retained in memory and perform audio processing in
 the absence of any connected inputs.
@@ -10239,7 +10243,13 @@ Constructors</h5>
 			1. Set <var>processor</var>’s {{AudioWorkletProcessor/port}}
 				to <var>processorPort</var>.
 
+			1. Set <var>processor</var>'s {{[[node reference]]}} to
+				<var>node</var>.
+
 			1. Set <var>processor</var>'s {{[[callable process]]}} to `true`.
+
+			1. Set <var>node</var>'s <a>processor reference</a> to
+				<var>processor</var>.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">

--- a/index.bs
+++ b/index.bs
@@ -9884,8 +9884,9 @@ the <a>rendering thread</a> will invoke the algorithm below:
 			<dfn><var>deserializedPort</var></dfn>, and
 			<var>deserializedOptions</var> available
 			for the execution of <var>processorCtor</var>.
-
-		1. Invoke the <var>processorCtor</var> with the argument of
+		
+		1. <a spec=webidl lt=construct>Construct a callback function</a>
+			from <var>processorCtor</var> with the argument of
 			<var>deserializedOptions</var>.
 	</div>
 

--- a/index.bs
+++ b/index.bs
@@ -9839,10 +9839,10 @@ will be prepared for the cross-thread transfer. This
 	<a>node name to processor constructor map</a>.
 - <dfn for="processor construction data">node</dfn> which is a reference to
 	the {{AudioWorkletNode}} created.
-- <dfn for="processor construction data">options</dfn> which a serialized
+- <dfn for="processor construction data">options</dfn> which is a serialized
 	{{AudioWorkletNodeOptions}} given to the {{AudioWorkletNode}}'s
 	{{AudioWorkletNode()|constructor}}.
-- <dfn for="processor construction data">port</dfn> which a serialized
+- <dfn for="processor construction data">port</dfn> which is a serialized
 	{{MessagePort}} paired with the {{AudioWorkletNode}}'s
 	{{AudioWorkletNode/port}}.
 
@@ -10071,10 +10071,10 @@ Attributes</h5>
 		When an unhandled exception is thrown from the processor's
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
-		<a>queue a task</a> to
-		<a spec="dom" lt="fire an event">fire</a> an
+		<a>queue a task</a> to <a spec="dom" lt="fire an event">
+		fire an event</a> named <code>processorerror</code> using
 		<a href="https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface">
-		ErrorEvent</a> to the associated {{AudioWorkletNode}}.
+		ErrorEvent</a> at the associated {{AudioWorkletNode}}.
 
 		The <code>ErrorEvent</code> is created and initialized
 		appropriately with its <code>message</code>,
@@ -10254,14 +10254,15 @@ Constructors</h5>
 				{{TypeError}} exception if not found.
 			
 			1. If any of following steps throws any exception,
-				abort the rest of steps and <a>queue a task</a>
-				to the <a>control thread</a> to
-				<a spec="dom" lt="fire an event">fire</a> an
+				abort the rest of the steps and 
+				<a>queue a task</a> to the <a>control thread</a>
+				to <a spec="dom" lt="fire an event">fire an
+				event</a> named <code>processorerror</code>
+				using 
 				<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-				named <code>processorerror</code> on
-				<var>nodeReference</var>.
+				at <var>nodeReference</var>.
 
-			1. Let <var>processor</var> be
+			1. Let <var>processor</var> be the
 				<a spec="webidl" lt="this">this</a> value.
 			
 			1. Set <var>processor</var>'s {{[[node reference]]}} to

--- a/index.bs
+++ b/index.bs
@@ -9828,54 +9828,64 @@ Methods</h5>
 The instantiation of AudioWorkletProcessor</h5>
 
 At the end of the {{AudioWorkletNode}} construction,
-<dfn>processor construction data</dfn> will be prepared for the cross-thread
-transfer. This data contains:
+A [=struct=] named
+<dfn>processor construction data</dfn>
+will be prepared for the cross-thread transfer. This
+<a spec="infra" lt="struct">struct</a> contains the following
+<a spec="infra" for="struct" lt="item">items</a>:
 
-<dl>
-	: <dfn dfn>nodeName</dfn>
-	::
-		A {{DOMString}} which is the {{AudioWorkletProcessor}} name
-		that is to be looked up in the <a>node name to processor
-		constructor map</a>.
-	: <dfn dfn>nodePort</dfn>
-	::
-		A serialized {{MessagePort}} that is paired with
-		the associated {{AudioWorkletNode}}'s {{AudioWorkletNode/port}}.
-	: <dfn dfn>nodeOptions</dfn>
-	::
-		A serialized {{AudioWorkletNodeOptions}} dictionary that is
-		given to the {{AudioWorkletNode}}
-		{{AudioWorkletNode()|constructor}}.
-</dl>
+- <dfn for="processor construction data">name</dfn> which is a {{DOMString}}
+	that is to be looked up in the
+	<a>node name to processor constructor map</a>.
+- <dfn for="processor construction data">node</dfn> which is a reference to
+	the {{AudioWorkletNode}} created.
+- <dfn for="processor construction data">options</dfn> which a serialized
+	{{AudioWorkletNodeOptions}} given to the {{AudioWorkletNode}}'s
+	{{AudioWorkletNode()|constructor}}.
+- <dfn for="processor construction data">port</dfn> which a serialized
+	{{MessagePort}} paired with the {{AudioWorkletNode}}'s
+	{{AudioWorkletNode/port}}.
 
 Upon the arrival of the transferred data on the {{AudioWorkletGlobalScope}},
-the <a>rendering thread</a> will trigger the algorithm below:
+the <a>rendering thread</a> will invoke the algorithm below:
 
 	<div id="invoking-processor-constructor" algorithm="invoking processor constructor">
-		Upon the arrival of <a>processor construction data</a>
-		<var>constructionData</var>, perform the following steps. If
-		any step throws an exception, abort the remaining steps and
-		<a>queue a task</a> to fire an
-		<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
-		ErrorEvent</a> named <code>processorerror</code> at the
-		{{AudioWorkletNode}} on the <a>control thread</a> with the
-		relevant information about the error.
+		1. Let <var>constructionData</var> be the
+			[=processor construction data=] transferred from the
+			[=control thread=].
 
-		1. Let <var>name</var> be the [=nodeName=] member of
-			<var>constructionData</var>.
+		1. Let <var>processorName</var> be <var>constructionData</var>'s
+			[=processor construction data/name=].
 
-		1. Let <var>options</var> be the [=nodeOptions=] member of
-			<var>constructionData</var>.
+		1. Let <var>nodeReference</var> be <var>constructionData</var>'s
+			[=processor construction data/node=].
 
-		1. Let <var>port</var> be the [=nodePort=] member of
-			<var>constructionData</var>.
+		1. Let <var>serializedPort</var> be <var>constructionData</var>'s
+			[=processor construction data/port=].
+		
+		1. Let <var>serializedOptions</var> be
+			<var>constructionData</var>'s
+			[=processor construction data/options=].
+		
+		1. Let <var>deserializedPort</var> be the result of
+			[$StructuredDeserialize$](<var>serializedPort</var>,
+			the current Realm).
 
+		1. Let <var>deserializedOptions</var> be the result of
+			[$StructuredDeserialize$](<var>serializedOptions</var>,
+			the current Realm).
+		
 		1. Let <var>processorCtor</var> be the result of looking
-			up <var>name</var> on the {{AudioWorkletGlobalScope}}'s
+			up  <var>processorName</var> on the
+			{{AudioWorkletGlobalScope}}'s
 			<a>node name to processor constructor map</a>.
+		
+		1. Make <var>nodeReference</var>, <var>deserializedPort</var>,
+			<var>deserializedOptions</var> available for the
+			execution of <var>processorCtor</var>.
 
-		1. Perform Construct(<var>processorCtor</var>,
-			« <var>options</var> ») with the given <var>port</var>.
+		1. Invoke the <var>processorCtor</var> with the argument of
+			<var>deserializedOptions</var>.
 	</div>
 
 <h4 interface lt="AudioWorkletNode">
@@ -9898,10 +9908,6 @@ macros:
 	tail-time: See notes
 	tail-time-notes:  Any <a>tail-time</a> is handled by the node itself
 </pre>
-
-Every {{AudioWorkletNode}} has an associated <dfn>processor
-reference</dfn>, initially null, which refers to the
-{{AudioWorkletProcessor}} handling the processing for this node.
 
 Every {{AudioWorkletProcessor}} has an associated <dfn>active source</dfn> flag, initially `true`. This flag causes
 the node to be retained in memory and perform audio processing in
@@ -10049,9 +10055,9 @@ Constructors</h5>
 				the corresponding {{AudioWorkletProcessor}} with
 				the [=processor construction data=] that consists of:
 				<var>nodeName</var>,
-				<var>serializedProcessorPort</var>,
-				<var>serializedOptions</var>,
-				and <var>node</var>.
+				<var>node</var>,
+				<var>serializedOptions</var>, and
+				<var>serializedProcessorPort</var>.
 		</div>
 </dl>
 
@@ -10064,7 +10070,8 @@ Attributes</h5>
 		When an unhandled exception is thrown from the processor's
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
-		<a>queue a task</a> to fire an
+		<a>queue a task</a> to
+		<a spec="dom" lt="fire an event">fire</a> an
 		<a href="https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface">
 		ErrorEvent</a> to the associated {{AudioWorkletNode}}.
 
@@ -10241,46 +10248,34 @@ Constructors</h5>
 		the following steps are performed on the <a>rendering thread</a>.
 
 		<div algorithm="AudioWorkletProcessor()">
-			This constructor is invoked by processing a control
-			message queued by the {{AudioWorkletNode()|constructor}}
-			of the associated {{AudioWorkletNode}}. This control
-			message carries the [=processor construction data=] that
-			consists of:
-			<var>nodeName</var>,
-			<var>serializedProcessorPort</var>,
-			<var>serializedOptions</var>,
-			and <var>node</var>.
-
-			If any of these steps throws an exception,
-			abort the rest of steps and
-			<a>queue a task</a> to the <a>control thread</a>
+			1. Find <var>nodeReference</var> that is made available
+				for this constructor. Throw a {{TypeError}}
+				exception if not found.
+			
+			If any of following steps throws any exception,
+			abort the rest of steps and <a>queue a task</a> to the
+			<a>control thread</a> to
 			<a spec="dom" lt="fire an event">fire</a> an
 			<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-			named <code>processorerror</code> at the associated
-			{{AudioWorkletNode}}.
-
-			1. If there is no provided [=nodePort=] at the
-				invocation of the constructor throw a
-				{{TypeError}}.
+			named <code>processorerror</code> on
+			<var>nodeReference</var>.
 
 			1. Let <var>processor</var> be
 				<a spec="webidl" lt="this">this</a> value.
-
-			1. Let <var>processorPort</var> be
-				[$StructuredDeserializeWithTransfer$](
-				[=nodePort=], the current Realm).
-
-			1. Set <var>processor</var>’s {{AudioWorkletProcessor/port}}
-				to <var>processorPort</var>.
-
+			
 			1. Set <var>processor</var>'s {{[[node reference]]}} to
-				<var>node</var>.
+				<var>nodeReference</var>.
+			
+			1. Set <var>processor</var>'s {{[[callable process]]}}
+				to `true`.
 
-			1. Set <var>processor</var>'s {{[[callable process]]}} to
-				`true`.
+			1. Find <var>deserializedPort</var> that is made
+				available for this constructor. Throw
+				{{TypeError}} exception if not found.
 
-			1. Set <var>node</var>'s <a>processor reference</a> to
-				<var>processor</var>.
+			1. Set <var>processor</var>’s
+				{{AudioWorkletProcessor/port}}
+				to <var>deserializedPort</var>.
 		</div>
 
 		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">


### PR DESCRIPTION
This is an attempt to fix #2021.

Key changes:
- A new algorithm is introduced: "invoking AWP constructor with processor construction data"
- The "processor construction data" is now defined clearly.
- The AWN constructor will now explicitly trigger the algorithm above.
- The AWP constructor does not have infinite loop anymore.

cc @bzbarsky


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2022.html" title="Last updated on Aug 15, 2019, 10:05 PM UTC (e9ce078)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2022/6b1fd01...hoch:e9ce078.html" title="Last updated on Aug 15, 2019, 10:05 PM UTC (e9ce078)">Diff</a>