### PR TITLE
Fix #2054: Fix compile errors due to incorrect use of links

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -10,10 +10,6 @@ LINE 3133: Can't find the 'destinationNode' argument of method 'AudioNode/discon
 LINE 3148: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE 3148: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE 10077: Can't find method '['AudioWorkletProcessor/process(inputs, outputs, parameters))']'.
-LINK ERROR: No 'idl-name' refs found for 'MediaStream'.
-<a data-link-type="idl-name" class="n" data-lt="MediaStream">MediaStream</a>
-LINK ERROR: No 'idl-name' refs found for 'MediaStreamTrack'.
-<a data-link-type="idl-name" class="n" data-lt="MediaStreamTrack">MediaStreamTrack</a>
 LINE 1407: No 'method' refs found for 'AudioContext()'.
 LINE 1910: No 'method' refs found for 'OfflineAudioContext(contextOptions)'.
 LINE 1934: No 'method' refs found for 'OfflineAudioContext(numberOfChannels, length, sampleRate)'.
@@ -31,12 +27,8 @@ LINE 7451: No 'method' refs found for 'GainNode()'.
 LINE 7558: No 'method' refs found for 'IIRFilterNode()'.
 LINE 7731: No 'method' refs found for 'MediaElementAudioSourceNode()'.
 LINE 7837: No 'method' refs found for 'MediaStreamAudioDestinationNode()'.
-LINK ERROR: No 'idl-name' refs found for 'MediaStream'.
-<a data-link-type="idl-name" data-lt="MediaStream">MediaStream</a>
 LINE 7929: No 'method' refs found for 'MediaStreamAudioSourceNode()'.
 LINE 8005: No 'method' refs found for 'MediaStreamTrackAudioSourceNode()'.
-LINK ERROR: No 'idl-name' refs found for 'MediaStreamTrack'.
-<a data-link-type="idl-name" data-lt="MediaStreamTrack">MediaStreamTrack</a>
 LINE 8144: No 'method' refs found for 'OscillatorNode()'.
 LINE 8533: No 'method' refs found for 'PannerNode()'.
 LINE 8934: No 'method' refs found for 'PeriodicWave()'.

--- a/index.bs
+++ b/index.bs
@@ -253,7 +253,7 @@ The API supports these primary features:
 	{{MediaElementAudioSourceNode|media element}}.
 
 * Processing live audio input using a {{MediaStreamTrackAudioSourceNode|MediaStream}} from
-	[[mediacapture-streams#dom-mediadevices-getusermedia|getUserMedia()]].
+	{{getUserMedia()}}.
 
 * Integration with WebRTC
 	* Processing audio received from a remote peer using a
@@ -588,7 +588,7 @@ The interfaces defined are:
 
 * A {{MediaStreamTrackAudioSourceNode}} interface,
 	an {{AudioNode}} which is the audio source from a
-	[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]].
+	{{MediaStreamTrack}}.
 
 * A {{MediaStreamAudioDestinationNode}} interface,
 	an {{AudioNode}} which is the audio destination to a
@@ -1501,7 +1501,7 @@ Methods</h4>
 		</div>
 
 		When an {{AudioContext}} is closed, any
-		[[mediacapture-streams#mediastream|MediaStream]]s and {{HTMLMediaElement}}s
+		{{MediaStream}}s and {{HTMLMediaElement}}s
 		that were connected to an {{AudioContext}} will have their
 		output ignored. That is, these will no longer cause any output
 		to speakers or other output devices. For more flexibility in
@@ -1564,7 +1564,7 @@ Methods</h4>
 		Creates a {{MediaStreamTrackAudioSourceNode}}.
 
 		<pre class=argumentdef for="AudioContext/createMediaStreamTrackSource()">
-		mediaStreamTrack: The [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] that will act as source. <span class="synchronous">The value of its <code>kind</code> attribute must be equal to <code>"audio"</code>, or an {{InvalidStateError}} exception MUST be thrown.</span>
+		mediaStreamTrack: The {{MediaStreamTrack}} that will act as source. <span class="synchronous">The value of its <code>kind</code> attribute must be equal to <code>"audio"</code>, or an {{InvalidStateError}} exception MUST be thrown.</span>
 		</pre>
 
 		<div>
@@ -1761,7 +1761,7 @@ Methods</h4>
 		</div>
 
 		While an {{AudioContext}} is suspended,
-		[[mediacapture-streams#mediastream|MediaStream]]s will have their output ignored; that
+		{{MediaStream}}s will have their output ignored; that
 		is, data will be lost by the real time nature of media streams.
 		{{HTMLMediaElement}}s will similarly have their output
 		ignored until the system is resumed. {{AudioWorkletNode}}s
@@ -2779,7 +2779,7 @@ during a <a>render quantum</a>, if any of the following conditions hold.
 	the current rendering quantum.
 - A {{MediaStreamAudioSourceNode}} or a {{MediaStreamTrackAudioSourceNode}} are
 	[=actively processing=] when the associated
-	[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] object has a
+	{{MediaStreamTrack}} object has a
 	<code>readyState</code> attribute equal to <code>"live"</code>, a
 	<code>muted</code> attribute equal to <code>false</code> and an
 	<code>enabled</code> attribute equal to <code>true</code>.
@@ -7800,12 +7800,12 @@ algorithm</a> [[!FETCH]] labeled the resource as
 The {{MediaStreamAudioDestinationNode}} Interface</h3>
 
 This interface is an audio destination representing a
-[[mediacapture-streams#mediastream|MediaStream]] with a single [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]
-whose <code>kind</code> is <code>"audio"</code>. This [[mediacapture-streams#mediastream|MediaStream]] is
+{{MediaStream}} with a single {{MediaStreamTrack}}
+whose <code>kind</code> is <code>"audio"</code>. This {{MediaStream}} is
 created when the node is created and is accessible via the
 {{MediaStreamAudioDestinationNode/stream}} attribute. This stream can be used in a similar way
-as a [[mediacapture-streams#mediastream|MediaStream]] obtained via
-[[mediacapture-streams#dom-mediadevices-getusermedia|getUserMedia()]], and can, for example, be sent to a
+as a {{MediaStream}} obtained via
+{{getUserMedia()}}, and can, for example, be sent to a
 remote peer using the <code>RTCPeerConnection</code> (described in
 [[!webrtc]]) <code>addStream()</code> method.
 
@@ -7854,7 +7854,7 @@ Attributes</h4>
 <dl dfn-type=attribute dfn-for="MediaStreamAudioDestinationNode">
 	: <dfn>stream</dfn>
 	::
-		A [[mediacapture-streams#mediastream|MediaStream]] containing a single [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] with the same
+		A {{MediaStream}} containing a single {{MediaStreamTrack}} with the same
 		number of channels as the node itself, and whose
 		<code>kind</code> attribute has the value <code>"audio"</code>.
 </dl>
@@ -7867,7 +7867,7 @@ Attributes</h4>
 The {{MediaStreamAudioSourceNode}} Interface</h3>
 
 This interface represents an audio source from a
-[[mediacapture-streams#mediastream|MediaStream]].
+{{MediaStream}}.
 
 <pre class=include>
 path: audionode-noinput.include
@@ -7877,8 +7877,8 @@ macros:
 </pre>
 
 The number of channels of the output corresponds to the number of channels of
-the [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]. When the
-[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] ends, this
+the {{MediaStreamTrack}}. When the
+{{MediaStreamTrack}} ends, this
 {{AudioNode}} outputs one channel of silence.
 
 <pre class="idl">
@@ -7899,13 +7899,13 @@ Constructors</h4>
 				{{NotSupportedError}} exception and abort these steps.
 			2. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
 				{{MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()/options!!argument}} does not reference a
-				[[mediacapture-streams#mediastream|MediaStream]] that has at least one
-				[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] whose
+				{{MediaStream}} that has at least one
+				{{MediaStreamTrack}} whose
 				<code>kind</code> attribute has the value <code>"audio"</code>,
 				throw an {{InvalidStateError}} and abort these steps. Else, let
 				this stream be <var>inputStream</var>.
 			3. Let <var>tracks</var> be the list of all
-				[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]s of
+				{{MediaStreamTrack}}s of
 				<var>inputStream</var> that have a <code>kind</code> of
 				<code>"audio"</code>.
 			4. Sort the elements in <var>tracks</var> based on their <code>id</code>
@@ -7921,15 +7921,15 @@ Constructors</h4>
 			7. Return <var>node</var>.
 
 			After construction, any change to the
-			[[mediacapture-streams#mediastream|MediaStream]] that was passed to
+			{{MediaStream}} that was passed to
 			the constructor do not affect the underlying output of this {{AudioNode}}.
 
 			The slot {{[[input track]]}} is only used to keep a reference to the
-			[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]].
+			{{MediaStreamTrack}}.
 
 			Note: This means that when removing the track chosen by the constructor
 			of the {{MediaStreamAudioSourceNode}} from the
-			[[mediacapture-streams#mediastream|MediaStream]] passed into this
+			{{MediaStream}} passed into this
 			constructor, the {{MediaStreamAudioSourceNode}} will still take its input
 			from the same track.
 
@@ -7949,7 +7949,7 @@ Attributes</h4>
 
 <dl dfn-type=attribute dfn-for="MediaStreamAudioSourceNode">
 	: <dfn>mediaStream</dfn>
-	:: The [[mediacapture-streams#mediastream|MediaStream]] used when constructing this {{MediaStreamAudioSourceNode}}.
+	:: The {{MediaStream}} used when constructing this {{MediaStreamAudioSourceNode}}.
 </dl>
 
 <h4 dictionary lt="MediaStreamAudioSourceOptions">
@@ -7979,7 +7979,7 @@ Dictionary {{MediaStreamAudioSourceOptions}} Members</h5>
 <h3 interface lt="MediaStreamTrackAudioSourceNode">
 The {{MediaStreamTrackAudioSourceNode}} Interface</h3>
 
-This interface represents an audio source from a [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]].
+This interface represents an audio source from a {{MediaStreamTrack}}.
 
 <pre class=include>
 path: audionode-noinput.include
@@ -7989,7 +7989,7 @@ macros:
 </pre>
 
 The number of channels of the output corresponds to the number of
-channels of the [[mediacapture-streams#mediastreamtrack|MediaStreamTrack]].
+channels of the {{MediaStreamTrack}}.
 
 <pre class="idl">
 [Exposed=Window,
@@ -8039,7 +8039,7 @@ Dictionary {{MediaStreamTrackAudioSourceOptions}} Members</h5>
 	: <dfn>mediaStreamTrack</dfn>
 	::
 		The media stream track that will act as a source. <span class="synchronous">If this
-		[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]] <code>kind</code> attribute is
+		{{MediaStreamTrack}} <code>kind</code> attribute is
 		not <code>"audio"</code>, an {{InvalidStateError}}
 		MUST be thrown.</span>
 </dl>
@@ -12067,7 +12067,7 @@ to Consider</a>
 	No. Credit card information and the like is not used in Web Audio.
 	It is possible to use Web Audio to process or analyze voice data,
 	which might be a privacy concern, but access to the user's
-	microphone is permission-based via [[mediacapture-streams#dom-mediadevices-getusermedia|getUserMedia()]].
+	microphone is permission-based via {{getUserMedia()}}.
 
 3. Does this specification introduce new state for an origin that
 	persists across browsing sessions?
@@ -12143,7 +12143,7 @@ to Consider</a>
 	document, but it will involve gaining access to the client
 	machine's audio input or microphone. This will require asking the
 	user for permission in an appropriate way, probably via the
-	[[mediacapture-streams#dom-mediadevices-getusermedia|getUserMedia() API]].
+	{{getUserMedia()}} API.
 
 9. Does this specification allow an origin access to aspects of a
 	user’s local computing environment?

--- a/index.bs
+++ b/index.bs
@@ -41,6 +41,7 @@ Markup Shorthands: markdown on, dfn on, css off
 
 <pre class=anchors>
 spec: ECMAScript; url: https://tc39.github.io/ecma262/#sec-data-blocks; type: dfn; text: data block;
+url: https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia; type: method; for: MediaDevices; text: getUserMedia()
 </pre>
 
 <link rel="preload" href="https://www.w3.org/scripts/MathJax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" as="script">

--- a/index.bs
+++ b/index.bs
@@ -585,7 +585,7 @@ The interfaces defined are:
 
 * A {{MediaStreamAudioSourceNode}} interface, an
 	{{AudioNode}} which is the audio source from a
-	MediaStream such as live audio input, or from a remote peer.
+	{{MediaStream}} such as live audio input, or from a remote peer.
 
 * A {{MediaStreamTrackAudioSourceNode}} interface,
 	an {{AudioNode}} which is the audio source from a
@@ -593,7 +593,7 @@ The interfaces defined are:
 
 * A {{MediaStreamAudioDestinationNode}} interface,
 	an {{AudioNode}} which is the audio destination to a
-	MediaStream sent to a remote peer.
+	{{MediaStream}} sent to a remote peer.
 
 * A {{PannerNode}} interface, an
 	{{AudioNode}} for spatializing / positioning audio in


### PR DESCRIPTION
Replaced the incorrect links with new links now that bikeshed knows
about the MediaCapture spec:

* `[[mediacapture-streams#dom-mediadevices-getusermedia|getUserMedia()]]` -> `{{getUserMedia()}}`
* `[[mediacapture-streams#mediastreamtrack|MediaStreamTrack]]` -> `{{MediaStreamTrack}}`
* `[[mediacapture-streams#mediastream|MediaStream]]` -> `{{MediaStream}}`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2057.html" title="Last updated on Sep 9, 2019, 6:12 PM UTC (10a2328)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2057/41d1e60...rtoy:10a2328.html" title="Last updated on Sep 9, 2019, 6:12 PM UTC (10a2328)">Diff</a>