### PR TITLE
Add an entry for AudioWorkletNode in channelCount constraints section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2807,7 +2807,7 @@ Attributes</h4>
 
 		: {{AudioWorkletNode}}
 		::
-			See <a href="#configuring-channels-with-audioworkletnodeoptions">
+			See [[#configuring-channels-with-audioworkletnodeoptions]]
 			Configuring Channels with AudioWorkletNodeOptions</a>.
 
 		: {{ChannelMergerNode}}

--- a/index.bs
+++ b/index.bs
@@ -2805,6 +2805,11 @@ Attributes</h4>
 				MUST be thrown for any attempt to change the
 				value.</span>
 
+		: {{AudioWorkletNode}}
+		::
+			See <a href="#configuring-channels-with-audioworkletnodeoptions">
+			Configuring Channels with AudioWorkletNodeOptions</a>.
+
 		: {{ChannelMergerNode}}
 		::
 			The channel count cannot be changed, and an <span class="synchronous">{{InvalidStateError}} exception MUST


### PR DESCRIPTION
Fixes #2025.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2103.html" title="Last updated on Nov 22, 2019, 5:49 PM UTC (2972d22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2103/bde2483...hoch:2972d22.html" title="Last updated on Nov 22, 2019, 5:49 PM UTC (2972d22)">Diff</a>