### PR TITLE
Fix typo in the prose for linearRampToValueAtTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3666,7 +3666,7 @@ Methods</h4>
 		$$
 		</pre>
 
-		Where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is
+		where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is
 		the {{AudioParam/linearRampToValueAtTime()/value!!argument}} parameter passed into this method.
 
 		If there are no more events after this <em>LinearRampToValue</em> event


### PR DESCRIPTION
This fixes #2059.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2065.html" title="Last updated on Sep 18, 2019, 2:16 AM UTC (23043b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2065/77eaf0b...padenot:23043b8.html" title="Last updated on Sep 18, 2019, 2:16 AM UTC (23043b8)">Diff</a>