### PR TITLE
Fix #2150: AudioBufferOptions aren't checked again for required members

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2484,8 +2484,7 @@ acquired.
 
 This specifies the options to use in constructing an
 {{AudioBuffer}}. The {{AudioBufferOptions/length}} and {{AudioBufferOptions/sampleRate}} members are
-required. <span class="synchronous">A {{NotFoundError}} exception MUST be thrown if
-any of the required members are not specified.</span>
+required.
 
 <pre class="idl">
 dictionary AudioBufferOptions {


### PR DESCRIPTION
Just remove the bit about throwing errors if the required members are
not specified.  Let WebIDL handle this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2159.html" title="Last updated on Feb 14, 2020, 12:27 AM UTC (c7eb2a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2159/e0d8770...rtoy:c7eb2a2.html" title="Last updated on Feb 14, 2020, 12:27 AM UTC (c7eb2a2)">Diff</a>