### PR TITLE
Fix #2175:  Incorrect numbering in algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1179,7 +1179,7 @@ Methods</h4>
 				2. <a>Queue a task</a> on the <a>control thread</a>'s event loop
 					to execute the following steps:
 
-					1.Let <var>buffer</var> be an
+					1. Let <var>buffer</var> be an
 						{{AudioBuffer}} containing the final result
 						(after possibly performing sample-rate conversion).
 


### PR DESCRIPTION
This is a simple typo.  Numbered items in a list MUST have whitespace between the number (and period) and the text.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139705468127104:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 9:39 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWebAudio%2Fweb-audio-api%2Fpull%2F2179%2Fd43886d.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Frtoy%2Fweb-audio-api%2Fpull%2F2179.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232179.)._
</details>
