### PR TITLE
Fix #2192: Fix WaveShaperNode curve interpolation algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9534,7 +9534,7 @@ Attributes</h4>
 						\begin{cases}
 						c_0 & v \lt 0 \\
 						c_{N-1} & v \ge N - 1 \\
-						(1-f)\,c_k + fc_k & \mathrm{otherwise}
+						(1-f)\,c_k + fc_{k+1} & \mathrm{otherwise}
 						\end{cases}
 					\end{align*}
 				$$


### PR DESCRIPTION
Change `(1-f)*c[k] + f*c[k]` to `(1-f)*c[k] + f*c[k+1]`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2197.html" title="Last updated on Apr 24, 2020, 4:30 PM UTC (977e1e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2197/288bafb...rtoy:977e1e3.html" title="Last updated on Apr 24, 2020, 4:30 PM UTC (977e1e3)">Diff</a>