### PR TITLE
Fix #2184: Clarify refDistance description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8800,7 +8800,7 @@ Attributes</h4>
 	: <dfn>refDistance</dfn>
 	::
 		A reference distance for reducing volume as source moves further
-		from the listener. The default value is 1. <span class="synchronous">A
+		from the listener. For distances less than this, the volume is not reduced. The default value is 1. <span class="synchronous">A
 		{{RangeError}} exception MUST be thrown if this is set
 		to a negative value.</span>
 


### PR DESCRIPTION
Just mention that the volume is not reduced when the distance is less than the refDistance.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2187.html" title="Last updated on Mar 27, 2020, 4:46 PM UTC (fe5cb9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2187/6122985...rtoy:fe5cb9d.html" title="Last updated on Mar 27, 2020, 4:46 PM UTC (fe5cb9d)">Diff</a>