### PR TITLE
Return rejected promise when the document is not fully active, for operations returning promises.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1105,9 +1105,11 @@ Methods</h4>
 			called, the following steps MUST be performed on the control
 			thread:</span>
 
-			1. Let <var>promise</var> be a new Promise.
+			1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
 
-			2. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
+			2. Let <var>promise</var> be a new Promise.
+
+			3. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
 				(described in [[!ECMASCRIPT]]) on {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} is
 				<code>false</code>, execute the following steps:
 
@@ -1121,14 +1123,14 @@ Methods</h4>
 
 				3. Queue a decoding operation to be performed on another thread.
 
-			3. Else, execute the following error steps:
+			4. Else, execute the following error steps:
 
 				1. Let <var>error</var> be a {{DataCloneError}}.
 				2. Reject <var>promise</var> with <var>error</var>, and remove it from
 					{{BaseAudioContext/[[pending promises]]}}.
 				3. <a>Queue a task</a> to invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
 
-			4. Return <var>promise</var>.
+			5. Return <var>promise</var>.
 		</div>
 
 		<div algorithm="queue a decode operation">
@@ -1493,6 +1495,8 @@ Methods</h4>
 		<div algorithm="AudioContext.close()">
 			<span class="synchronous">When close is called, execute these steps:</span>
 
+			1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
+
 			1. Let <var>promise</var> be a new Promise.
 
 			1. If the <a>control thread state</a> flag on the
@@ -1676,6 +1680,8 @@ Methods</h4>
 			<span class="synchronous">When resume is called,
 			execute these steps:</span>
 
+			1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
+
 			1. Let <var>promise</var> be a new Promise.
 
 			2. If the <a>control thread state</a> on the
@@ -1760,6 +1766,8 @@ Methods</h4>
 
 		<div algorithm="AudioContext.suspend()">
 			<span class="synchronous">When suspend is called, execute these steps:</span>
+
+			1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
 
 			1. Let <var>promise</var> be a new Promise.
 
@@ -2025,6 +2033,8 @@ Methods</h4>
 			thread</a>:</span>
 
 			<ol>
+				<li>If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
+
 				<li>If the {{[[rendering started]]}} slot on the
 				{{OfflineAudioContext}} is <em>true</em>, return a rejected
 				promise with {{InvalidStateError}}, and abort these
@@ -2106,6 +2116,10 @@ Methods</h4>
 		<div algorithm="OfflineAudioContext::resume()">
 			<span class="synchronous">When resume is called,
 			execute these steps:</span>
+
+			1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is
+				not [=fully active=] then return [=a promise rejected with=]
+				"{{InvalidStateError}}" {{DOMException}}.
 
 			1. Let <var>promise</var> be a new Promise.
 


### PR DESCRIPTION
Essentially a conversion to bikeshed of @domenic's [comment](https://github.com/WebAudio/web-audio-api/issues/2176#issuecomment-640930168) and then used everywhere we create a promise.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2210.html" title="Last updated on Jul 7, 2020, 9:02 AM UTC (c0ddda0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2210/5d87cf8...c0ddda0.html" title="Last updated on Jul 7, 2020, 9:02 AM UTC (c0ddda0)">Diff</a>