### PR TITLE
Fix #2113:  BiquadFilter gain lower bound is lower

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5949,8 +5949,8 @@ Attributes</h4>
 		path: audioparam.include
 		macros:
 			default: 0
-			min: \(\approx -1541\)
-			min-notes:
+			min: <a>most-negative-single-float</a>
+			min-notes: Approximately 3.4028235e38
 			max: \(\approx 1541\)
 			max-notes: This value is approximately \(40\ \log_{10} \mathrm{FLT\_MAX}\) where FLT_MAX is the largest {{float}} value.
 			rate: "{{AutomationRate/a-rate}}"


### PR DESCRIPTION
Since the filter gain is in dB, any finite negative value is fine
since the value should just underflow to a linear gain value of
0. (Unlike the upper bound which would cause overflow if it were
higher.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2117.html" title="Last updated on Dec 19, 2019, 6:06 PM UTC (ae27e4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2117/73726d1...rtoy:ae27e4d.html" title="Last updated on Dec 19, 2019, 6:06 PM UTC (ae27e4d)">Diff</a>