### PR TITLE
Fix #2041: Remove Bug Tracker entry in favor of Issue Tracking

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,7 +21,6 @@ Former Editor: Chris Wilson (Until Jan 2016)
 Former Editor: Chris Rogers (Until Aug 2013)
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webaudio
 Repository: WebAudio/web-audio-api
-!Bug Tracker: <a href="https://github.com/WebAudio/web-audio-api/issues?state=open">https://github.com/WebAudio/web-audio-api/issues?state=open</a>
 Abstract: This specification describes a high-level Web <abbr title="Application Programming Interface">API</abbr>
 	for processing and synthesizing audio in web applications.
 	The primary paradigm is of an audio routing graph,


### PR DESCRIPTION
Bikeshed automatically inserts an Issue Tracking line so the manually
added Bug Tracker line is redundant (the links produce the same
results).  Thus, remove the Bug Tracker link.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2043.html" title="Last updated on Aug 22, 2019, 5:17 PM UTC (02ea073)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2043/8b52eb7...rtoy:02ea073.html" title="Last updated on Aug 22, 2019, 5:17 PM UTC (02ea073)">Diff</a>