### PR TITLE
Fix #2193: Fix typo in azimuth algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11762,7 +11762,7 @@ if (frontBack < 0)
   azimuth = 360 - azimuth;
 
 // Make azimuth relative to "forward" and not "right" listener vector.
-if ((azimuth <= 0) && (azimuth <= 270))
+if ((azimuth >= 0) && (azimuth <= 270))
   azimuth = 90 - azimuth;
 else
   azimuth = 450 - azimuth;


### PR DESCRIPTION
Change `<=` to `>=` as noted by @koalefant


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2198.html" title="Last updated on Apr 24, 2020, 4:36 PM UTC (8edf54b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2198/288bafb...rtoy:8edf54b.html" title="Last updated on Apr 24, 2020, 4:36 PM UTC (8edf54b)">Diff</a>