### PR TITLE
Allow not having get parameterDescriptors in an AudioWorkletProcessor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9847,49 +9847,52 @@ Methods</h5>
 				result of
 				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
 
-			1. Let <var>parameterDescriptorSequence</var>
-				be the result of
-				<a href="https://heycam.github.io/webidl/#es-to-sequence">
-				the conversion</a> from
-				<var>parameterDescriptorsValue</var>
-				to an IDL value of type
-				<code>sequence&lt;AudioParamDescriptor&gt;</code>.
+			1. If <var>parameterDescriptorsValue</var> is not <code>undefined</code>,
+				execute the following steps:
 
-			1. Let <var>paramNames</var> be an empty Array.
+				1. Let <var>parameterDescriptorSequence</var>
+					be the result of
+					<a href="https://heycam.github.io/webidl/#es-to-sequence">
+					the conversion</a> from
+					<var>parameterDescriptorsValue</var>
+					to an IDL value of type
+					<code>sequence&lt;AudioParamDescriptor&gt;</code>.
 
-			1. For each <var>descriptor</var> of
-				<var>parameterDescriptorSequence</var>:
+				1. Let <var>paramNames</var> be an empty Array.
 
-				1. Let <var>paramName</var> be the value of
-					the member {{AudioParamDescriptor/name}}
-					in <var>descriptor</var>. Throw
-					a {{NotSupportedError}} if
-					<var>paramNames</var> already
-					contains <var>paramName</var> value.
+				1. For each <var>descriptor</var> of
+					<var>parameterDescriptorSequence</var>:
 
-				1. Append <var>paramName</var> to
-					the <var>paramNames</var> array.
+					1. Let <var>paramName</var> be the value of
+						the member {{AudioParamDescriptor/name}}
+						in <var>descriptor</var>. Throw
+						a {{NotSupportedError}} if
+						<var>paramNames</var> already
+						contains <var>paramName</var> value.
 
-				1. Let <var>defaultValue</var> be the value of
-					the member
-					{{AudioParamDescriptor/defaultValue}}
-					in <var>descriptor</var>.
+					1. Append <var>paramName</var> to
+						the <var>paramNames</var> array.
 
-				1. Let <var>minValue</var> be the value of
-					the member
-					{{AudioParamDescriptor/minValue}}
-					in <var>descriptor</var>.
+					1. Let <var>defaultValue</var> be the value of
+						the member
+						{{AudioParamDescriptor/defaultValue}}
+						in <var>descriptor</var>.
 
-				1. Let <var>maxValue</var> be the value of
-					the member
-					{{AudioParamDescriptor/maxValue}}
-					in <var>descriptor</var>.
+					1. Let <var>minValue</var> be the value of
+						the member
+						{{AudioParamDescriptor/minValue}}
+						in <var>descriptor</var>.
 
-				1. If <var>defaultValue</var> is less than
-					<var>minValue</var> or greater than
-					<var>maxValue</var>,
-					<span class="synchronous">throw a
-					{{InvalidStateError}}</span>.
+					1. Let <var>maxValue</var> be the value of
+						the member
+						{{AudioParamDescriptor/maxValue}}
+						in <var>descriptor</var>.
+
+					1. If <var>defaultValue</var> is less than
+						<var>minValue</var> or greater than
+						<var>maxValue</var>,
+						<span class="synchronous">throw a
+						{{InvalidStateError}}</span>.
 
 			1. Append the key-value pair <var>name</var> →
 				<var>processorCtor</var> to


### PR DESCRIPTION
This allows omitting it if a particular Processor is not going to use
AudioParam. However, if the getter is specified, then it MUST return an
iterable.

This fixes #2171.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2172.html" title="Last updated on Mar 3, 2020, 3:35 PM UTC (fe0a930)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2172/d43886d...padenot:fe0a930.html" title="Last updated on Mar 3, 2020, 3:35 PM UTC (fe0a930)">Diff</a>