### PR TITLE
Add links to browser issue trackers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,14 +8,24 @@ assignees: ''
 ---
 
 **Describe the issue**
+
 A clear and concise description of what the problem is in the spec.
 
 If you need help on how to use WebAudio, ask on your favorite forum or consider visiting
 the [WebAudio Slack Channel](https://web-audio.slack.com/) (register [here](https://web-audio-slackin.herokuapp.com/)) or
 [StackOverflow](https://stackoverflow.com/).
 
+If it's really an implementation bug, considering filing an issue for your browser at
+
+    * Safari (WebKit): https://bugs.webkit.org/enter_bug.cgi?product=WebKit&component=Web%20Audio (WebKit bugzilla account needed).
+    * Chrome (Blink): https://new.crbug.com/ (Google account needed).
+    * Firefox (Gecko): https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Web%20Audio (GitHub or Mozilla Bugzilla account needed).
+
+
 **Where Is It**
+
 Provide a link to where the problem is in the spec
 
 **Additional Information**
+
 Provide any additional information


### PR DESCRIPTION
Link to safari, chrome, and firefox issue trackers so people can easily find out where to go to file issues.