### PR TITLE
fixed wrong optionality of IIRFilterNode options

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7688,7 +7688,7 @@ Constructors</h4>
 
 		<pre class=argumentdef for="IIRFilterNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{IIRFilterNode}} will be <a href="#associated">associated</a> with.
-			options: Optional initial parameter value for this {{IIRFilterNode}}.
+			options: Initial parameter value for this {{IIRFilterNode}}.
 		</pre>
 </dl>
 


### PR DESCRIPTION
the description of `options` parameter of `IIRFilterNode` constructor says its optional but
- its `Optional` column is not checked
- there are no means to change `IIRFilterNode` options 

i guess this was a typo or something


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/khodzha/web-audio-api/pull/2201.html" title="Last updated on May 5, 2020, 2:13 PM UTC (b1c126f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2201/80ee1a8...khodzha:b1c126f.html" title="Last updated on May 5, 2020, 2:13 PM UTC (b1c126f)">Diff</a>