### PR TITLE
AudioWorklet addModule requests destination are of type type "audioworklet"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9672,10 +9672,13 @@ within a special scope named {{AudioWorkletGlobalScope}}.
 </figure>
 
 Each {{BaseAudioContext}} possesses exactly one
-{{AudioWorklet}}. Scripts imported using this {{AudioWorklet}}
-are run in one {{AudioWorkletGlobalScope}},
-which is created to process audio associated with that
-{{BaseAudioContext}}.
+{{AudioWorklet}}.
+
+The {{AudioWorklet}}'s <a>worklet global scope type</a> is
+{{AudioWorkletGlobalScope}}.
+
+The {{AudioWorklet}}'s <a>worklet destination type</a> is
+<code>"audioworklet"</code>.
 
 Importing a script via the {{addModule()|addModule(moduleUrl)}}
 method registers class definitions of {{AudioWorkletProcessor}}


### PR DESCRIPTION
This fixes #2203.

This needs https://github.com/w3c/css-houdini-drafts/issues/378 for the second link to work, and the fix to make sense.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2212.html" title="Last updated on Jul 7, 2020, 9:45 AM UTC (2436903)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2212/5d87cf8...2436903.html" title="Last updated on Jul 7, 2020, 9:45 AM UTC (2436903)">Diff</a>