### PR TITLE
Re-allow setting the channelCount and the channelCountMode of a ConvolverNode to 1 and explicit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2852,8 +2852,10 @@ Attributes</h4>
 
 		: {{ConvolverNode}}
 		::
-			The channel count cannot changed from two, and a <span class="synchronous">{{NotSupportedError}} exception MUST
-			be thrown for any attempt to change the value.</span>
+			The channel count cannot be greater than two, and a
+			<span class="synchronous">{{NotSupportedError}}
+			exception MUST be thrown for any attempt to change it to a
+			value greater than two.</span>
 
 		: {{DynamicsCompressorNode}}
 		::
@@ -2916,9 +2918,10 @@ Attributes</h4>
 
 		: {{ConvolverNode}}
 		::
-			The channel count mode cannot be changed from "{{ChannelCountMode/clamped-max}}",
-			and a <span class="synchronous">{{NotSupportedError}} exception MUST
-			be thrown for any attempt to change the value.</span>
+			The channel count mode cannot be set to "{{ChannelCountMode/max}}", and a
+			<span class="synchronous">{{NotSupportedError}}
+			exception MUST be thrown for any attempt to set it to
+			"{{ChannelCountMode/max}}".</span>
 
 		: {{DynamicsCompressorNode}}
 		::


### PR DESCRIPTION
This fixes #2050.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2091.html" title="Last updated on Oct 28, 2019, 9:32 AM UTC (0576609)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2091/77eaf0b...padenot:0576609.html" title="Last updated on Oct 28, 2019, 9:32 AM UTC (0576609)">Diff</a>