### PR TITLE
Fix #2112: Wrap long IDL lines

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -697,28 +697,39 @@ interface BaseAudioContext : EventTarget {
 
 	AnalyserNode createAnalyser ();
 	BiquadFilterNode createBiquadFilter ();
-	AudioBuffer createBuffer (unsigned long numberOfChannels, unsigned long length, float sampleRate);
+	AudioBuffer createBuffer (
+		unsigned long numberOfChannels,
+		unsigned long length,
+		float sampleRate);
 	AudioBufferSourceNode createBufferSource ();
 	ChannelMergerNode createChannelMerger (optional unsigned long numberOfInputs = 6);
-	ChannelSplitterNode createChannelSplitter (optional unsigned long numberOfOutputs = 6);
+	ChannelSplitterNode createChannelSplitter (
+		optional unsigned long numberOfOutputs = 6);
 	ConstantSourceNode createConstantSource ();
 	ConvolverNode createConvolver ();
 	DelayNode createDelay (optional double maxDelayTime = 1.0);
 	DynamicsCompressorNode createDynamicsCompressor ();
 	GainNode createGain ();
-	IIRFilterNode createIIRFilter (sequence<double> feedforward, sequence<double> feedback);
+	IIRFilterNode createIIRFilter (
+		sequence<double> feedforward,
+		sequence<double> feedback);
 	OscillatorNode createOscillator ();
 	PannerNode createPanner ();
-	PeriodicWave createPeriodicWave (sequence<float> real, sequence<float> imag, optional PeriodicWaveConstraints constraints = {});
-	ScriptProcessorNode createScriptProcessor(optional unsigned long bufferSize = 0,
-	                                          optional unsigned long numberOfInputChannels = 2,
-	                                          optional unsigned long numberOfOutputChannels = 2);
+	PeriodicWave createPeriodicWave (
+		sequence<float> real,
+		sequence<float> imag,
+		optional PeriodicWaveConstraints constraints = {});
+	ScriptProcessorNode createScriptProcessor(
+		optional unsigned long bufferSize = 0,
+		optional unsigned long numberOfInputChannels = 2,
+		optional unsigned long numberOfOutputChannels = 2);
 	StereoPannerNode createStereoPanner ();
 	WaveShaperNode createWaveShaper ();
 
-	Promise<AudioBuffer> decodeAudioData (ArrayBuffer audioData,
-	                                      optional DecodeSuccessCallback? successCallback,
-	                                      optional DecodeErrorCallback? errorCallback);
+	Promise<AudioBuffer> decodeAudioData (
+		ArrayBuffer audioData,
+		optional DecodeSuccessCallback? successCallback,
+		optional DecodeErrorCallback? errorCallback);
 };
 </xmp>
 
@@ -1318,7 +1329,8 @@ interface AudioContext : BaseAudioContext {
 	Promise<void> close ();
 	MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
 	MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
-	MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (MediaStreamTrack mediaStreamTrack);
+	MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (
+		MediaStreamTrack mediaStreamTrack);
 	MediaStreamAudioDestinationNode createMediaStreamDestination ();
 };
 </xmp>
@@ -2256,8 +2268,14 @@ interface AudioBuffer {
 	readonly attribute double duration;
 	readonly attribute unsigned long numberOfChannels;
 	Float32Array getChannelData (unsigned long channel);
-	void copyFromChannel (Float32Array destination, unsigned long channelNumber, optional unsigned long bufferOffset = 0);
-	void copyToChannel (Float32Array source, unsigned long channelNumber, optional unsigned long bufferOffset = 0);
+	void copyFromChannel (
+		Float32Array destination,
+		unsigned long channelNumber,
+		optional unsigned long bufferOffset = 0);
+	void copyToChannel (
+		Float32Array source, 
+		unsigned long channelNumber, 
+		optional unsigned long bufferOffset = 0);
 };
 </pre>
 
@@ -2565,7 +2583,10 @@ interface AudioNode : EventTarget {
 	void disconnect (unsigned long output);
 	void disconnect (AudioNode destinationNode);
 	void disconnect (AudioNode destinationNode, unsigned long output);
-	void disconnect (AudioNode destinationNode, unsigned long output, unsigned long input);
+	void disconnect (
+		AudioNode destinationNode,
+		unsigned long output,
+		unsigned long input);
 	void disconnect (AudioParam destinationParam);
 	void disconnect (AudioParam destinationParam, unsigned long output);
 	readonly attribute BaseAudioContext context;
@@ -3365,7 +3386,10 @@ interface AudioParam {
 	AudioParam linearRampToValueAtTime (float value, double endTime);
 	AudioParam exponentialRampToValueAtTime (float value, double endTime);
 	AudioParam setTargetAtTime (float target, double startTime, float timeConstant);
-	AudioParam setValueCurveAtTime (sequence&lt;float> values, double startTime, double duration);
+	AudioParam setValueCurveAtTime (
+		sequence&lt;float> values, 
+		double startTime, 
+		double duration);
 	AudioParam cancelScheduledValues (double cancelTime);
 	AudioParam cancelAndHoldAtTime (double cancelTime);
 };
@@ -4574,7 +4598,8 @@ slot <dfn attribute for="AudioBufferSourceNode">[[buffer set]]</dfn>, initially 
 <pre class="idl">
 [Exposed=Window]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
-	constructor (BaseAudioContext context, optional AudioBufferSourceOptions options = {});
+	constructor (BaseAudioContext context,
+	             optional AudioBufferSourceOptions options = {});
 	attribute AudioBuffer? buffer;
 	readonly attribute AudioParam playbackRate;
 	readonly attribute AudioParam detune;
@@ -5825,7 +5850,10 @@ interface BiquadFilterNode : AudioNode {
 	readonly attribute AudioParam detune;
 	readonly attribute AudioParam Q;
 	readonly attribute AudioParam gain;
-	void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
+	void getFrequencyResponse (
+		Float32Array frequencyHz,
+		Float32Array magResponse,
+		Float32Array phaseResponse);
 };
 </pre>
 
@@ -7024,7 +7052,9 @@ macros:
 <pre class="idl">
 [Exposed=Window]
 interface DynamicsCompressorNode : AudioNode {
-	constructor (BaseAudioContext context, optional DynamicsCompressorOptions options = {});
+	constructor (
+		BaseAudioContext context,
+		optional DynamicsCompressorOptions options = {});
 	readonly attribute AudioParam threshold;
 	readonly attribute AudioParam knee;
 	readonly attribute AudioParam ratio;
@@ -7589,7 +7619,10 @@ channels of the input.
 [Exposed=Window]
 interface IIRFilterNode : AudioNode {
 	constructor (BaseAudioContext context, IIRFilterOptions options);
-	void getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
+	void getFrequencyResponse (
+		Float32Array frequencyHz,
+		Float32Array magResponse,
+		Float32Array phaseResponse);
 };
 </pre>
 
@@ -9721,7 +9754,9 @@ callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object option
 
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {
-	void registerProcessor (DOMString name, AudioWorkletProcessorConstructor processorCtor);
+	void registerProcessor (
+		DOMString name,
+		AudioWorkletProcessorConstructor processorCtor);
 	readonly attribute unsigned long long currentFrame;
 	readonly attribute double currentTime;
 	readonly attribute float sampleRate;

--- a/index.bs
+++ b/index.bs
@@ -697,10 +697,9 @@ interface BaseAudioContext : EventTarget {
 
 	AnalyserNode createAnalyser ();
 	BiquadFilterNode createBiquadFilter ();
-	AudioBuffer createBuffer (
-		unsigned long numberOfChannels,
-		unsigned long length,
-		float sampleRate);
+	AudioBuffer createBuffer (unsigned long numberOfChannels,
+	                          unsigned long length,
+	                          float sampleRate);
 	AudioBufferSourceNode createBufferSource ();
 	ChannelMergerNode createChannelMerger (optional unsigned long numberOfInputs = 6);
 	ChannelSplitterNode createChannelSplitter (
@@ -710,15 +709,13 @@ interface BaseAudioContext : EventTarget {
 	DelayNode createDelay (optional double maxDelayTime = 1.0);
 	DynamicsCompressorNode createDynamicsCompressor ();
 	GainNode createGain ();
-	IIRFilterNode createIIRFilter (
-		sequence<double> feedforward,
-		sequence<double> feedback);
+	IIRFilterNode createIIRFilter (sequence<double> feedforward,
+	                               sequence<double> feedback);
 	OscillatorNode createOscillator ();
 	PannerNode createPanner ();
-	PeriodicWave createPeriodicWave (
-		sequence<float> real,
-		sequence<float> imag,
-		optional PeriodicWaveConstraints constraints = {});
+	PeriodicWave createPeriodicWave (sequence<float> real,
+	                                 sequence<float> imag,
+	                                 optional PeriodicWaveConstraints constraints = {});
 	ScriptProcessorNode createScriptProcessor(
 		optional unsigned long bufferSize = 0,
 		optional unsigned long numberOfInputChannels = 2,
@@ -2268,14 +2265,12 @@ interface AudioBuffer {
 	readonly attribute double duration;
 	readonly attribute unsigned long numberOfChannels;
 	Float32Array getChannelData (unsigned long channel);
-	void copyFromChannel (
-		Float32Array destination,
-		unsigned long channelNumber,
-		optional unsigned long bufferOffset = 0);
-	void copyToChannel (
-		Float32Array source, 
-		unsigned long channelNumber, 
-		optional unsigned long bufferOffset = 0);
+	void copyFromChannel (Float32Array destination,
+	                      unsigned long channelNumber,
+	                      optional unsigned long bufferOffset = 0);
+	void copyToChannel (Float32Array source, 
+	                    unsigned long channelNumber, 
+	                    optional unsigned long bufferOffset = 0);
 };
 </pre>
 
@@ -2583,10 +2578,9 @@ interface AudioNode : EventTarget {
 	void disconnect (unsigned long output);
 	void disconnect (AudioNode destinationNode);
 	void disconnect (AudioNode destinationNode, unsigned long output);
-	void disconnect (
-		AudioNode destinationNode,
-		unsigned long output,
-		unsigned long input);
+	void disconnect (AudioNode destinationNode,
+	                 unsigned long output,
+	                 unsigned long input);
 	void disconnect (AudioParam destinationParam);
 	void disconnect (AudioParam destinationParam, unsigned long output);
 	readonly attribute BaseAudioContext context;
@@ -3386,10 +3380,9 @@ interface AudioParam {
 	AudioParam linearRampToValueAtTime (float value, double endTime);
 	AudioParam exponentialRampToValueAtTime (float value, double endTime);
 	AudioParam setTargetAtTime (float target, double startTime, float timeConstant);
-	AudioParam setValueCurveAtTime (
-		sequence&lt;float> values, 
-		double startTime, 
-		double duration);
+	AudioParam setValueCurveAtTime (sequence&lt;float> values, 
+	                                double startTime, 
+	                                double duration);
 	AudioParam cancelScheduledValues (double cancelTime);
 	AudioParam cancelAndHoldAtTime (double cancelTime);
 };
@@ -5850,10 +5843,9 @@ interface BiquadFilterNode : AudioNode {
 	readonly attribute AudioParam detune;
 	readonly attribute AudioParam Q;
 	readonly attribute AudioParam gain;
-	void getFrequencyResponse (
-		Float32Array frequencyHz,
-		Float32Array magResponse,
-		Float32Array phaseResponse);
+	void getFrequencyResponse (Float32Array frequencyHz,
+	                           Float32Array magResponse,
+	                           Float32Array phaseResponse);
 };
 </pre>
 
@@ -7052,9 +7044,8 @@ macros:
 <pre class="idl">
 [Exposed=Window]
 interface DynamicsCompressorNode : AudioNode {
-	constructor (
-		BaseAudioContext context,
-		optional DynamicsCompressorOptions options = {});
+	constructor (BaseAudioContext context,
+	             optional DynamicsCompressorOptions options = {});
 	readonly attribute AudioParam threshold;
 	readonly attribute AudioParam knee;
 	readonly attribute AudioParam ratio;
@@ -7619,10 +7610,9 @@ channels of the input.
 [Exposed=Window]
 interface IIRFilterNode : AudioNode {
 	constructor (BaseAudioContext context, IIRFilterOptions options);
-	void getFrequencyResponse (
-		Float32Array frequencyHz,
-		Float32Array magResponse,
-		Float32Array phaseResponse);
+	void getFrequencyResponse (Float32Array frequencyHz,
+	                           Float32Array magResponse,
+	                           Float32Array phaseResponse);
 };
 </pre>
 
@@ -9754,9 +9744,8 @@ callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object option
 
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {
-	void registerProcessor (
-		DOMString name,
-		AudioWorkletProcessorConstructor processorCtor);
+	void registerProcessor (DOMString name,
+	                        AudioWorkletProcessorConstructor processorCtor);
 	readonly attribute unsigned long long currentFrame;
 	readonly attribute double currentTime;
 	readonly attribute float sampleRate;


### PR DESCRIPTION
Wrap long IDL lines so that there's no need for a horizontal scrollbar to see all of the IDL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2114.html" title="Last updated on Dec 17, 2019, 6:46 PM UTC (437fa50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2114/e4f8da2...rtoy:437fa50.html" title="Last updated on Dec 17, 2019, 6:46 PM UTC (437fa50)">Diff</a>