### PR TITLE
Fix #2125: Fix incorrect IDL links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4227,7 +4227,7 @@ Methods</h4>
 	::
 		Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the [[WebIDL#idl-Uint8Array|Uint8Array]]
+		reference to the bytes</a> held by the {{Uint8Array}}
 		passed as an argument.  Copies the <a>current frequency data</a> to those
 		bytes. If the array has fewer elements than the {{frequencyBinCount}}, the
 		excess elements will be dropped. If the array has more elements than the
@@ -4272,7 +4272,7 @@ Methods</h4>
 	::
 		Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the [[WebIDL#idl-Uint8Array|Uint8Array]]
+		reference to the bytes</a> held by the {{Uint8Array}}
 		passed as an argument.  Copies the <a>current time-domain data</a>
 		(waveform data) into those bytes. If the array has fewer elements than the
 		value of {{AnalyserNode/fftSize}}, the excess elements will be dropped. If
@@ -4306,7 +4306,7 @@ Methods</h4>
 		Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
 		reference to the bytes</a> held by the
-		[[WebIDL#idl-Float32Array|Float32Array]] passed as an argument.  Copies
+		{{Float32Array}} passed as an argument.  Copies
 		the <a>current frequency data</a> into those bytes.  If the array has
 		fewer elements than the {{frequencyBinCount}}, the excess elements will be
 		dropped. If the array has more elements than the {{frequencyBinCount}},
@@ -4334,7 +4334,7 @@ Methods</h4>
 		Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
 		reference to the bytes</a> held by the
-		[[WebIDL#idl-Float32Array|Float32Array]] passed as an argument.  Copies the
+		{{Float32Array}} passed as an argument.  Copies the
 		<a>current time-domain data</a> (waveform data) into those bytes. If the
 		array has fewer elements than the value of {{AnalyserNode/fftSize}}, the
 		excess elements will be dropped. If the array has more elements than


### PR DESCRIPTION
As explained it tabatkins/bikeshed#1593, the links we had to these IDL
entries were always incorrect.  Update these to use the correct
`{{fooArray}}`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2126.html" title="Last updated on Jan 17, 2020, 3:51 PM UTC (28161ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2126/e139bd4...rtoy:28161ed.html" title="Last updated on Jan 17, 2020, 3:51 PM UTC (28161ed)">Diff</a>