### PR TITLE
Abort the start algorithm if argument validation failed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4036,7 +4036,8 @@ Methods</h4>
 				{{InvalidStateError}} exception MUST be thrown.</span>
 
 			2. Check for any errors that must be thrown due to parameter
-				constraints described below.
+				constraints described below. If any exception is thrown during this
+				step, abort those steps.
 
 			3. Set the internal slot {{AudioScheduledSourceNode/[[source started]]}} on
 				this {{AudioScheduledSourceNode}} to <code>true</code>.


### PR DESCRIPTION
This fixes #2165.

I don't think this is particularly controversial so I went ahead and did it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2167.html" title="Last updated on Feb 18, 2020, 10:32 AM UTC (c4efe66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2167/be4592d...padenot:c4efe66.html" title="Last updated on Feb 18, 2020, 10:32 AM UTC (c4efe66)">Diff</a>