### PR TITLE
Add missing minus sign

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5950,7 +5950,7 @@ Attributes</h4>
 		macros:
 			default: 0
 			min: <a>most-negative-single-float</a>
-			min-notes: Approximately 3.4028235e38
+			min-notes: Approximately -3.4028235e38
 			max: \(\approx 1541\)
 			max-notes: This value is approximately \(40\ \log_{10} \mathrm{FLT\_MAX}\) where FLT_MAX is the largest {{float}} value.
 			rate: "{{AutomationRate/a-rate}}"


### PR DESCRIPTION
I noticed that there is a minus sign missing in the explanation of the [`gain`](https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-gain) AudioParam of the BiquadFilterNode.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisguttandin/web-audio-api/pull/2134.html" title="Last updated on Jan 19, 2020, 5:20 PM UTC (60cc0a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2134/57735ed...chrisguttandin:60cc0a9.html" title="Last updated on Jan 19, 2020, 5:20 PM UTC (60cc0a9)">Diff</a>