### PR TITLE
Remove a redundant initial value setting step in AWN constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10038,15 +10038,6 @@ Constructors</h5>
 							of <var>audioParamInMap</var>
 							to <var>paramValue</var>.
 
-				1. For each key-value pair <var>paramNameInOption</var>
-					→ <var>paramValue</var> of <var>options</var>:
-
-					1. If there exists an entry with name member
-						equal to <var>paramNameInOption</var>
-						inside <var>audioParamMap</var>,
-						set that {{AudioParam}}'s value to
-						<var>paramValue</var>.
-
 				1. Set <var>node</var>'s {{AudioWorkletNode/parameters}} to <var>audioParamMap</var>.
 
 			1. <a>Queue a control message</a> to


### PR DESCRIPTION
Fixes #2035.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2039.html" title="Last updated on Aug 21, 2019, 4:53 PM UTC (93819c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2039/1d1a03b...hoch:93819c1.html" title="Last updated on Aug 21, 2019, 4:53 PM UTC (93819c1)">Diff</a>