### PR TITLE
Fix #2190: Update expected results

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+usage () {
+    echo "compile.sh [-Kh?]"
+    echo "   -K       Keep the actual-errs.txt.  Useful for updating"
+    echo "            expected-errs.txt.  (Otherwise removed when done.)"
+    echo "   -h       This help"
+    echo "   -?       This help"
+    exit 0
+}
+
+KEEP=no
+while getopts "Kh?" arg
+do
+  case $arg in
+      K) KEEP=yes ;;
+      h) usage ;;
+      \?) usage ;;
+  esac
+done
+  
 # So we can see what we're doing
 set -x
 
@@ -10,7 +29,9 @@ ERRLOG="actual-errs.txt"
 
 # Remove ERRLOG when we're done with this script, but keep BSLOG so we
 # can update the expected errors.
+if [ "$KEEP" = "no" ]; then
 trap "rm $ERRLOG" 0
+fi
 
 # Run bikeshed and save the output.  You can use this output as is
 # to update expected-errs.txt.

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -2,42 +2,17 @@ WARNING: Multiple elements have the same ID 'dom-decodeerrorcallback-error'.
 Deduping, but this ID may not be stable across revisions.
 WARNING: Multiple elements have the same ID 'dom-decodesuccesscallback-decodeddata'.
 Deduping, but this ID may not be stable across revisions.
-LINE 1961: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block.
-LINE 3056: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE 3056: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE 3157: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 3170: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 3185: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 3185: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE 10478: Can't find method '['AudioWorkletProcessor/process(inputs, outputs, parameters))']'.
-LINE 1435: No 'method' refs found for 'constructor(contextOptions)'.
-LINE 1961: No 'method' refs found for 'constructor(contextOptions)'.
-LINE 1985: No 'method' refs found for 'constructor(numberOfChannels, length, sampleRate)'.
-LINE 2346: No 'method' refs found for 'constructor(options)'.
-LINE 4216: No 'method' refs found for 'constructor(context, options)'.
-LINE 4678: No 'method' refs found for 'constructor(context, options)'.
-LINE 5922: No 'method' refs found for 'constructor(context, options)'.
-LINE 6374: No 'method' refs found for 'constructor(context, options)'.
-LINE 6487: No 'method' refs found for 'constructor(context, options)'.
-LINE 6570: No 'method' refs found for 'constructor(context, options)'.
-LINE 6701: No 'method' refs found for 'constructor(context, options)'.
-LINE 6964: No 'method' refs found for 'constructor(context, options)'.
-LINE 7132: No 'method' refs found for 'constructor(context, options)'.
-LINE 7575: No 'method' refs found for 'constructor(context, options)'.
-LINE 7689: No 'method' refs found for 'constructor(context, options)'.
-LINE 7857: No 'method' refs found for 'constructor(context, options)'.
-LINE 7960: No 'method' refs found for 'constructor(context, options)'.
-LINE 8052: No 'method' refs found for 'constructor(context, options)'.
-LINE 8125: No 'method' refs found for 'constructor(context, options)'.
-LINE 8265: No 'method' refs found for 'constructor(context, options)'.
-LINE 8646: No 'method' refs found for 'constructor(context, options)'.
-LINE 9041: No 'method' refs found for 'constructor(context, options)'.
-LINE 9344: No 'method' refs found for 'constructor(context, options)'.
-LINE 9476: No 'method' refs found for 'constructor(context, options)'.
-LINE 10045: No 'method' refs found for 'constructor(context, name, options)'.
+LINE: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
+LINE: Can't find method '['AudioWorkletProcessor/process(inputs, outputs, parameters))']'.
 LINK ERROR: No 'idl-name' refs found for 'sequence<unsigned long>'.
 <a data-link-type="idl-name" data-lt="sequence&lt;unsigned long&gt;">sequence&lt;unsigned long&gt;</a>
 LINK ERROR: No 'idl-name' refs found for 'record<DOMString, double>'.
 <a data-link-type="idl-name" data-lt="record&lt;DOMString, double&gt;">record&lt;DOMString, double&gt;</a>
-LINE 10478: No 'method' refs found for 'process(inputs, outputs, parameters))'.
+LINE: No 'idl' refs found for 'process(inputs, outputs, parameters))'.
  ✔  Successfully generated, but fatal errors were suppressed


### PR DESCRIPTION
The latest bikeshed has fixed the issues we had, and has also improved
the errors in the generating the spec.  So update expected-errs.txt
with the new results.

Also, add some command line options to compile.sh.  In particular -K
will keep actual-errs.txt so you can examine it and copy it to
expected-errs.txt as needed.  The option -h (or -?) prints out a brief
explanation of the available command-line options.