### PR TITLE
Fix #2199: Prevent wrapping of lines in some places

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -195,6 +195,9 @@ div.enum-description > table > thead > tr > th {
 	color: #178217;
 	border-bottom: 1px solid #707070;
 }
+code.nobreak {
+  white-space: nowrap;
+}
 </style>
 
 <h2 id="introductory" class=no-num>
@@ -10497,12 +10500,12 @@ of {{AudioParamDescriptor}}s.
 
 		<pre class=argumentdef for="AudioWorkletProcessor/process(inputs, outputs, parameters))">
 			inputs:
-				The input audio buffer from the incoming connections provided by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>inputs[n][m]</code> is a {{Float32Array}} of audio samples for the \(m\)th channel of the \(n\)th input. While the number of inputs is fixed at construction, the number of channels can be changed dynamically based on [=computedNumberOfChannels=].
+ 				The input audio buffer from the incoming connections provided by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>.<code class="nobreak">inputs[n][m]</code> is a {{Float32Array}} of audio samples for the \(m\)th channel of the \(n\)th input. While the number of inputs is fixed at construction, the number of channels can be changed dynamically based on [=computedNumberOfChannels=].
 
 				If there are no [=actively processing=] {{AudioNode}}s connected to the \(n\)th input of the {{AudioWorkletNode}} for the current render quantum, then the content of <code>inputs[n]</code> is an empty array, indicating that zero channels of input are available. This is the only circumstance under which the number of elements of <code>inputs[n]</code> can be zero.
 
 			outputs:
-				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>. <code>outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
+				The output audio buffer that is to be consumed by the user agent. It has type <code>sequence&lt;sequence&lt;Float32Array>></code>.<code class="nobreak">outputs[n][m]</code> is a {{Float32Array}} object containing the audio samples for \(m\)th channel of \(n\)th output. Each of the {{Float32Array}}s are zero-filled. The number of channels in the output will match [=computedNumberOfChannels=] only when the node has a single output.
 
 			parameters:
 				An [=ordered map=] of <var>name</var> → <var>parameterValues</var>. <code>parameters["<var>name</var>"]</code> returns <var>parameterValues</var>, which is a {{Float32Array}} with the automation values of the <var>name</var> {{AudioParam}}.


### PR DESCRIPTION
Added some CSS for `<code>` to disallow wrapping of lines.  This fixes the issue in the description of the `inputs` and `outputs` parameters for the `process()` method.  Didn't apply this anywhere else.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2221.html" title="Last updated on Jul 17, 2020, 6:23 PM UTC (198ccfc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2221/10b654b...rtoy:198ccfc.html" title="Last updated on Jul 17, 2020, 6:23 PM UTC (198ccfc)">Diff</a>