### PR TITLE
Fix #2154: SPN throws NotSupportetError on channelCountMode change

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2926,7 +2926,7 @@ Attributes</h4>
 		: {{ScriptProcessorNode}}
 		::
 			The channel count mode cannot be changed from "{{ChannelCountMode/explicit}}" and
-			an <span class="synchronous">{{InvalidStateError}}
+			an <span class="synchronous">{{NotSupportedError}}
 			exception MUST be thrown for any attempt to change the
 			value.</span>
 


### PR DESCRIPTION
Throw NotSupportedError instead of InvalidStateError when trying to change the channelCountMode.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2162.html" title="Last updated on Feb 14, 2020, 12:46 AM UTC (e677405)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2162/e0d8770...rtoy:e677405.html" title="Last updated on Feb 14, 2020, 12:46 AM UTC (e677405)">Diff</a>