### PR TITLE
Fix #2145: Update link to Audio EQ Cookbook

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6039,7 +6039,7 @@ having very different characteristics. The formulas in this section
 describe the filters that a <a>conforming implementation</a> MUST
 implement, as they determine the characteristics of the different
 filter types. They are inspired by formulas found in the
-<a href="https://www.w3.org/2011/audio/audio-eq-cookbook.html">Audio EQ Cookbook</a>.
+<a href="https://github.com/WebAudio/Audio-EQ-Cookbook">Audio EQ Cookbook</a>.
 
 The {{BiquadFilterNode}} processes audio with a transfer function of
 

--- a/index.bs
+++ b/index.bs
@@ -6039,7 +6039,7 @@ having very different characteristics. The formulas in this section
 describe the filters that a <a>conforming implementation</a> MUST
 implement, as they determine the characteristics of the different
 filter types. They are inspired by formulas found in the
-<a href="https://github.com/WebAudio/Audio-EQ-Cookbook">Audio EQ Cookbook</a>.
+<a href="https://webaudio.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html">Audio EQ Cookbook</a>.
 
 The {{BiquadFilterNode}} processes audio with a transfer function of
 


### PR DESCRIPTION
Link to the fork that we maintain instead of the out-dated one at w3.org.  Since we maintain this version, it's more likely to be up-to-date with the information we want.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2146.html" title="Last updated on Feb 12, 2020, 5:16 PM UTC (fdef899)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2146/db4e8c6...rtoy:fdef899.html" title="Last updated on Feb 12, 2020, 5:16 PM UTC (fdef899)">Diff</a>