### PR TITLE
Remove `options` argument from AWP constructor

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -47,6 +47,5 @@ LINK ERROR: No 'idl-name' refs found for 'sequence<unsigned long>'.
 <a data-link-type="idl-name" data-lt="sequence&lt;unsigned long&gt;">sequence&lt;unsigned long&gt;</a>
 LINK ERROR: No 'idl-name' refs found for 'record<DOMString, double>'.
 <a data-link-type="idl-name" data-lt="record&lt;DOMString, double&gt;">record&lt;DOMString, double&gt;</a>
-LINE 9993: No 'method' refs found for 'AudioWorkletProcessor()'.
 LINE 10077: No 'method' refs found for 'process(inputs, outputs, parameters))'.
 YAY Successfully generated, but fatal errors were suppressed

--- a/index.bs
+++ b/index.bs
@@ -10233,7 +10233,7 @@ interface AudioWorkletProcessor {
 Constructors</h5>
 
 <dl dfn-type="constructor" dfn-for="AudioWorkletProcessor">
-	: <dfn>AudioWorkletProcessor(options)</dfn>
+	: <dfn>AudioWorkletProcessor()</dfn>
 	::
 		When the constructor for {{AudioWorkletProcessor}} is invoked,
 		the following steps are performed on the <a>rendering thread</a>.
@@ -10269,10 +10269,6 @@ Constructors</h5>
 				{{AudioWorkletProcessor/port}}
 				to <var>deserializedPort</var>.
 		</div>
-
-		<pre class="argumentdef" for="AudioWorkletProcessor/AudioWorkletProcessor()">
-		options: User-specified dictionary for custom initializations.
-		</pre>
 </dl>
 
 <h5 id="AudioWorkletProcessor-attributes">Attributes</h5>


### PR DESCRIPTION
Fixes #2036 per https://github.com/WebAudio/web-audio-api/issues/2036#issuecomment-523601202.

In short, the base class constructor does not need `options` passed from the node.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2040.html" title="Last updated on Aug 21, 2019, 7:30 PM UTC (8534ca8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2040/a73dab6...hoch:8534ca8.html" title="Last updated on Aug 21, 2019, 7:30 PM UTC (8534ca8)">Diff</a>