### PR TITLE
Update the spec to refer to the new activation mechanism in HTML

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1327,7 +1327,7 @@ An {{AudioContext}} is said to be <dfn>allowed to start</dfn> if the user agent
 allows the context state to transition from "{{AudioContextState/suspended}}" to
 "{{AudioContextState/running}}". A user agent may delay this initial transition,
 to allow it only when the {{AudioContext}}'s [=relevant global object=] has
-[=sticky activation=] or [=transient activation=].
+[=sticky activation=].
 
 {{AudioContext}} has an internal slot:
 

--- a/index.bs
+++ b/index.bs
@@ -1324,9 +1324,10 @@ interface AudioContext : BaseAudioContext {
 </xmp>
 
 An {{AudioContext}} is said to be <dfn>allowed to start</dfn> if the user agent
-allows the context state to transition from "{{AudioContextState/suspended}}" to "{{AudioContextState/running}}". A user
-agent may require the actual audio production from an {{AudioContext}} to be
-<a>triggered by user activation</a> (as described in [[HTML]]).
+allows the context state to transition from "{{AudioContextState/suspended}}" to
+"{{AudioContextState/running}}". A user agent may delay this initial transition,
+to allow it only when the {{AudioContext}}'s [=relevant global object=] has
+[=sticky activation=] or [=transient activation=].
 
 {{AudioContext}} has an internal slot:
 


### PR DESCRIPTION
This is intentionaly vague to not restrict implementors: it's plausible
that an implementation chooses to be transient or sticky here.

This fixes #2107.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2110.html" title="Last updated on Dec 19, 2019, 3:48 PM UTC (fb5b7a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2110/e4f8da2...padenot:fb5b7a7.html" title="Last updated on Dec 19, 2019, 3:48 PM UTC (fb5b7a7)">Diff</a>