### PR TITLE
Check that `minValue` is smaller `maxValue` than  when checking  after conversion to a sequence

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9885,6 +9885,11 @@ Methods</h5>
 					{{AudioParamDescriptor/maxValue}}
 					in <var>descriptor</var>.
 
+				1. If  <var>minValue</var> is greater than
+					<var>maxValue</var>,
+					<span class="synchronous">throw a
+					{{InvalidStateError}}</span>.
+
 				1. If <var>defaultValue</var> is less than
 					<var>minValue</var> or greater than
 					<var>maxValue</var>,


### PR DESCRIPTION
This fixes #2173.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/padenot/web-audio-api/pull/2174.html" title="Last updated on Mar 5, 2020, 2:21 PM UTC (c42e050)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2174/d43886d...padenot:c42e050.html" title="Last updated on Mar 5, 2020, 2:21 PM UTC (c42e050)">Diff</a>