### PR TITLE
Remove redundant texts from the AudioWorkletProcessor method description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10254,12 +10254,9 @@ Methods</h5>
 Users can define a custom audio processor by extending
 {{AudioWorkletProcessor}}. The subclass MUST define a method
 named {{process()}} that implements the audio processing
-algorithm and may have a valid static property named
+algorithm and may have a static property named
 <code><dfn>parameterDescriptors</dfn></code> which is an iterable
-of {{AudioParamDescriptor}} that is looked up by the
-{{AudioWorkletProcessor}} constructor to create instances of
-{{AudioParam}} in the <code>parameters</code> maplike storage
-in the node.
+of {{AudioParamDescriptor}}s.
 
 <dl dfn-type=method dfn-for="AudioWorkletProcessor">
 	: <dfn>process(inputs, outputs, parameters)</dfn>


### PR DESCRIPTION
Fixes #2022.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2024.html" title="Last updated on Aug 13, 2019, 9:09 PM UTC (bf604ab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2024/e9006e7...hoch:bf604ab.html" title="Last updated on Aug 13, 2019, 9:09 PM UTC (bf604ab)">Diff</a>