### PR TITLE
Fix #1772: Sort tracks by code units

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8022,7 +8022,7 @@ Constructors</h4>
 				<var>inputStream</var> that have a <code>kind</code> of
 				<code>"audio"</code>.
 			1. Sort the elements in <var>tracks</var> based on their <code>id</code>
-				attribute using lexicographic ordering on sequences of code unit
+				attribute using an ordering on sequences of [=code unit=]
 				values.
 			1. <a href="#audionode-constructor-init">Initialize the AudioNode</a>
 				<var>this</var>, with <var>context</var> and <var>options</var> as arguments.


### PR DESCRIPTION
* Remove "lexicographic"
* Add whatwg link to "code unit"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2189.html" title="Last updated on Apr 24, 2020, 3:49 PM UTC (179f0db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2189/52d90ff...rtoy:179f0db.html" title="Last updated on Apr 24, 2020, 3:49 PM UTC (179f0db)">Diff</a>