### PR TITLE
Fix: #2077: Replace NaN in AudioParam with defaultValue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3857,7 +3857,7 @@ These values MUST be computed as follows:
 
 	2. <var>paramComputedValue</var> is the sum of the <var>paramIntrinsicValue</var>
 		value and the value of the <a href="#input-audioparam-buffer">input
-		AudioParam buffer</a>.
+		AudioParam buffer</a>.  If the sum is <code>NaN</code>, replace the sum with the {{AudioParam/defaultValue}}.
 
 	3. If this {{AudioParam}} is a <a>compound parameter</a>,
 		compute its final value with other {{AudioParam}}s.


### PR DESCRIPTION
If an AudioParam value is NaN (perhaps because the connected input
contains NaN), replace the NaN value with AudioParam.defaultValue.
This seems like a reasonable default that might be a bit easier to
explaing than choosing 0 or the min or max value of the AudioParam.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2081.html" title="Last updated on Oct 14, 2019, 5:29 PM UTC (f61564f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2081/3a5e40a...rtoy:f61564f.html" title="Last updated on Oct 14, 2019, 5:29 PM UTC (f61564f)">Diff</a>