### PR TITLE
Update with the new ctor syntax 

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -2,42 +2,42 @@ WARNING: Multiple elements have the same ID 'dom-decodeerrorcallback-error'.
 Deduping, but this ID may not be stable across revisions.
 WARNING: Multiple elements have the same ID 'dom-decodesuccesscallback-decodeddata'.
 Deduping, but this ID may not be stable across revisions.
-LINE 1910: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)' in the argumentdef block.
-LINE 3019: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE 3019: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE 3120: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 3133: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 3148: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 3148: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 10077: Can't find method '['AudioWorkletProcessor/process(inputs, outputs, parameters))']'.
-LINE 1407: No 'method' refs found for 'AudioContext()'.
-LINE 1910: No 'method' refs found for 'OfflineAudioContext(contextOptions)'.
-LINE 1934: No 'method' refs found for 'OfflineAudioContext(numberOfChannels, length, sampleRate)'.
-LINE 2291: No 'method' refs found for 'AudioBuffer()'.
-LINE 4158: No 'method' refs found for 'AnalyserNode()'.
-LINE 4618: No 'method' refs found for 'AudioBufferSourceNode()'.
-LINE 5853: No 'method' refs found for 'BiquadFilterNode()'.
-LINE 6286: No 'method' refs found for 'ChannelMergerNode()'.
-LINE 6398: No 'method' refs found for 'ChannelSplitterNode()'.
-LINE 6480: No 'method' refs found for 'ConstantSourceNode()'.
-LINE 6588: No 'method' refs found for 'ConvolverNode()'.
-LINE 6844: No 'method' refs found for 'DelayNode()'.
-LINE 7009: No 'method' refs found for 'DynamicsCompressorNode()'.
-LINE 7451: No 'method' refs found for 'GainNode()'.
-LINE 7558: No 'method' refs found for 'IIRFilterNode()'.
-LINE 7731: No 'method' refs found for 'MediaElementAudioSourceNode()'.
-LINE 7837: No 'method' refs found for 'MediaStreamAudioDestinationNode()'.
-LINE 7929: No 'method' refs found for 'MediaStreamAudioSourceNode()'.
-LINE 8005: No 'method' refs found for 'MediaStreamTrackAudioSourceNode()'.
-LINE 8144: No 'method' refs found for 'OscillatorNode()'.
-LINE 8533: No 'method' refs found for 'PannerNode()'.
-LINE 8934: No 'method' refs found for 'PeriodicWave()'.
-LINE 9246: No 'method' refs found for 'StereoPannerNode()'.
-LINE 9375: No 'method' refs found for 'WaveShaperNode()'.
-LINE 9806: No 'method' refs found for 'AudioWorkletNode()'.
+LINE: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find method '['AudioWorkletProcessor/process(inputs, outputs, parameters))']'.
+LINE: No 'method' refs found for 'constructor(contextOptions)'.
+LINE: No 'method' refs found for 'constructor(contextOptions)'.
+LINE: No 'method' refs found for 'constructor(numberOfChannels, length, sampleRate)'.
+LINE: No 'method' refs found for 'constructor(options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, options)'.
+LINE: No 'method' refs found for 'constructor(context, name, options)'.
 LINK ERROR: No 'idl-name' refs found for 'sequence<unsigned long>'.
 <a data-link-type="idl-name" data-lt="sequence&lt;unsigned long&gt;">sequence&lt;unsigned long&gt;</a>
 LINK ERROR: No 'idl-name' refs found for 'record<DOMString, double>'.
 <a data-link-type="idl-name" data-lt="record&lt;DOMString, double&gt;">record&lt;DOMString, double&gt;</a>
-LINE 10077: No 'method' refs found for 'process(inputs, outputs, parameters))'.
+LINE: No 'method' refs found for 'process(inputs, outputs, parameters))'.
 YAY Successfully generated, but fatal errors were suppressed

--- a/index.bs
+++ b/index.bs
@@ -1314,19 +1314,19 @@ enum AudioContextLatencyCategory {
 </div>
 
 <xmp class="idl">
-[Exposed=Window,
- Constructor (optional AudioContextOptions contextOptions)]
+[Exposed=Window]
 interface AudioContext : BaseAudioContext {
-		readonly attribute double baseLatency;
-		readonly attribute double outputLatency;
-		AudioTimestamp getOutputTimestamp ();
-		Promise<void> resume ();
-		Promise<void> suspend ();
-		Promise<void> close ();
-		MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
-		MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
-		MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (MediaStreamTrack mediaStreamTrack);
-		MediaStreamAudioDestinationNode createMediaStreamDestination ();
+	constructor (optional AudioContextOptions contextOptions);
+	readonly attribute double baseLatency;
+	readonly attribute double outputLatency;
+	AudioTimestamp getOutputTimestamp ();
+	Promise<void> resume ();
+	Promise<void> suspend ();
+	Promise<void> close ();
+	MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
+	MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
+	MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (MediaStreamTrack mediaStreamTrack);
+	MediaStreamAudioDestinationNode createMediaStreamDestination ();
 };
 </xmp>
 
@@ -1876,10 +1876,10 @@ returned promise with the rendered result as an
 {{AudioBuffer}}.
 
 <xmp class="idl">
-[Exposed=Window,
- Constructor (OfflineAudioContextOptions contextOptions),
- Constructor (unsigned long numberOfChannels, unsigned long length, float sampleRate)]
+[Exposed=Window]
 interface OfflineAudioContext : BaseAudioContext {
+	constructor(OfflineAudioContextOptions contextOptions);
+	constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
 	Promise<AudioBuffer> startRendering();
 	Promise<void> resume();
 	Promise<void> suspend(double suspendTime);
@@ -2173,9 +2173,9 @@ This is an {{Event}} object which is dispatched to
 {{OfflineAudioContext}} for legacy reasons.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (DOMString type, OfflineAudioCompletionEventInit eventInitDict)]
+[Exposed=Window]
 interface OfflineAudioCompletionEvent : Event {
+	constructor (DOMString type, OfflineAudioCompletionEventInit eventInitDict);
 	readonly attribute AudioBuffer renderedBuffer;
 };
 </pre>
@@ -2255,9 +2255,9 @@ An {{AudioBuffer}} may be used by one or more
 </dl>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (AudioBufferOptions options)]
+[Exposed=Window]
 interface AudioBuffer {
+	constructor (AudioBufferOptions options);
 	readonly attribute float sampleRate;
 	readonly attribute unsigned long length;
 	readonly attribute double duration;
@@ -4138,9 +4138,9 @@ macros:
 </pre>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional AnalyserOptions options = {})]
+[Exposed=Window]
 interface AnalyserNode : AudioNode {
+	constructor (BaseAudioContext context, optional AnalyserOptions options = {});
 	void getFloatFrequencyData (Float32Array array);
 	void getByteFrequencyData (Uint8Array array);
 	void getFloatTimeDomainData (Float32Array array);
@@ -4594,9 +4594,9 @@ The <a>nominal range</a> for this <a>compound parameter</a> is
 slot <dfn attribute for="AudioBufferSourceNode">[[buffer set]]</dfn>, initially set to false.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional AudioBufferSourceOptions options = {})]
+[Exposed=Window]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
+	constructor (BaseAudioContext context, optional AudioBufferSourceOptions options = {});
 	attribute AudioBuffer? buffer;
 	readonly attribute AudioParam playbackRate;
 	readonly attribute AudioParam detune;
@@ -5563,9 +5563,9 @@ synthesized data if there are no inputs) is then placed into the
 {{AudioProcessingEvent/outputBuffer}}.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (DOMString type, AudioProcessingEventInit eventInitDict)]
+[Exposed=Window]
 interface AudioProcessingEvent : Event {
+	constructor (DOMString type, AudioProcessingEventInit eventInitDict);
 	readonly attribute double playbackTime;
 	readonly attribute AudioBuffer inputBuffer;
 	readonly attribute AudioBuffer outputBuffer;
@@ -5832,9 +5832,9 @@ enum BiquadFilterType {
 All attributes of the {{BiquadFilterNode}} are <a>a-rate</a> {{AudioParam}}s.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional BiquadFilterOptions options = {})]
+[Exposed=Window]
 interface BiquadFilterNode : AudioNode {
+	constructor (BaseAudioContext context, optional BiquadFilterOptions options = {});
 	attribute BiquadFilterType type;
 	readonly attribute AudioParam frequency;
 	readonly attribute AudioParam detune;
@@ -6271,9 +6271,9 @@ output channels.
 </div>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelMergerOptions options = {})]
+[Exposed=Window]
 interface ChannelMergerNode : AudioNode {
+	constructor (BaseAudioContext context, optional ChannelMergerOptions options = {});
 };
 </pre>
 
@@ -6383,9 +6383,9 @@ One application for {{ChannelSplitterNode}} is for doing
 desired.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ChannelSplitterOptions options = {})]
+[Exposed=Window]
 interface ChannelSplitterNode : AudioNode {
+	constructor (BaseAudioContext context, optional ChannelSplitterOptions options = {});
 };
 </pre>
 
@@ -6464,9 +6464,9 @@ macros:
 </pre>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ConstantSourceOptions options = {})]
+[Exposed=Window]
 interface ConstantSourceNode : AudioScheduledSourceNode {
+	constructor (BaseAudioContext context, optional ConstantSourceOptions options = {});
 	readonly attribute AudioParam offset;
 };
 </pre>
@@ -6569,9 +6569,9 @@ constraints</a> for this node. These constraints ensure that the
 input to the node is either mono or stereo.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional ConvolverOptions options = {})]
+[Exposed=Window]
 interface ConvolverNode : AudioNode {
+	constructor (BaseAudioContext context, optional ConvolverOptions options = {});
 	attribute AudioBuffer? buffer;
 	attribute boolean normalize;
 };
@@ -6834,9 +6834,9 @@ Note: By definition, a {{DelayNode}} introduces an audio processing
 latency equal to the amount of the delay.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional DelayOptions options = {})]
+[Exposed=Window]
 interface DelayNode : AudioNode {
+	constructor (BaseAudioContext context, optional DelayOptions options = {});
 	readonly attribute AudioParam delayTime;
 };
 </pre>
@@ -6990,9 +6990,9 @@ macros:
 </pre>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional DynamicsCompressorOptions options = {})]
+[Exposed=Window]
 interface DynamicsCompressorNode : AudioNode {
+	constructor (BaseAudioContext context, optional DynamicsCompressorOptions options = {});
 	readonly attribute AudioParam threshold;
 	readonly attribute AudioParam knee;
 	readonly attribute AudioParam ratio;
@@ -7440,9 +7440,9 @@ Each sample of each channel of the input data of the
 <a>computedValue</a> of the {{GainNode/gain}} {{AudioParam}}.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional GainOptions options = {})]
+[Exposed=Window]
 interface GainNode : AudioNode {
+	constructor (BaseAudioContext context, optional GainOptions options = {});
 	readonly attribute AudioParam gain;
 };
 </pre>
@@ -7551,9 +7551,9 @@ The number of channels of the output always equals the number of
 channels of the input.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, IIRFilterOptions options)]
+[Exposed=Window]
 interface IIRFilterNode : AudioNode {
+	constructor (BaseAudioContext context, IIRFilterOptions options);
 	void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
 };
 </pre>
@@ -7718,9 +7718,9 @@ attribute changes, and other aspects of the
 </pre>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (AudioContext context, MediaElementAudioSourceOptions options)]
+[Exposed=Window]
 interface MediaElementAudioSourceNode : AudioNode {
+	constructor (AudioContext context, MediaElementAudioSourceOptions options);
 	[SameObject] readonly attribute HTMLMediaElement mediaElement;
 };
 </pre>
@@ -7824,9 +7824,9 @@ macros:
 The number of channels of the input is by default 2 (stereo).
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (AudioContext context, optional AudioNodeOptions options = {})]
+[Exposed=Window]
 interface MediaStreamAudioDestinationNode : AudioNode {
+	constructor (AudioContext context, optional AudioNodeOptions options = {});
 	readonly attribute MediaStream stream;
 };
 </pre>
@@ -7883,9 +7883,9 @@ the {{MediaStreamTrack}}. When the
 {{AudioNode}} outputs one channel of silence.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (AudioContext context, MediaStreamAudioSourceOptions options)]
+[Exposed=Window]
 interface MediaStreamAudioSourceNode : AudioNode {
+	constructor (AudioContext context, MediaStreamAudioSourceOptions options);
 	[SameObject] readonly attribute MediaStream mediaStream;
 };
 </pre>
@@ -7993,9 +7993,9 @@ The number of channels of the output corresponds to the number of
 channels of the {{MediaStreamTrack}}.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (AudioContext context, MediaStreamTrackAudioSourceOptions options)]
+[Exposed=Window]
 interface MediaStreamTrackAudioSourceNode : AudioNode {
+	constructor (AudioContext context, MediaStreamTrackAudioSourceOptions options);
 };
 </pre>
 
@@ -8133,9 +8133,9 @@ enum OscillatorType {
 </div>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional OscillatorOptions options = {})]
+[Exposed=Window]
 interface OscillatorNode : AudioScheduledSourceNode {
+	constructor (BaseAudioContext context, optional OscillatorOptions options = {});
 	attribute OscillatorType type;
 	readonly attribute AudioParam frequency;
 	readonly attribute AudioParam detune;
@@ -8501,9 +8501,9 @@ enum DistanceModelType {
 </div>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional PannerOptions options = {})]
+[Exposed=Window]
 interface PannerNode : AudioNode {
+	constructor (BaseAudioContext context, optional PannerOptions options = {});
 	attribute PanningModelType panningModel;
 	readonly attribute AudioParam positionX;
 	readonly attribute AudioParam positionY;
@@ -8894,9 +8894,9 @@ A <a>conforming implementation</a> MUST support {{PeriodicWave}}
 up to at least 8192 elements.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional PeriodicWaveOptions options = {})]
+[Exposed=Window]
 interface PeriodicWave {
+	constructor (BaseAudioContext context, optional PeriodicWaveOptions options = {});
 };
 </pre>
 
@@ -9238,9 +9238,9 @@ The output of this node is hard-coded to stereo (2 channels) and
 cannot be configured.
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional StereoPannerOptions options = {})]
+[Exposed=Window]
 interface StereoPannerNode : AudioNode {
+	constructor (BaseAudioContext context, optional StereoPannerOptions options = {});
 	readonly attribute AudioParam pan;
 };
 </pre>
@@ -9368,9 +9368,9 @@ enum OverSampleType {
 </div>
 
 <pre class="idl">
-[Exposed=Window,
- Constructor (BaseAudioContext context, optional WaveShaperOptions options = {})]
+[Exposed=Window]
 interface WaveShaperNode : AudioNode {
+	constructor (BaseAudioContext context, optional WaveShaperOptions options = {});
 	attribute Float32Array? curve;
 	attribute OverSampleType oversample;
 };
@@ -9925,11 +9925,10 @@ This interface has "entries", "forEach", "get", "has", "keys",
 <code>readonly maplike</code>.
 
 <pre class="idl">
-[Exposed=Window,
- SecureContext,
- Constructor (BaseAudioContext context, DOMString name,
-              optional AudioWorkletNodeOptions options = {})]
+[Exposed=Window, SecureContext]
 interface AudioWorkletNode : AudioNode {
+	constructor (BaseAudioContext context, DOMString name,
+               optional AudioWorkletNodeOptions options = {});
 	readonly attribute AudioParamMap parameters;
 	readonly attribute MessagePort port;
 	attribute EventHandler onprocessorerror;
@@ -10209,9 +10208,9 @@ Note that the an {{AudioWorkletProcessor}} construction can only happen as a
 result of an {{AudioWorkletNode}} contruction.
 
 <pre class="idl">
-[Exposed=AudioWorklet,
-Constructor (optional AudioWorkletNodeOptions options = {})]
+[Exposed=AudioWorklet]
 interface AudioWorkletProcessor {
+	constructor (optional AudioWorkletNodeOptions options = {});
 	readonly attribute MessagePort port;
 };
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -1406,7 +1406,7 @@ Constructors</h4>
 		they have access to a logging mechanism, such as a developer
 		tools console.
 
-		<pre class="argumentdef" for="AudioContext/AudioContext()">
+		<pre class="argumentdef" for="AudioContext/constructor(contextOptions)">
 		contextOptions: User-specified options controlling how the {{AudioContext}} should be constructed.
 		</pre>
 </dl>
@@ -1909,7 +1909,7 @@ Constructors</h4>
 				<code>contextOptions.numberOfChannels</code>.
 		</div>
 
-		<pre class=argumentdef for="OfflineAudioContext/OfflineAudioContext(contextOptions)">
+		<pre class=argumentdef for="OfflineAudioContext/constructor(contextOptions)">
 		contextOptions: The initial parameters needed to construct this context.
 		</pre>
 
@@ -1933,7 +1933,7 @@ Constructors</h4>
 
 		were called instead.
 
-		<pre class=argumentdef for="OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)">
+		<pre class=argumentdef for="OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)">
 		numberOfChannels: Determines how many channels the buffer will have. See {{BaseAudioContext/createBuffer()}} for the supported number of channels.
 		length: Determines the size of the buffer in sample-frames.
 		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in the buffer in sample-frames per second. See {{BaseAudioContext/createBuffer()}} for valid sample rates.
@@ -2291,8 +2291,8 @@ Constructors</h4>
 
 			1. Return <var>b</var>.
 		</div>
-		<pre class=argumentdef for="AudioBuffer/AudioBuffer()">
-		options:
+		<pre class=argumentdef for="AudioBuffer/constructor(options)">
+		options: An {{AudioBufferOptions}} that determine the properties for this {{AudioBuffer}}.
 		</pre>
 </dl>
 
@@ -4159,7 +4159,7 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="AnalyserNode">
 	: <dfn>AnalyserNode(context, options)</dfn>
 	::
-		<pre class=argumentdef for="AnalyserNode/AnalyserNode()">
+		<pre class=argumentdef for="AnalyserNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{AnalyserNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{AnalyserNode}}.
 		</pre>
@@ -4612,14 +4612,14 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
 <h4 id="AudioBufferSourceNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="AudioBufferSourceNode">
+<dl dfn-type=method dfn-for="AudioBufferSourceNode/constructor">
 	: <dfn>AudioBufferSourceNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{AudioBufferSourceNode}}
 		object. <a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="AudioBufferSourceNode/AudioBufferSourceNode()">
+		<pre class=argumentdef for="AudioBufferSourceNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{AudioBufferSourceNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{AudioBufferSourceNode}}.
 		</pre>
@@ -5847,14 +5847,14 @@ interface BiquadFilterNode : AudioNode {
 <h4 id="BiquadFilterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="BiquadFilterNode">
+<dl dfn-type=method dfn-for="BiquadFilterNode">
 	: <dfn>BiquadFilterNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{BiquadFilterNode}} object.
 		<a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="BiquadFilterNode/BiquadFilterNode()">
+		<pre class=argumentdef for="BiquadFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{BiquadFilterNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{BiquadFilterNode}}.
 		</pre>
@@ -6280,14 +6280,14 @@ interface ChannelMergerNode : AudioNode {
 <h4 id="ChannelMergerNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ChannelMergerNode">
+<dl dfn-type=method dfn-for="ChannelMergerNode/constructor">
 	: <dfn>ChannelMergerNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{ChannelMergerNode}} object.
 		<a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="ChannelMergerNode/ChannelMergerNode()">
+		<pre class=argumentdef for="ChannelMergerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ChannelMergerNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{ChannelMergerNode}}.
 		</pre>
@@ -6392,14 +6392,14 @@ interface ChannelSplitterNode : AudioNode {
 <h4 id="ChannelSplitterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ChannelSplitterNode">
+<dl dfn-type=constructor dfn-for="ChannelSplitterNode/constructor()">
 	: <dfn>ChannelSplitterNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{ChannelSplitterNode}} object.
 		<a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="ChannelSplitterNode/ChannelSplitterNode()">
+		<pre class=argumentdef for="ChannelSplitterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ChannelSplitterNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{ChannelSplitterNode}}.
 		</pre>
@@ -6474,14 +6474,14 @@ interface ConstantSourceNode : AudioScheduledSourceNode {
 <h4 id="ConstantSourceNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ConstantSourceNode">
+<dl dfn-type=method dfn-for="ConstantSourceNode/constructor()">
 	: <dfn>ConstantSourceNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{ConstantSourceNode}} object.
 		<a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="ConstantSourceNode/ConstantSourceNode()">
+		<pre class=argumentdef for="ConstantSourceNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ConstantSourceNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{ConstantSourceNode}}.
 		</pre>
@@ -6580,7 +6580,7 @@ interface ConvolverNode : AudioNode {
 <h4 id="ConvolverNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ConvolverNode">
+<dl dfn-type=constructor dfn-for="ConvolverNode/constructor()">
 	: <dfn>ConvolverNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{ConvolverNode}} object.
@@ -6589,7 +6589,7 @@ Constructors</h4>
 		<dfn attribute for="ConvolverNode">[[buffer set]]</dfn>, and initialize it to <code>false</code>. Return
 		<var>node</var>.
 
-		<pre class=argumentdef for="ConvolverNode/ConvolverNode()">
+		<pre class=argumentdef for="ConvolverNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ConvolverNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{ConvolverNode}}.
 		</pre>
@@ -6844,13 +6844,13 @@ interface DelayNode : AudioNode {
 <h4 id="DelayNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="DelayNode">
+<dl dfn-type=constructor dfn-for="DelayNode/constructor()">
 	: <dfn>DelayNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{DelayNode}} object. <a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
 		and return <var>node</var>.
 
-		<pre class=argumentdef for="DelayNode/DelayNode()">
+		<pre class=argumentdef for="DelayNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{DelayNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{DelayNode}}.
 		</pre>
@@ -7005,7 +7005,7 @@ interface DynamicsCompressorNode : AudioNode {
 <h4 id="DynamicsCompressorNode-constructors">
 Constructors</h4>
 
-<dl dfn-type="constructor" dfn-for="DynamicsCompressorNode">
+<dl dfn-type="method" dfn-for="DynamicsCompressorNode/constructor()">
 	: <dfn>DynamicsCompressorNode(context, options)</dfn>
 	::
 		Let <var>node</var> be a new {{DynamicsCompressorNode}}
@@ -7015,7 +7015,7 @@ Constructors</h4>
 		point number, in decibels. Set {{[[internal reduction]]}} to 0.0.
 		Return <var>node</var>.
 
-		<pre class=argumentdef for="DynamicsCompressorNode/DynamicsCompressorNode()">
+		<pre class=argumentdef for="DynamicsCompressorNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{DynamicsCompressorNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{DynamicsCompressorNode}}.
 		</pre>
@@ -7450,14 +7450,14 @@ interface GainNode : AudioNode {
 <h4 id="GainNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="GainNode">
+<dl dfn-type=method dfn-for="GainNode/constructor()">
 	: <dfn>GainNode(context, options)</dfn>
 	::
 		Let <var>gain</var> be a new {{GainNode}} object.
 		<a href="#audionode-constructor-init">Initialize</a> <var>gain</var>,
 		and return <var>gain</var>.
 
-		<pre class=argumentdef for="GainNode/GainNode()">
+		<pre class=argumentdef for="GainNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{GainNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter values for this {{GainNode}}.
 		</pre>
@@ -7561,10 +7561,10 @@ interface IIRFilterNode : AudioNode {
 <h4 id="IIRFilterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="IIRFilterNode">
+<dl dfn-type=constructor dfn-for="IIRFilterNode/constructor()">
 	: <dfn>IIRFilterNode(context, options)</dfn>
 	::
-		<pre class=argumentdef for="IIRFilterNode/IIRFilterNode()">
+		<pre class=argumentdef for="IIRFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{IIRFilterNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{IIRFilterNode}}.
 		</pre>
@@ -7737,7 +7737,7 @@ Constructors</h4>
 			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
 			return <var>node</var>.
 
-		<pre class=argumentdef for="MediaElementAudioSourceNode/MediaElementAudioSourceNode()">
+		<pre class=argumentdef for="MediaElementAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaElementAudioSourceNode}} will be <a href="#associated">associated</a> with.
 			options: Initial parameter value for this {{MediaElementAudioSourceNode}}.
 		</pre>
@@ -7843,7 +7843,7 @@ Constructors</h4>
 			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
 			return <var>node</var>.
 
-		<pre class=argumentdef for="MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode()">
+		<pre class=argumentdef for="MediaStreamAudioDestinationNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{MediaStreamAudioDestinationNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{MediaStreamAudioDestinationNode}}.
 		</pre>
@@ -7938,7 +7938,7 @@ Constructors</h4>
 			legacy reasons. {{MediaStreamTrackAudioSourceNode}} can be used
 			instead to be explicit about which track to use as input.
 
-		<pre class=argumentdef for="MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()">
+		<pre class=argumentdef for="MediaStreamAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaStreamAudioSourceNode}} will be <a href="#associated">associated</a> with.
 			options: Initial parameter value for this {{MediaStreamAudioSourceNode}}.
 		</pre>
@@ -8014,7 +8014,7 @@ Constructors</h4>
 			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
 			return <var>node</var>.
 
-		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode()">
+		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaStreamTrackAudioSourceNode}} will be <a href="#associated">associated</a> with.
 			options: Initial parameter value for this {{MediaStreamTrackAudioSourceNode}}.
 		</pre>
@@ -8153,7 +8153,7 @@ Constructors</h4>
 		<a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="OscillatorNode/OscillatorNode()">
+		<pre class=argumentdef for="OscillatorNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{OscillatorNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{OscillatorNode}}.
 		</pre>
@@ -8542,7 +8542,7 @@ Constructors</h4>
 		<a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
 		and return <var>node</var>.
 
-		<pre class=argumentdef for="PannerNode/PannerNode()">
+		<pre class=argumentdef for="PannerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{PannerNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{PannerNode}}.
 		</pre>
@@ -8943,7 +8943,7 @@ Constructors</h4>
 			6. Return <var>p</var>.
 		</div>
 
-		<pre class=argumentdef for="PeriodicWave/PeriodicWave()">
+		<pre class=argumentdef for="PeriodicWave/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{PeriodicWave}} will be <a href="#associated">associated</a> with. Unlike {{AudioBuffer}}, {{PeriodicWave}}s can't be shared accross {{AudioContext}}s or {{OfflineAudioContext}}s. It is associated with a particular {{BaseAudioContext}}.
 			options: Optional initial parameter value for this {{PeriodicWave}}.
 		</pre>
@@ -9255,7 +9255,7 @@ Constructors</h4>
 		object. <a href="#audionode-constructor-init">Initialize</a>
 		<var>node</var>, and return <var>node</var>.
 
-		<pre class=argumentdef for="StereoPannerNode/StereoPannerNode()">
+		<pre class=argumentdef for="StereoPannerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{StereoPannerNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{StereoPannerNode}}.
 		</pre>
@@ -9384,7 +9384,7 @@ Constructors</h4>
 	::
 		Let <var>node</var> be a new {{WaveShaperNode}} object, and let <dfn attribute for="WaveShaperNode">[[curve set]]</dfn> be an internal slot of the <var>node</var>, initialized to <code>false</code>.  <a href="#audionode-constructor-init">Initialize</a> <var>node</var>. If {{WaveShaperNode/WaveShaperNode()/options!!argument}} is given and specifies a {{WaveShaperOptions/curve}}, set {{[[curve set]]}} to <code>true</code>. Return <var>node</var>.
 
-		<pre class=argumentdef for="WaveShaperNode/WaveShaperNode()">
+		<pre class=argumentdef for="WaveShaperNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{WaveShaperNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{WaveShaperNode}}.
 		</pre>
@@ -9941,7 +9941,7 @@ Constructors</h5>
 <dl dfn-type=constructor dfn-for="AudioWorkletNode">
 	: <dfn>AudioWorkletNode(context, name, options)</dfn>
 	::
-		<pre class=argumentdef for="AudioWorkletNode/AudioWorkletNode()">
+		<pre class=argumentdef for="AudioWorkletNode/constructor(context, name, options)">
 			context: The {{BaseAudioContext}} this new {{AudioWorkletNode}} will be <a href="#associated">associated</a> with.
 			name: A string that is a key for the {{BaseAudioContext}}’s <a>node name to parameter descriptor map</a>.
 			options: Optional initial parameters value for this {{AudioWorkletNode}}.


### PR DESCRIPTION
This fixes #2051.

There are still issues with bikeshed and the webidl parser, but it's largely there. In particular, arguments don't work yet, and method referencing seems buggy as well. I'll investigate later.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2066.html" title="Last updated on Sep 27, 2019, 3:38 PM UTC (073f55a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2066/77eaf0b...padenot:073f55a.html" title="Last updated on Sep 27, 2019, 3:38 PM UTC (073f55a)">Diff</a>