### PR TITLE
The message queue is for message running on the rendering thread.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10960,7 +10960,7 @@ tasks.
 
 Each {{AudioContext}} has a single <dfn>control message
 queue</dfn> that is a list of <dfn lt="control message">control
-messages</dfn> that are operations running on the <a>control
+messages</dfn> that are operations running on the <a>rendering
 thread</a>.
 
 <dfn id="queuing" lt="queue a control message">Queuing a control message</dfn>


### PR DESCRIPTION
This fixes #2213.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2214.html" title="Last updated on Jul 8, 2020, 4:57 PM UTC (13a3b8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2214/b0c0380...13a3b8b.html" title="Last updated on Jul 8, 2020, 4:57 PM UTC (13a3b8b)">Diff</a>