### PR TITLE
Fix #2153: SPN throws NotSupportedError on channelCount change

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2859,7 +2859,7 @@ Attributes</h4>
 
 		: {{ScriptProcessorNode}}
 		::
-			The channel count cannot be changed, and an <span class="synchronous">{{InvalidStateError}} exception MUST
+			The channel count cannot be changed, and an <span class="synchronous">{{NotSupportedError}} exception MUST
 			be thrown for any attempt to change the value.</span>
 
 		: {{StereoPannerNode}}


### PR DESCRIPTION
Throw NotSupportedError instead of InvalidStateError when trying to change the channelCount.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2161.html" title="Last updated on Feb 14, 2020, 12:43 AM UTC (9dc86d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2161/e0d8770...rtoy:9dc86d1.html" title="Last updated on Feb 14, 2020, 12:43 AM UTC (9dc86d1)">Diff</a>