### PR TITLE
Empty the pending data slot when an exception is thrown in the AWP construction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10300,14 +10300,20 @@ Constructors</h5>
 				Throw a {{TypeError}} exception if the slot is
 				empty.
 
-			1. If any of following steps throws any exception,
-				abort the rest of the steps and
-				<a>queue a task</a> to the <a>control thread</a>
-				to <a spec="dom" lt="fire an event">fire an
-				event</a> named <code>processorerror</code>
-				using
-				<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-				at <var>nodeReference</var>.
+			1. If any of following steps throws any exception:
+
+				1. Empty the
+					[=pending processor construction data=]
+					slot.
+
+				2. Abort the rest of the steps and
+					<a>queue a task</a> to the
+					<a>control thread</a>
+					to <a spec="dom" lt="fire an event">fire
+					an event</a> named
+					<code>processorerror</code> using
+					<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
+					at <var>nodeReference</var>.
 
 			1. Let <var>processor</var> be the
 				<a spec="webidl" lt="this">this</a> value.

--- a/index.bs
+++ b/index.bs
@@ -10301,7 +10301,7 @@ Constructors</h5>
 				empty.
 
 			1. If any of following steps throws any exception,
-				perform theese substeps:
+				perform these substeps:
 
 				1. Empty the
 					[=pending processor construction data=]

--- a/index.bs
+++ b/index.bs
@@ -10300,14 +10300,15 @@ Constructors</h5>
 				Throw a {{TypeError}} exception if the slot is
 				empty.
 
-			1. If any of following steps throws any exception:
+			1. If any of following steps throws any exception,
+				perform theese substeps:
 
 				1. Empty the
 					[=pending processor construction data=]
 					slot.
 
-				2. Abort the rest of the steps and
-					<a>queue a task</a> to the
+				2. Abort the rest of the constructor algorithm
+					and <a>queue a task</a> to the
 					<a>control thread</a>
 					to <a spec="dom" lt="fire an event">fire
 					an event</a> named


### PR DESCRIPTION
Fixes #2096.

cc @karlt


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2105.html" title="Last updated on Nov 22, 2019, 10:37 PM UTC (b547463)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2105/2f03431...hoch:b547463.html" title="Last updated on Nov 22, 2019, 10:37 PM UTC (b547463)">Diff</a>