### PR TITLE
Fix JS in Example 2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -354,28 +354,21 @@ reverb send with a dynamics compressor at the final output stage:
 </figure>
 
 <pre class="example" highlight="js" line-numbers>
-const context = 0;
-const compressor = 0;
-const reverb = 0;
+let context;
+let compressor;
+let reverb;
 
-const source1 = 0;
-const source2 = 0;
-const source3 = 0;
+let source1, source2, source3;
 
-const lowpassFilter = 0;
-const waveShaper = 0;
-const panner = 0;
+let lowpassFilter;
+let waveShaper;
+let panner;
 
-const dry1 = 0;
-const dry2 = 0;
-const dry3 = 0;
+let dry1, dry2, dry3;
+let wet1, wet2, wet3;
 
-const wet1 = 0;
-const wet2 = 0;
-const wet3 = 0;
-
-const masterDry = 0;
-const masterWet = 0;
+let masterDry;
+let masterWet;
 
 function setupRoutingGraph () {
 	context = new AudioContext();


### PR DESCRIPTION
The code in example 2 would throw an error once `setupRoutingGraph()` is called.
Replaced `const` with `let` and removed initialization with `0` (which does not make any sense).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tim-we/web-audio-api/pull/2068.html" title="Last updated on Sep 26, 2019, 8:56 PM UTC (088946b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2068/98bef48...tim-we:088946b.html" title="Last updated on Sep 26, 2019, 8:56 PM UTC (088946b)">Diff</a>