### PR TITLE
Refactor the constructor and factory method text

### DIFF
--- a/audionode-init.include
+++ b/audionode-init.include
@@ -1,0 +1,4 @@
+When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+an option object <var>option</var>, the user agent MUST <a
+href="#audionode-constructor-init">initialize the AudioNode</a>
+<var>this</var>, with <var>context</var> and <var>options</var> as arguments.

--- a/index.bs
+++ b/index.bs
@@ -2631,41 +2631,29 @@ is called on.
 
 <div algorithm="initialize an AudioNode">
 	<dfn id="audionode-constructor-init">Initializing</dfn> an object
-	<var>o</var> of interface <var>n</var> that inherits from
-	{{AudioNode}} means executing the following steps, given the
-	arguments <var>context</var> and <var>dict</var> passed to the
-	constructor of this interface.
+	<var>o</var> that inherits from {{AudioNode}} means executing the following
+	steps, given the arguments <var>context</var> and <var>dict</var> passed to
+	the constructor of this interface.
 
 	1. Set <var>o</var>'s associated {{BaseAudioContext}} to <var>context</var>.
 
-	2. Set its value for {{AudioNode/numberOfInputs}}, {{AudioNode/numberOfOutputs}}, {{AudioNode/channelCount}}, {{AudioNode/channelCountMode}}, {{AudioNode/channelInterpretation}} to the default value for this
+	2. Set its value for {{AudioNode/numberOfInputs}},
+		{{AudioNode/numberOfOutputs}}, {{AudioNode/channelCount}},
+		{{AudioNode/channelCountMode}}, {{AudioNode/channelInterpretation}} to the
+		default value for this
 		specific interface outlined in the section for each {{AudioNode}}.
 
-	3. If the {{AudioNode}} being constructed is a
-		{{ConvolverNode}}, set its {{ConvolverNode/normalize}} attribute with the inverse of the
-		value of the {{ConvolverOptions/disableNormalization}} in <var>dict</var>, and
-		then set its {{ConvolverNode/buffer}} attribute
-		to the value of the {{ConvolverOptions/buffer}}
-		in <var>dict</var> member, in this order, and jump to the last step
-		of this algorithm.
+	3. For each member of <var>dict</var> passed in, execute these steps, with
+		<var>k</var> the key of the member, and <var>v</var> its value. If any
+		exceptions is thrown when executing these steps, abort the iteration and
+		propagate the exception to the caller of the algorithm (constructor or
+		factory method).
 
-		Note: This means that the buffer will be normalized according to the
-		value of the {{ConvolverNode/normalize}}
-		attribute.
-
-	4. For each member of <var>dict</var> passed in, execute these
-		steps, with <var>k</var> the key of the member, and <var>v</var>
-		its value:
-
-		1. If <var>k</var> is {{ConvolverOptions/disableNormalization}} or
-			{{ConvolverOptions/buffer}} and <var>n</var> is {{ConvolverNode}},
-			jump to the beginning of this loop.
-
-		2. If <var>k</var> is the name of an {{AudioParam}} on this
+		1. If <var>k</var> is the name of an {{AudioParam}} on this
 			interface, set the {{AudioParam/value}}
 			attribute of this {{AudioParam}} to <var>v</var>.
 
-		3. Else if <var>k</var> is the name of an attribute on this
+		2. Else if <var>k</var> is the name of an attribute on this
 			interface, set the object associated with this attribute to
 			<var>v</var>.
 </div>
@@ -4152,6 +4140,11 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="AnalyserNode">
 	: <dfn>AnalyserNode(context, options)</dfn>
 	::
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
 		<pre class=argumentdef for="AnalyserNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{AnalyserNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{AnalyserNode}}.
@@ -4608,9 +4601,11 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="AudioBufferSourceNode/constructor">
 	: <dfn>AudioBufferSourceNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{AudioBufferSourceNode}}
-		object. <a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="AudioBufferSourceNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{AudioBufferSourceNode}} will be <a href="#associated">associated</a> with.
@@ -5843,9 +5838,10 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="BiquadFilterNode">
 	: <dfn>BiquadFilterNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{BiquadFilterNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="BiquadFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{BiquadFilterNode}} will be <a href="#associated">associated</a> with.
@@ -6276,9 +6272,10 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="ChannelMergerNode/constructor">
 	: <dfn>ChannelMergerNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{ChannelMergerNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="ChannelMergerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ChannelMergerNode}} will be <a href="#associated">associated</a> with.
@@ -6388,9 +6385,10 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="ChannelSplitterNode/constructor()">
 	: <dfn>ChannelSplitterNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{ChannelSplitterNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="ChannelSplitterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ChannelSplitterNode}} will be <a href="#associated">associated</a> with.
@@ -6470,9 +6468,11 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="ConstantSourceNode/constructor()">
 	: <dfn>ConstantSourceNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{ConstantSourceNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="ConstantSourceNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ConstantSourceNode}} will be <a href="#associated">associated</a> with.
@@ -6576,11 +6576,22 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="ConvolverNode/constructor()">
 	: <dfn>ConvolverNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{ConvolverNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>. Set an internal boolean slot
-		<dfn attribute for="ConvolverNode">[[buffer set]]</dfn>, and initialize it to <code>false</code>. Return
-		<var>node</var>.
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, execute these steps:
+
+		1. Set the attributes {{ConvolverNode/normalize}} to the inverse of the
+			value of {{ConvolverOptions/disableNormalization}}.
+		2. If {{ConvolverNode/buffer}} is
+			<a href="https://heycam.github.io/webidl/#dfn-present">present</a>, set the
+			{{ConvolverNode/buffer}} attribute to its value.
+
+			Note: This means that the buffer will be normalized according to the
+			value of the {{ConvolverNode/normalize}}
+			attribute.
+
+		3. Let <var>o</var> be an empty dictionnary.
+		4. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+			<var>this</var>, with <var>c</var> and <var>o</var> as argument.
 
 		<pre class=argumentdef for="ConvolverNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ConvolverNode}} will be <a href="#associated">associated</a> with.
@@ -6840,8 +6851,10 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="DelayNode/constructor()">
 	: <dfn>DelayNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{DelayNode}} object. <a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
-		and return <var>node</var>.
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="DelayNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{DelayNode}} will be <a href="#associated">associated</a> with.
@@ -7001,12 +7014,15 @@ Constructors</h4>
 <dl dfn-type="method" dfn-for="DynamicsCompressorNode/constructor()">
 	: <dfn>DynamicsCompressorNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{DynamicsCompressorNode}}
-		object. <a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>. Let <dfn attribute for="DynamicsCompressorNode">[[internal reduction]]</dfn> be a private slot
-		on this {{DynamicsCompressorNode}}, that holds a floating
-		point number, in decibels. Set {{[[internal reduction]]}} to 0.0.
-		Return <var>node</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
+		Let <dfn attribute for="DynamicsCompressorNode">[[internal reduction]]</dfn>
+		be a private slot on <var>this</var>, that holds a floating point number, in
+		decibels. Set {{[[internal reduction]]}} to 0.0.
 
 		<pre class=argumentdef for="DynamicsCompressorNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{DynamicsCompressorNode}} will be <a href="#associated">associated</a> with.
@@ -7446,9 +7462,11 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="GainNode/constructor()">
 	: <dfn>GainNode(context, options)</dfn>
 	::
-		Let <var>gain</var> be a new {{GainNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a> <var>gain</var>,
-		and return <var>gain</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="GainNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{GainNode}} will be <a href="#associated">associated</a> with.
@@ -7557,6 +7575,12 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="IIRFilterNode/constructor()">
 	: <dfn>IIRFilterNode(context, options)</dfn>
 	::
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
 		<pre class=argumentdef for="IIRFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{IIRFilterNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{IIRFilterNode}}.
@@ -7726,9 +7750,8 @@ Constructors</h4>
 	::
 		1. If <var>context</var> is not an {{AudioContext}}, throw an
 			{{NotSupportedError}} exception and abort these steps.
-		2. Let <var>node</var> be a new {{MediaElementAudioSourceNode}} object.
-			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
-			return <var>node</var>.
+		2. <a href="#audionode-constructor-init">initialize the AudioNode</a>
+			<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="MediaElementAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaElementAudioSourceNode}} will be <a href="#associated">associated</a> with.
@@ -7832,9 +7855,8 @@ Constructors</h4>
 	::
 		1. If <code>context</code> is not an {{AudioContext}}, throw an
 			{{NotSupportedError}} and abort these steps.
-		2. Let <var>node</var> be a new {{MediaStreamAudioDestinationNode}} object.
-			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
-			return <var>node</var>.
+		2. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+			<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamAudioDestinationNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{MediaStreamAudioDestinationNode}} will be <a href="#associated">associated</a> with.
@@ -7905,14 +7927,14 @@ Constructors</h4>
 			4. Sort the elements in <var>tracks</var> based on their <code>id</code>
 				attribute using lexicographic ordering on sequences of code unit
 				values.
-			5. Let <var>node</var> be a new {{MediaStreamAudioSourceNode}}
-				object. <a href="#audionode-constructor-init">Initialize</a>
-				<var>node</var>.
-			6. Set an internal slot <dfn attribute for="MediaStreamAudioSourceNode">[[input track]]</dfn> on this
+			5. Let <var>o</var> be an empty dictionnary.
+			6. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+				<var>this</var>, with <var>c</var> and <var>o</var> as arguments.
+			7. Set an internal slot <dfn attribute
+				for="MediaStreamAudioSourceNode">[[input track]]</dfn> on this
 				{{MediaStreamAudioSourceNode}} to be the first element of
 				<var>tracks</var>.  This is the track used as the input audio for this
 				{{MediaStreamAudioSourceNode}}.
-			7. Return <var>node</var>.
 
 			After construction, any change to the
 			{{MediaStream}} that was passed to
@@ -8003,9 +8025,9 @@ Constructors</h4>
 		2. If the {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}}'s
 			<code>kind</code> attribute is not <code>"audio"</code>, throw an
 			{{InvalidStateError}} and abort these steps.
-		3. Let <var>node</var> be a new {{MediaStreamTrackAudioSourceNode}} object.
-			<a href="#audionode-constructor-init">Initialize</a> <var>node</var>, and
-			return <var>node</var>.
+		3. Let <var>o</var> be an empty dictionnary.
+		4. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+			<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaStreamTrackAudioSourceNode}} will be <a href="#associated">associated</a> with.
@@ -8142,9 +8164,11 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="OscillatorNode">
 	: <dfn>OscillatorNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{OscillatorNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="OscillatorNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{OscillatorNode}} will be <a href="#associated">associated</a> with.
@@ -8522,18 +8546,11 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="PannerNode">
 	: <dfn>PannerNode(context, options)</dfn>
 	::
-		If {{PannerNode/PannerNode()/options}} is given, check
-		for valid values.  If values are not valid, an error
-		is thrown.  Validity is determined as if the
-		attribute of the same name as the
-		{{PannerNode/PannerNode()/options}} member were set to
-		the given value. <span class="synchronous">If an error would be thrown for when
-		setting this value, the same error MUST be thrown when
-		constructing this node.</span>
 
-		Otherwise, let <var>node</var> be a new {{PannerNode}} object.
-		<a href="#audionode-constructor-init">Initialize</a> <var>node</var>,
-		and return <var>node</var>.
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="PannerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{PannerNode}} will be <a href="#associated">associated</a> with.
@@ -9244,9 +9261,11 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="StereoPannerNode">
 	: <dfn>StereoPannerNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{StereoPannerNode}}
-		object. <a href="#audionode-constructor-init">Initialize</a>
-		<var>node</var>, and return <var>node</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="StereoPannerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{StereoPannerNode}} will be <a href="#associated">associated</a> with.
@@ -9375,7 +9394,11 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="WaveShaperNode">
 	: <dfn>WaveShaperNode(context, options)</dfn>
 	::
-		Let <var>node</var> be a new {{WaveShaperNode}} object, and let <dfn attribute for="WaveShaperNode">[[curve set]]</dfn> be an internal slot of the <var>node</var>, initialized to <code>false</code>.  <a href="#audionode-constructor-init">Initialize</a> <var>node</var>. If {{WaveShaperNode/WaveShaperNode()/options!!argument}} is given and specifies a {{WaveShaperOptions/curve}}, set {{[[curve set]]}} to <code>true</code>. Return <var>node</var>.
+
+		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		an option object <var>option</var>, the user agent MUST <a
+		href="#audionode-constructor-init">initialize the AudioNode</a>
+		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="WaveShaperNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{WaveShaperNode}} will be <a href="#associated">associated</a> with.

--- a/index.bs
+++ b/index.bs
@@ -2592,23 +2592,6 @@ method, the <a>associated <code>BaseAudioContext</code></a> of the
 {{AudioNode}} is the {{BaseAudioContext}} this factory method
 is called on.
 
-<div algorithm="construct an AudioNode">
-	To create a new {{AudioNode}} of a particular type <var>n</var>
-	using its constructor, with a {{BaseAudioContext}} <var>c</var>
-	as first argument, and an <a>associated option object</a>
-	<var>option</var> as second argument,
-	from the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global">relevant global</a>
-	of <var>c</var>, execute these steps:
-
-	1. Let <var>o</var> be a new object of type <var>n</var>.
-
-	2. <a href="#audionode-constructor-init">Initialize</a>
-		<var>o</var>, with <var>c</var> and <var>option</var> as
-		arguments.
-
-	3. Return <var>o</var>
-</div>
-
 <div algorithm="AudioNode factory method">
 	To create a new {{AudioNode}} of a particular type <var>n</var>
 	using its <a>factory method</a>, called on a

--- a/index.bs
+++ b/index.bs
@@ -6573,8 +6573,20 @@ Constructors</h4>
 			value of the {{ConvolverNode/normalize}}
 			attribute.
 
-		3. Let <var>o</var> be an empty dictionnary.
-		4. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+		3. Let <var>o</var> be new {{AudioNodeOptions}} dictionnary.
+		4. If {{AudioNodeOptions/channelCount}} is
+			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+			<var>options</var>, set {{AudioNodeOptions/channelCount}} on <var>o</var>
+			with the same value.
+		5. If {{AudioNodeOptions/channelCountMode}} is
+			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+			<var>options</var>, set {{AudioNodeOptions/channelCountMode}} on
+			<var>o</var> with the same value.
+		6. If {{AudioNodeOptions/channelInterpretation}} is <a
+			href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+			<var>options</var>, set {{AudioNodeOptions/channelInterpretation}} on
+			<var>o</var> with the same value.
+		7. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
 			<var>this</var>, with <var>c</var> and <var>o</var> as argument.
 
 		<pre class=argumentdef for="ConvolverNode/constructor(context, options)">
@@ -7911,10 +7923,9 @@ Constructors</h4>
 			4. Sort the elements in <var>tracks</var> based on their <code>id</code>
 				attribute using lexicographic ordering on sequences of code unit
 				values.
-			5. Let <var>o</var> be an empty dictionnary.
-			6. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
-				<var>this</var>, with <var>c</var> and <var>o</var> as arguments.
-			7. Set an internal slot <dfn attribute
+			5. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+				<var>this</var>, with <var>c</var> and <var>options</var> as arguments.
+			6. Set an internal slot <dfn attribute
 				for="MediaStreamAudioSourceNode">[[input track]]</dfn> on this
 				{{MediaStreamAudioSourceNode}} to be the first element of
 				<var>tracks</var>.  This is the track used as the input audio for this
@@ -8009,9 +8020,8 @@ Constructors</h4>
 		2. If the {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}}'s
 			<code>kind</code> attribute is not <code>"audio"</code>, throw an
 			{{InvalidStateError}} and abort these steps.
-		3. Let <var>o</var> be an empty dictionnary.
-		4. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
-			<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		3. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+			<var>this</var>, with <var>c</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaStreamTrackAudioSourceNode}} will be <a href="#associated">associated</a> with.

--- a/index.bs
+++ b/index.bs
@@ -2597,19 +2597,20 @@ is called on.
 	using its <a>factory method</a>, called on a
 	{{BaseAudioContext}} <var>c</var>, execute these steps:
 
-	1. Let <var>o</var> be a new object of type <var>n</var>.
+	1. Let <var>node</var> be a new object of type <var>n</var>.
 
-	2. Let <var>option</var> be a dictionary of the type <a lt="associated option object">associated</a> to the interface
-		<a lt="associated interface">associated</a> to this factory method.
+	2. Let <var>option</var> be a dictionary of the type <a lt="associated option
+		object">associated</a> to the interface <a lt="associated interface">
+		associated</a> to this factory method.
 
 	3. For each parameter passed to the factory method, set the
 		dictionary member of the same name on <var>option</var> to the
 		value of this parameter.
 
-	4. <a href="#audionode-constructor-init">Initialize</a> <var>o</var>
-		with <var>c</var> and <var>option</var> as arguments.
+	4. Call the constructor for <var>n</var> on <var>node</var> with
+		<var>c</var> and <var>option</var> as arguments.
 
-	5. Return <var>o</var>
+	5. Return <var>node</var>
 </div>
 
 <div algorithm="initialize an AudioNode">

--- a/index.bs
+++ b/index.bs
@@ -9969,7 +9969,7 @@ Constructors</h5>
 
 		<div algorithm="AudioWorkletNode()">
 			When the {{AudioWorkletNode()|AudioWorkletNode}} constructor
-			is invoked with <var ignore>context</var>, <var>nodeName</var>, <var>options</var>:
+			is invoked with <var>context</var>, <var>nodeName</var>, <var>options</var>:
 
 			1. If <var>nodeName</var> does not exist as a key in the
 				{{BaseAudioContext}}’s <a>node name to parameter
@@ -9978,6 +9978,10 @@ Constructors</h5>
 
 			1. Let <var>node</var> be
 				<a spec="webidl" lt="this">this</a> value.
+
+			1. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+				<var>node</var> with <var>context</var> and <var>options</var> as
+				arguments.
 
 			1. <a href="#configure-with-audioworkletnodeoptions">
 				Configure input, output and output channels</a>

--- a/index.bs
+++ b/index.bs
@@ -4124,10 +4124,10 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="AnalyserNode">
 	: <dfn>AnalyserNode(context, options)</dfn>
 	::
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="AnalyserNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{AnalyserNode}} will be <a href="#associated">associated</a> with.
@@ -4586,10 +4586,9 @@ Constructors</h4>
 	: <dfn>AudioBufferSourceNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="AudioBufferSourceNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{AudioBufferSourceNode}} will be <a href="#associated">associated</a> with.
@@ -5822,10 +5821,10 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="BiquadFilterNode">
 	: <dfn>BiquadFilterNode(context, options)</dfn>
 	::
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="BiquadFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{BiquadFilterNode}} will be <a href="#associated">associated</a> with.
@@ -6256,10 +6255,10 @@ Constructors</h4>
 <dl dfn-type=method dfn-for="ChannelMergerNode/constructor">
 	: <dfn>ChannelMergerNode(context, options)</dfn>
 	::
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="ChannelMergerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ChannelMergerNode}} will be <a href="#associated">associated</a> with.
@@ -6369,10 +6368,10 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="ChannelSplitterNode/constructor()">
 	: <dfn>ChannelSplitterNode(context, options)</dfn>
 	::
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="ChannelSplitterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ChannelSplitterNode}} will be <a href="#associated">associated</a> with.
@@ -6453,10 +6452,9 @@ Constructors</h4>
 	: <dfn>ConstantSourceNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="ConstantSourceNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{ConstantSourceNode}} will be <a href="#associated">associated</a> with.
@@ -6847,10 +6845,10 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="DelayNode/constructor()">
 	: <dfn>DelayNode(context, options)</dfn>
 	::
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="DelayNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{DelayNode}} will be <a href="#associated">associated</a> with.
@@ -7011,10 +7009,9 @@ Constructors</h4>
 	: <dfn>DynamicsCompressorNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		Let <dfn attribute for="DynamicsCompressorNode">[[internal reduction]]</dfn>
 		be a private slot on <var>this</var>, that holds a floating point number, in
@@ -7459,10 +7456,9 @@ Constructors</h4>
 	: <dfn>GainNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="GainNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{GainNode}} will be <a href="#associated">associated</a> with.
@@ -7572,10 +7568,9 @@ Constructors</h4>
 	: <dfn>IIRFilterNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="IIRFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{IIRFilterNode}} will be <a href="#associated">associated</a> with.
@@ -8159,10 +8154,9 @@ Constructors</h4>
 	: <dfn>OscillatorNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="OscillatorNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{OscillatorNode}} will be <a href="#associated">associated</a> with.
@@ -8541,10 +8535,9 @@ Constructors</h4>
 	: <dfn>PannerNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="PannerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{PannerNode}} will be <a href="#associated">associated</a> with.
@@ -9256,10 +9249,9 @@ Constructors</h4>
 	: <dfn>StereoPannerNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="StereoPannerNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{StereoPannerNode}} will be <a href="#associated">associated</a> with.
@@ -9389,10 +9381,9 @@ Constructors</h4>
 	: <dfn>WaveShaperNode(context, options)</dfn>
 	::
 
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
-		an option object <var>option</var>, the user agent MUST <a
-		href="#audionode-constructor-init">initialize the AudioNode</a>
-		<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+		<pre class=include>
+			path: audionode-init.include
+		</pre>
 
 		<pre class=argumentdef for="WaveShaperNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{WaveShaperNode}} will be <a href="#associated">associated</a> with.


### PR DESCRIPTION
This fixes #2073, by doing what is spelled out at https://github.com/WebAudio/web-audio-api/issues/2073#issuecomment-540651254.

I caught a couple mistakes while doing this, in the first commit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2092.html" title="Last updated on Nov 12, 2019, 3:04 PM UTC (18b95bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2092/ef3262d...padenot:18b95bd.html" title="Last updated on Nov 12, 2019, 3:04 PM UTC (18b95bd)">Diff</a>