### PR TITLE
Fix #2206: Describe clamping of rolloffFactor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8825,7 +8825,7 @@ Attributes</h4>
 		{{RangeError}} exception MUST be thrown if this is set to
 		a negative value.</span>
 
-		The nominal range for the <code>rolloffFactor</code> specifies
+		The nominal range for the {{PannerNode/rolloffFactor}} specifies
 		the minimum and maximum values the <code>rolloffFactor</code>
 		can have. Values outside the range are clamped to lie within
 		this range. The nominal range depends on the {{PannerNode/distanceModel}} as follows:
@@ -8840,6 +8840,10 @@ Attributes</h4>
 			: "{{exponential}}"
 			:: The nominal range is \([0, \infty)\).
 		</dl>
+
+		Note that the clamping happens as part of the
+		processing of the distance computation.  The attribute
+		reflects the value that was set and is not modified.
 </dl>
 
 <h4 id="PannerNode-methods">


### PR DESCRIPTION
The clamping of the rolloffFactor happens during the processing for the distance computation.  The attribute is not changed; it reflects the value that was set.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2220.html" title="Last updated on Jul 17, 2020, 4:48 PM UTC (e3d5a9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2220/ca76b67...rtoy:e3d5a9a.html" title="Last updated on Jul 17, 2020, 4:48 PM UTC (e3d5a9a)">Diff</a>