### PR TITLE
Fix #2083: Restore note for WaveShaper output from #1497

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9468,6 +9468,12 @@ Attributes</h4>
 				attribute.
 		</div>
 
+		Note: The use of a curve that produces a non-zero
+		output value for zero input value will cause this node
+		to produce a DC signal even if there are no inputs
+		connected to this node. This will persist until the
+		node is disconnected from downstream nodes.
+
 	: <dfn>oversample</dfn>
 	::
 		Specifies what type of oversampling (if any) should be used


### PR DESCRIPTION
Restores the note introduced in #1497 that states that the
WaveShaperNode will continue to output a value if there are no inputs
if the curve produces a non-zero output for a zero input.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2085.html" title="Last updated on Oct 21, 2019, 2:50 PM UTC (7c48423)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2085/a1f3ff4...rtoy:7c48423.html" title="Last updated on Oct 21, 2019, 2:50 PM UTC (7c48423)">Diff</a>