### PR TITLE
Fix #2082: Clarify WaveShaperNode interpolation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9420,23 +9420,25 @@ Attributes</h4>
 				the length of the
 				{{WaveShaperNode/curve}}.
 
-			1. Compute the output \(y\) according to
-				<pre nohighlight>
-					$$
-					y = \left(1-f\right)c_k + fc_{k+1}
-					$$
-				</pre>
-				where
+			1. Let
 				<pre nohighlight>
 				$$
 					\begin{align*}
-					v &= 
+					v &= \frac{N-1}{2}(x + 1) \\
+					k &= \lfloor v \rfloor
+					\end{align*}
+				$$
+				</pre>
+			1. Then
+				<pre nohighlight>
+				$$
+					\begin{align*}
+					y &= 
 						\begin{cases}
-						0 & x \lt -1 \\
-						1 & x > 1 \\
-						\frac{N-1}{2}(x + 1) & \mathrm{otherwise}
-						\end{cases} \\
-					f &= v - \lfloor v \rfloor \\
+						c_0 & v \lt 0 \\
+						c_{N-1} & v \ge N - 1 \\
+						(1-f)\,c_k + fc_k & \mathrm{otherwise}
+						\end{cases}
 					\end{align*}
 				$$
 				</pre>

--- a/index.bs
+++ b/index.bs
@@ -9425,7 +9425,8 @@ Attributes</h4>
 				$$
 					\begin{align*}
 					v &= \frac{N-1}{2}(x + 1) \\
-					k &= \lfloor v \rfloor
+					k &= \lfloor v \rfloor \\
+					f &= v - k
 					\end{align*}
 				$$
 				</pre>


### PR DESCRIPTION
Clarify the interpolation algorithm which was missing a method of how
to compute `k`.  We refine the algorithm to show how `k` is computed.
This required some small rearrangement of the computations.

This is based on how Chrome actually does the interpolation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2086.html" title="Last updated on Oct 21, 2019, 6:06 PM UTC (dbb44ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2086/a1f3ff4...rtoy:dbb44ee.html" title="Last updated on Oct 21, 2019, 6:06 PM UTC (dbb44ee)">Diff</a>