### PR TITLE
Fix #2122: Auto-apply labels for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,3 +16,5 @@ Provide a link to where the problem is in the spec
 
 **Additional Information**
 Provide any additional information
+
+labels: Untriaged, Needs WG Review

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,3 +11,5 @@ If you have a prototype (possibly using an AudioWorkletNode), provide links to i
 
 **Describe the feature in more detail**
 Provide more information how it does and how it works.
+
+labels: Feagure Request/Missing Feature


### PR DESCRIPTION
Update the issue templates to apply appropriate initial labels for bugs and feature requests.