### PR TITLE
Remove `options` from the AudioWorkletProcessor constructor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10259,7 +10259,7 @@ result of an {{AudioWorkletNode}} contruction.
 <pre class="idl">
 [Exposed=AudioWorklet]
 interface AudioWorkletProcessor {
-	constructor (optional AudioWorkletNodeOptions options = {});
+	constructor ();
 	readonly attribute MessagePort port;
 };
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -10145,8 +10145,7 @@ Attributes</h5>
 {{AudioWorkletNodeOptions}}</h5>
 
 The {{AudioWorkletNodeOptions}} dictionary can be used
-to initialize attibutes in the instance of an {{AudioWorkletNode}} and
-an {{AudioWorkletProcessor}}.
+to initialize attibutes in the instance of an {{AudioWorkletNode}}.
 
 <xmp class="idl">
 dictionary AudioWorkletNodeOptions : AudioNodeOptions {


### PR DESCRIPTION
cc @karlt


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2102.html" title="Last updated on Nov 20, 2019, 7:04 PM UTC (5d90649)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2102/bde2483...hoch:5d90649.html" title="Last updated on Nov 20, 2019, 7:04 PM UTC (5d90649)">Diff</a>