### PR TITLE
Add a note about MessagePort listener and garbage collection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10163,6 +10163,11 @@ Attributes</h5>
 		bidirectional communication between the
 		{{AudioWorkletNode}} and its {{AudioWorkletProcessor}}.
 
+		Note: Authors that register a event listener on the <code>"message"</code>
+		event of this {{AudioWorkletNode/port}} should call {{MessagePort/close}} on
+		either end of the {{MessageChannel}} (either in the
+		{{AudioWorkletProcessor}} or the {{AudioWorkletNode}} side) to allow for
+		ressources to be [[html#ports-and-garbage-collection|collected]].
 </dl>
 
 <h5 dictionary lt="AudioWorkletNodeOptions">
@@ -10369,6 +10374,12 @@ Constructors</h5>
 		the port on the corresponding {{AudioWorkletNode}} object
 		allowing bidirectional communication between an
 		{{AudioWorkletNode}} and its {{AudioWorkletProcessor}}.
+
+		Note: Authors that register a event listener on the <code>"message"</code>
+		event of this {{AudioWorkletProcessor/port}} should call
+		{{MessagePort/close}} on either end of the {{MessageChannel}} (either in the
+		{{AudioWorkletProcessor}} or the {{AudioWorkletNode}} side) to allow for
+		ressources to be [[html#ports-and-garbage-collection|collected]].
 </dl>
 
 <h5 id="AudioWorkletProcessor-methods">

--- a/index.bs
+++ b/index.bs
@@ -10167,7 +10167,7 @@ Attributes</h5>
 		event of this {{AudioWorkletNode/port}} should call {{MessagePort/close}} on
 		either end of the {{MessageChannel}} (either in the
 		{{AudioWorkletProcessor}} or the {{AudioWorkletNode}} side) to allow for
-		ressources to be [[html#ports-and-garbage-collection|collected]].
+		resources to be [[html#ports-and-garbage-collection|collected]].
 </dl>
 
 <h5 dictionary lt="AudioWorkletNodeOptions">
@@ -10379,7 +10379,7 @@ Constructors</h5>
 		event of this {{AudioWorkletProcessor/port}} should call
 		{{MessagePort/close}} on either end of the {{MessageChannel}} (either in the
 		{{AudioWorkletProcessor}} or the {{AudioWorkletNode}} side) to allow for
-		ressources to be [[html#ports-and-garbage-collection|collected]].
+		resources to be [[html#ports-and-garbage-collection|collected]].
 </dl>
 
 <h5 id="AudioWorkletProcessor-methods">


### PR DESCRIPTION
This fixes #2060.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2116.html" title="Last updated on Jan 7, 2020, 11:21 AM UTC (baaa070)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2116/e3bed78...padenot:baaa070.html" title="Last updated on Jan 7, 2020, 11:21 AM UTC (baaa070)">Diff</a>