### PR TITLE
Fix #2087: Clarify minor issues in BiquadFilter AudioParams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5865,22 +5865,31 @@ Attributes</h4>
 		For {{BiquadFilterType/lowpass}} and
 		{{BiquadFilterType/highpass}} filters the
 		{{BiquadFilterNode/Q}} value is interpreted to be in
-		dB.  For the {{BiquadFilterType/bandpass}},
+		dB.  For these filters the nominal range is
+		\([-Q_{lim}, Q_{lim}]\) where \(Q_{lim}\) is the largest
+		value for which \(10^{Q/20}\) does not overflow.  This
+		is approximately \(770.63678\).
+
+		For the {{BiquadFilterType/bandpass}},
 		{{BiquadFilterType/notch}},
 		{{BiquadFilterType/allpass}}, and
 		{{BiquadFilterType/peaking}} filters, this value is a
 		linear value.  The value is related to the bandwidth
 		of the filter and hence should be a positive value.
-		Implementations must clamp negative values to 0.
+		The nominal range is \([0, 3.4028235e38]\), the upper
+		limit being the <a>most-positive-single-float</a>.
+
+		This is not used for the {{BiquadFilterType/lowshelf}}
+		and {{BiquadFilterType/highshelf}} filters.
 
 		<pre class=include>
 		path: audioparam.include
 		macros:
 			default: 1
 			min: <a>most-negative-single-float</a>
-			min-notes: Approximately -3.4028235e38
+			min-notes: Approximately -3.4028235e38, but see above for the actual limits for different filters
 			max: <a>most-positive-single-float</a>
-			max-notes: Approximately 3.4028235e38
+			max-notes: Approximately 3.4028235e38, but see above for the actual limits for different filters
 			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 

--- a/index.bs
+++ b/index.bs
@@ -5862,6 +5862,17 @@ Attributes</h4>
 		The <a href="https://en.wikipedia.org/wiki/Q_factor">Q</a>
 		factor of the filter. This is not used for {{BiquadFilterType/lowshelf}} or {{BiquadFilterType/highshelf}} filters.
 
+		For {{BiquadFilterType/lowpass}} and
+		{{BiquadFilterType/highpass}} filters the
+		{{BiquadFilterNode/Q}} value is interpreted to be in
+		dB.  For the {{BiquadFilterType/bandpass}},
+		{{BiquadFilterType/notch}},
+		{{BiquadFilterType/allpass}}, and
+		{{BiquadFilterType/peaking}} filters, this value is a
+		linear value.  The value is related to the bandwidth
+		of the filter and hence should be a positive value.
+		Implementations must clamp negative values to 0.
+
 		<pre class=include>
 		path: audioparam.include
 		macros:
@@ -5882,10 +5893,10 @@ Attributes</h4>
 		path: audioparam.include
 		macros:
 			default: 0
-			min: <a>most-negative-single-float</a>
-			min-notes: Approximately -3.4028235e38
-			max: <a>most-positive-single-float</a>
-			max-notes: Approximately 3.4028235e38
+			min: \(\approx -153600\)
+			min-notes:
+			max: \(\approx 153600\)
+			max-notes: This value is approximately \(1200\ \log_2 \mathrm{FLT\_MAX}\) where FLT_MAX is the largest {{float}} value.
 			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
@@ -5899,10 +5910,8 @@ Attributes</h4>
 		path: audioparam.include
 		macros:
 			default: 350
-			min: <a>most-negative-single-float</a>
-			min-notes: Approximately -3.4028235e38
-			max: <a>most-positive-single-float</a>
-			max-notes: Approximately 3.4028235e38
+			min: 0
+			max: <a>Nyquist frequency</a>
 			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 
@@ -5917,10 +5926,10 @@ Attributes</h4>
 		path: audioparam.include
 		macros:
 			default: 0
-			min: <a>most-negative-single-float</a>
-			min-notes: Approximately -3.4028235e38
-			max: <a>most-positive-single-float</a>
-			max-notes: Approximately 3.4028235e38
+			min: \(\approx -1541\)
+			min-notes:
+			max: \(\approx 1541\)
+			max-notes: This value is approximately \(40\ \log_{10} \mathrm{FLT\_MAX}\) where FLT_MAX is the largest {{float}} value.
 			rate: "{{AutomationRate/a-rate}}"
 		</pre>
 


### PR DESCRIPTION
As mentioned in the bug, we are

- limiting the frequency from 0 to Nyquist,
- limiting the gain parameter is limited so that it won't cause overflow in the
  formulas
- limiting the detune values as done for the Oscillator.detune
- add some additiona text to mention Q is in dB for lowpass and
  highpass filters and that for the other filters Q, negative values
  of Q are clamped to 0.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2090.html" title="Last updated on Oct 30, 2019, 8:53 PM UTC (55943cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2090/ef3262d...rtoy:55943cd.html" title="Last updated on Oct 30, 2019, 8:53 PM UTC (55943cd)">Diff</a>