### PR TITLE
Fix the broken ordered list in registerProcessor()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9739,13 +9739,13 @@ Methods</h5>
 				Get</a>(O=<i>processorCtor</i>,
 				P="prototype")</code>.
 
-			<li id="check-prototype-type"> If the result of
+			1. If the result of
 				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">Type</a>(argument=<i>prototype</i>)</code>
 				is not <code>Object</code>,
 				<span class="synchronous">throw a {{TypeError}}
 				</span>.
 
-			<li id="check-is-callable"> If the result of
+			1. If the result of
 				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">IsCallable</a>(argument=Get(O=<i>prototype</i>, P="process"))</code>
 				is false,
 				<span class="synchronous">throw a {{TypeError}}

--- a/index.bs
+++ b/index.bs
@@ -9721,7 +9721,7 @@ Methods</h5>
 
 			1. If <var>name</var> is an empty string,
 				<span class="synchronous">throw a
-				{{NotSupportedError}}.</span>.
+				{{NotSupportedError}}</span>.
 
 			1. If <var>name</var> alredy exists as a key in the
 				<a>node name to processor constructor map</a>,


### PR DESCRIPTION
Remove `li` list items and change it to the bikeshed-style numbering.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2030.html" title="Last updated on Aug 19, 2019, 8:25 PM UTC (96cb8a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2030/1d1a03b...hoch:96cb8a5.html" title="Last updated on Aug 19, 2019, 8:25 PM UTC (96cb8a5)">Diff</a>