### PR TITLE
Fix #2139: Unknown refs in MSADN ctor algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6612,7 +6612,7 @@ Constructors</h4>
 	: <dfn>ConvolverNode(context, options)</dfn>
 	::
 		When the constructor is called with a {{BaseAudioContext}} <var>context</var> and
-		an option object <var>option</var>, execute these steps:
+		an option object <var>options</var>, execute these steps:
 
 		1. Set the attributes {{ConvolverNode/normalize}} to the inverse of the
 			value of {{ConvolverOptions/disableNormalization}}.
@@ -6624,7 +6624,7 @@ Constructors</h4>
 			value of the {{ConvolverNode/normalize}}
 			attribute.
 
-		3. Let <var>o</var> be new {{AudioNodeOptions}} dictionnary.
+		3. Let <var>o</var> be new {{AudioNodeOptions}} dictionary.
 		4. If {{AudioNodeOptions/channelCount}} is
 			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelCount}} on <var>o</var>
@@ -7798,7 +7798,7 @@ Constructors</h4>
 		1. If <var>context</var> is not an {{AudioContext}}, throw an
 			{{NotSupportedError}} exception and abort these steps.
 		2. <a href="#audionode-constructor-init">initialize the AudioNode</a>
-			<var>this</var>, with <var>context</var> and <var>option</var> as arguments.
+			<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaElementAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaElementAudioSourceNode}} will be <a href="#associated">associated</a> with.
@@ -7903,7 +7903,7 @@ Constructors</h4>
 		1. If <code>context</code> is not an {{AudioContext}}, throw an
 			{{NotSupportedError}} and abort these steps.
 		2. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
-			<var>this</var>, with <var>context</var> and <var>option</var> as arguments.
+			<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamAudioDestinationNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{MediaStreamAudioDestinationNode}} will be <a href="#associated">associated</a> with.

--- a/index.bs
+++ b/index.bs
@@ -6611,7 +6611,7 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="ConvolverNode/constructor()">
 	: <dfn>ConvolverNode(context, options)</dfn>
 	::
-		When the constructor is called with a {{BaseAudioContext}} <var>c</var> and
+		When the constructor is called with a {{BaseAudioContext}} <var>context</var> and
 		an option object <var>option</var>, execute these steps:
 
 		1. Set the attributes {{ConvolverNode/normalize}} to the inverse of the
@@ -7798,7 +7798,7 @@ Constructors</h4>
 		1. If <var>context</var> is not an {{AudioContext}}, throw an
 			{{NotSupportedError}} exception and abort these steps.
 		2. <a href="#audionode-constructor-init">initialize the AudioNode</a>
-			<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+			<var>this</var>, with <var>context</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="MediaElementAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaElementAudioSourceNode}} will be <a href="#associated">associated</a> with.
@@ -7903,7 +7903,7 @@ Constructors</h4>
 		1. If <code>context</code> is not an {{AudioContext}}, throw an
 			{{NotSupportedError}} and abort these steps.
 		2. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
-			<var>this</var>, with <var>c</var> and <var>option</var> as arguments.
+			<var>this</var>, with <var>context</var> and <var>option</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamAudioDestinationNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{MediaStreamAudioDestinationNode}} will be <a href="#associated">associated</a> with.
@@ -7975,7 +7975,7 @@ Constructors</h4>
 				attribute using lexicographic ordering on sequences of code unit
 				values.
 			5. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
-				<var>this</var>, with <var>c</var> and <var>options</var> as arguments.
+				<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 			6. Set an internal slot <dfn attribute
 				for="MediaStreamAudioSourceNode">[[input track]]</dfn> on this
 				{{MediaStreamAudioSourceNode}} to be the first element of
@@ -8072,7 +8072,7 @@ Constructors</h4>
 			<code>kind</code> attribute is not <code>"audio"</code>, throw an
 			{{InvalidStateError}} and abort these steps.
 		3. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
-			<var>this</var>, with <var>c</var> and <var>options</var> as arguments.
+			<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/constructor(context, options)">
 			context: The {{AudioContext}} this new {{MediaStreamTrackAudioSourceNode}} will be <a href="#associated">associated</a> with.


### PR DESCRIPTION
The constructor algorithm references a variable `c` which isn't defined.  This should really be `context`.  This also exists in other Media nodes and also the `ConvolverNode`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2156.html" title="Last updated on Feb 12, 2020, 12:40 AM UTC (afe34ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2156/db4e8c6...rtoy:afe34ee.html" title="Last updated on Feb 12, 2020, 12:40 AM UTC (afe34ee)">Diff</a>