### PR TITLE
Fix #2149: Remove test for AudioContext from Media constructors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7795,9 +7795,7 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaElementAudioSourceNode">
 	: <dfn>MediaElementAudioSourceNode(context, options)</dfn>
 	::
-		1. If <var>context</var> is not an {{AudioContext}}, throw an
-			{{NotSupportedError}} exception and abort these steps.
-		2. <a href="#audionode-constructor-init">initialize the AudioNode</a>
+		1. <a href="#audionode-constructor-init">initialize the AudioNode</a>
 			<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaElementAudioSourceNode/constructor(context, options)">
@@ -7900,9 +7898,7 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaStreamAudioDestinationNode">
 	: <dfn>MediaStreamAudioDestinationNode(context, options)</dfn>
 	::
-		1. If <code>context</code> is not an {{AudioContext}}, throw an
-			{{NotSupportedError}} and abort these steps.
-		2. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+		1. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
 			<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamAudioDestinationNode/constructor(context, options)">
@@ -7958,25 +7954,23 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaStreamAudioSourceNode">
 	: <dfn>MediaStreamAudioSourceNode(context, options)</dfn>
 	::
-			1. If <var>context</var> is not an {{AudioContext}}, throw an
-				{{NotSupportedError}} exception and abort these steps.
-			2. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
+			1. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
 				{{MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()/options!!argument}} does not reference a
 				{{MediaStream}} that has at least one
 				{{MediaStreamTrack}} whose
 				<code>kind</code> attribute has the value <code>"audio"</code>,
 				throw an {{InvalidStateError}} and abort these steps. Else, let
 				this stream be <var>inputStream</var>.
-			3. Let <var>tracks</var> be the list of all
+			1. Let <var>tracks</var> be the list of all
 				{{MediaStreamTrack}}s of
 				<var>inputStream</var> that have a <code>kind</code> of
 				<code>"audio"</code>.
-			4. Sort the elements in <var>tracks</var> based on their <code>id</code>
+			1. Sort the elements in <var>tracks</var> based on their <code>id</code>
 				attribute using lexicographic ordering on sequences of code unit
 				values.
-			5. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+			1. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
 				<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
-			6. Set an internal slot <dfn attribute
+			1. Set an internal slot <dfn attribute
 				for="MediaStreamAudioSourceNode">[[input track]]</dfn> on this
 				{{MediaStreamAudioSourceNode}} to be the first element of
 				<var>tracks</var>.  This is the track used as the input audio for this
@@ -8066,12 +8060,10 @@ Constructors</h4>
 <dl dfn-type=constructor dfn-for="MediaStreamTrackAudioSourceNode">
 	: <dfn>MediaStreamTrackAudioSourceNode(context, options)</dfn>
 	::
-		1. If <var>context</var> is not an {{AudioContext}}, throw an
-			{{NotSupportedError}} exception and abort these steps.
-		2. If the {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}}'s
+		1. If the {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}}'s
 			<code>kind</code> attribute is not <code>"audio"</code>, throw an
 			{{InvalidStateError}} and abort these steps.
-		3. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
+		1. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
 			<var>this</var>, with <var>context</var> and <var>options</var> as arguments.
 
 		<pre class=argumentdef for="MediaStreamTrackAudioSourceNode/constructor(context, options)">


### PR DESCRIPTION
In the constructor algorithm for all of the Media nodes, the first item was a check that the context was an AudioContext.  But the constructor requires an AudioContext, so the check is useless.  Remove them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2157.html" title="Last updated on Feb 13, 2020, 3:34 PM UTC (4fa463f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2157/e0d8770...rtoy:4fa463f.html" title="Last updated on Feb 13, 2020, 3:34 PM UTC (4fa463f)">Diff</a>