### PR TITLE
Use [[node reference]] to fire ErrorEvent from AWP to AWN

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10251,22 +10251,22 @@ Constructors</h5>
 			1. Find <var>[=nodeReference=]</var> that is made
 				available for this constructor. Throw a
 				{{TypeError}} exception if not found.
-			
+
 			1. If any of following steps throws any exception,
-				abort the rest of the steps and 
+				abort the rest of the steps and
 				<a>queue a task</a> to the <a>control thread</a>
 				to <a spec="dom" lt="fire an event">fire an
 				event</a> named <code>processorerror</code>
-				using 
+				using
 				<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
 				at <var>nodeReference</var>.
 
 			1. Let <var>processor</var> be the
 				<a spec="webidl" lt="this">this</a> value.
-			
+
 			1. Set <var>processor</var>'s {{[[node reference]]}} to
 				<var>nodeReference</var>.
-			
+
 			1. Set <var>processor</var>'s {{[[callable process]]}}
 				to `true`.
 
@@ -10316,6 +10316,13 @@ of {{AudioParamDescriptor}}s.
 		synchronously by the audio <a>rendering thread</a> at
 		every <a>render quantum</a>, if {{AudioWorkletNode}} is
 		[=actively processing=].
+
+		If the user-supplied code throws any exception,
+		<a>queue a task</a> to the <a>control thread</a> to
+		<a spec="dom" lt="fire an event">fire an event</a> named
+		<code>processorerror</code> using
+		<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
+		at {{[[node reference]]}}.
 
 		The return value of this method controls the lifetime of the
 		{{AudioWorkletProcessor}}'s associated


### PR DESCRIPTION
- Fixes #1976.
- Adds a paragraph to handle the exception during process() call.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2029.html" title="Last updated on Aug 19, 2019, 5:18 PM UTC (2624a02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2029/1d1a03b...hoch:2624a02.html" title="Last updated on Aug 19, 2019, 5:18 PM UTC (2624a02)">Diff</a>