### PR TITLE
Fix #2202: Update id of change log section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12437,7 +12437,7 @@ class Vec3 {
 }
 </pre>
 
-<h2 id="changelog">
+<h2 id="changes">
 Change Log</h2>
 <h3 id="changestart1">
  Since Candidate Recommendation of 18 September 2018


### PR DESCRIPTION
To satisfy bikeshed, change the id of the change log section to
"changes' that bikeshed wants.

The current id of "changelog" isn't used anywhere else in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2204.html" title="Last updated on May 26, 2020, 5:39 PM UTC (14be4d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2204/9b3f727...rtoy:14be4d5.html" title="Last updated on May 26, 2020, 5:39 PM UTC (14be4d5)">Diff</a>