### PR TITLE
Fix a typo. This fixes  #2151.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10892,7 +10892,7 @@ real-time, callback-based audio thread, if computing audio for an
 Each thread has an internal slot that indicates its current state.
 <dfn>control thread state</dfn> is the equivalent of {{BaseAudioContext/state}}
 and <dfn>rendering thread state</dfn> in the counterpart from the rendering
-thread. These slots hava a value of {{AudioContextState}}.
+thread. These slots have a value of {{AudioContextState}}.
 
 The <a>control thread</a> uses a traditional event loop, as described
 in [[HTML]].


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2164.html" title="Last updated on Feb 14, 2020, 3:04 PM UTC (7c63a31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2164/e0d8770...padenot:7c63a31.html" title="Last updated on Feb 14, 2020, 3:04 PM UTC (7c63a31)">Diff</a>