### PR TITLE
Fix #2169: Remove redundant constraints in AudioParamDescriptor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9883,13 +9883,13 @@ Methods</h5>
 
 				1. Let <var>paramNames</var> be an empty Array.
 
-				1. For each <var>descriptor</var> of
+				1. <div id="steps-parameterDescriptorSequence"></div>
+					For each <var>descriptor</var> of
 					<var>parameterDescriptorSequence</var>:
-
 					1. Let <var>paramName</var> be the value of
 						the member {{AudioParamDescriptor/name}}
-						in <var>descriptor</var>. Throw
-						a {{NotSupportedError}} if
+						in <var>descriptor</var>. <span class="synchronous">Throw
+						a {{NotSupportedError}}</span> if
 						<var>paramNames</var> already
 						contains <var>paramName</var> value.
 
@@ -9911,10 +9911,15 @@ Methods</h5>
 						{{AudioParamDescriptor/maxValue}}
 						in <var>descriptor</var>.
 
+					1. If <var>minValue</var> is
+						greater than or equal <var>maxValue</var>,
+						<span class="synchronous">throw an
+						{{InvalidStateError}}</span>.
+
 					1. If <var>defaultValue</var> is less than
 						<var>minValue</var> or greater than
 						<var>maxValue</var>,
-						<span class="synchronous">throw a
+						<span class="synchronous">throw an
 						{{InvalidStateError}}</span>.
 
 			1. Append the key-value pair <var>name</var> →
@@ -10568,40 +10573,29 @@ dictionary AudioParamDescriptor {
 <h6 id="dictionary-audioparamdescriptor-members">
 Dictionary {{AudioParamDescriptor}} Members</h6>
 
+There are constraints on the values for these members.  See the <a
+href="#steps-parameterDescriptorSequence">algorithm for handling an
+AudioParamDescriptor</a> for the constraints.
+
 <dl dfn-type=dict-member dfn-for="AudioParamDescriptor">
 	: <dfn>automationRate</dfn>
 	::
 		Represents the default automation rate.
-
 	: <dfn>defaultValue</dfn>
 	::
-		Represents the default value of the parameter. <span class="synchronous">If this value
-		is out of the range of float data type or the range defined
-		by {{AudioParamDescriptor/minValue}} and {{AudioParamDescriptor/maxValue}}, a
-		{{NotSupportedError}} exception MUST be thrown.</span>
+		Represents the default value of the parameter.
 
 	: <dfn>maxValue</dfn>
 	::
-		Represents the maximum value. <span class="synchronous">A
-		{{NotSupportedError}} exception MUST be thrown if
-		this value is out of range of float data type or it is
-		smaller than <code>minValue</code>.</span> This value is the most
-		positive finite single precision floating-point number.
+		Represents the maximum value.
 
 	: <dfn>minValue</dfn>
 	::
-		Represents the minimum value. <span class="synchronous">A
-		{{NotSupportedError}} exception MUST be thrown if
-		this value is out of range of float data type or it is
-		greater than <code>maxValue</code>.</span> This value is the most
-		negative finite single precision floating-point number.
+		Represents the minimum value.
 
 	: <dfn>name</dfn>
 	::
-		Represents the name of the parameter. <span class="synchronous">A
-		{{NotSupportedError}} exception MUST be thrown when
-		a duplicated name is found when registering the class
-		definition.</span>
+		Represents the name of the parameter.
 </dl>
 
 <h4 id="AudioWorklet-Sequence">

--- a/index.bs
+++ b/index.bs
@@ -9911,16 +9911,12 @@ Methods</h5>
 						{{AudioParamDescriptor/maxValue}}
 						in <var>descriptor</var>.
 
-					1. If <var>minValue</var> is
-						greater than or equal <var>maxValue</var>,
-						<span class="synchronous">throw an
-						{{InvalidStateError}}</span>.
-
-					1. If <var>defaultValue</var> is less than
-						<var>minValue</var> or greater than
-						<var>maxValue</var>,
-						<span class="synchronous">throw an
-						{{InvalidStateError}}</span>.
+					1. If the expresstion
+						<var>minValue</var> &lt;=
+						<var>defaultValue</var> &lt;=
+						<var>maxValue</var> is false,
+						<span class="synchronous">throw
+						an {{InvalidStateError}}</span>.
 
 			1. Append the key-value pair <var>name</var> →
 				<var>processorCtor</var> to


### PR DESCRIPTION
The constraints in the members of the `AudioParamDescriptor` are removed.  We replace that with a link to the steps in `registerProcessor` algorithm that describes how to handle the descriptor.

Updated the algorithm to include a step to throw an error if `minValue` is greater than `maxValue`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2222.html" title="Last updated on Jul 20, 2020, 2:28 PM UTC (d5c6a6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2222/ca76b67...rtoy:d5c6a6a.html" title="Last updated on Jul 20, 2020, 2:28 PM UTC (d5c6a6a)">Diff</a>