### PR TITLE
Fix #2148: Fix erroneous IIRFilterOptions description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7677,14 +7677,12 @@ Dictionary {{IIRFilterOptions}} Members</h5>
 	: <dfn>feedforward</dfn>
 	::
 		The feedforward coefficients for the
-		{{IIRFilterNode}}. This member is required. <span class="synchronous">If
-		not specifed, a {{NotFoundError}} MUST be thrown.</span>  See {{BaseAudioContext/createIIRFilter()/feedforward}} argument of {{BaseAudioContext/createIIRFilter()}} for other constraints.
+		{{IIRFilterNode}}. This member is required.  See {{BaseAudioContext/createIIRFilter()/feedforward}} argument of {{BaseAudioContext/createIIRFilter()}} for other constraints.
 
 	: <dfn>feedback</dfn>
 	::
 		The feedback coefficients for the
-		{{IIRFilterNode}}. This member is required. <span class="synchronous">If
-		not specifed, a {{NotFoundError}} MUST be thrown.</span> See {{BaseAudioContext/createIIRFilter()/feedback}} argument of {{BaseAudioContext/createIIRFilter()}} for other constraints.
+		{{IIRFilterNode}}. This member is required.  See {{BaseAudioContext/createIIRFilter()/feedback}} argument of {{BaseAudioContext/createIIRFilter()}} for other constraints.
 </dl>
 
 <h4 id="IIRFilterNode-filter-definition">


### PR DESCRIPTION
Just remove the test that says if the option isn't specified throw an error.  The option is required so this doesn't make sense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2158.html" title="Last updated on Feb 14, 2020, 12:06 AM UTC (5eed94e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2158/e0d8770...rtoy:5eed94e.html" title="Last updated on Feb 14, 2020, 12:06 AM UTC (5eed94e)">Diff</a>