### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Closes #???
+
+The following tasks have been completed:
+
+ * [ ] Modified Web platform tests (link to pull request)
+
+Implementation commitment:
+
+ * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+ * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+ * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


### PR DESCRIPTION
Recent situation come up where a change was made to the spec, but no corresponding web platform test was added. This ended up causing interop issues in Gecko. To prevent this, I'll encourage the WG to adopt this template. It helps guard against changes to being made to the spec without having both a Web Platform Test and public implementation commitments from the various browser engines.