### PR TITLE
Fix #2078: Link to computedFrequency for Biquad detune/frequency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5876,7 +5876,7 @@ Attributes</h4>
 	: <dfn>detune</dfn>
 	::
 		A detune value, in cents, for the frequency. It forms a
-		<a>compound parameter</a> with {{BiquadFilterNode/frequency}}.
+		<a>compound parameter</a> with {{BiquadFilterNode/frequency}} to form the <a>computedFrequency</a>.
 
 		<pre class=include>
 		path: audioparam.include
@@ -5893,7 +5893,7 @@ Attributes</h4>
 	::
 		The frequency at which the {{BiquadFilterNode}}
 		will operate, in Hz. It forms a <a>compound parameter</a> with
-		{{BiquadFilterNode/detune}}.
+		{{BiquadFilterNode/detune}} to form the <a>computedFrequency</a>.
 
 		<pre class=include>
 		path: audioparam.include


### PR DESCRIPTION
Adds a link from the Biquad detune and frequency attributes to the
computedFrequency to make it easier to find the how these combine.
Modeled after computedOscFrequency for Oscillators.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2084.html" title="Last updated on Oct 21, 2019, 2:42 PM UTC (4501a5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2084/a1f3ff4...rtoy:4501a5a.html" title="Last updated on Oct 21, 2019, 2:42 PM UTC (4501a5a)">Diff</a>