### PR TITLE
Address minor typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3326,7 +3326,7 @@ The following rules will apply when calling these methods:
 * <span class="synchronous">Similarly a
 	{{NotSupportedError}} exception MUST be thrown if any
 	<a href="#dfn-automation-method">automation method</a> is called at
-	a time which is contained in \([T, T+D)\), \(T\) being the time of the curve
+	a time which is contained in \([T, T+D]\), \(T\) being the time of the curve
 	and \(D\) its duration.
 	</span>
 


### PR DESCRIPTION
Unless I misunderstood deeper meaning, I *think* that the `)` character should be a `]` character in this sentence.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hughrawlinson/web-audio-api/pull/2097.html" title="Last updated on Nov 12, 2019, 9:31 PM UTC (adac127)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2097/ed004e0...hughrawlinson:adac127.html" title="Last updated on Nov 12, 2019, 9:31 PM UTC (adac127)">Diff</a>