### PR TITLE
Fix #2071: cancelScheduledValues with setValueCurveAtTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3555,6 +3555,12 @@ Methods</h4>
 		are also removed if the hold time occurs after
 		{{AudioParam/cancelScheduledValues()/cancelTime!!argument}}.
 
+		For a {{AudioParam/setValueCurveAtTime()}}, let \(T_0\) and \(T_D\) be the corresponding 
+		{{AudioParam/setValueCurveAtTime()/startTime!!argument}} and {{AudioParam/setValueCurveAtTime()/duration!!argument}}, respectively of this event.
+		Then if {{AudioParam/cancelScheduledValues()/cancelTime!!argument}}
+		is in the range \([T_0, T_0 + T_D]\), the event is
+		removed from the timeline.
+
 		<pre class=argumentdef for="AudioParam/cancelScheduledValues()">
 			cancelTime: The time after which any previously scheduled parameter changes will be cancelled. It is a time in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>cancelTime</code> is negative or is not a finite number.</span> If <code>cancelTime</code> is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
 		</pre>


### PR DESCRIPTION
If the cancelTime overlaps the setValueCurveAtTime event, remove the
event too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2108.html" title="Last updated on Dec 6, 2019, 10:00 PM UTC (866d369)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2108/e4f8da2...rtoy:866d369.html" title="Last updated on Dec 6, 2019, 10:00 PM UTC (866d369)">Diff</a>