### PR TITLE
Fix #1457:  Privacy for sample rates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12297,7 +12297,7 @@ to Consider</a>
 	1. 44.1 kHz and 48 kHz are allowed as default rates; the system will choose
 		between them for best applicability. (Obviously, if the audio device is
 		natively 44.1, 44.1 will be chosen, etc., but also the system may choose
-		the most "compatible" rat&mdash;e.g. if the system is natively 96kHz,
+		the most "compatible" rate&mdash;e.g. if the system is natively 96kHz,
 		48kHz would likely be chosen, not 44.1kHz.
 	1. The system should resample to one of those two rates for devices that are
 		natively at different rates, despite the fact that this may cause extra
@@ -12308,14 +12308,14 @@ to Consider</a>
 		affordance to force use of the native rate&mdash;e.g. by setting a flag in
 		the browser on the device. This setting would not be exposed in the API.
 	1. It is also expected behavior that a different rate could be explicitly
-		requested in the constructor for AudioContext (this is already in the
+		requested in the constructor for {{AudioContext}} (this is already in the
 		specification; it normally causes the audio rendering to be done at the
-		requested sampleRate, and then up- or down-scaled to the device output),
+		requested sampleRate, and then up- or down-sampled to the device output),
 		and if that rate is natively supported, the rendering could be passed
 		straight through. This would enable apps to render to higher rates without
 		user intervention (although it's not observable from Web Audio that the
 		audio output is not downsampled on output)&mdash;for example, if
-		MediaDevices capabilities were read (with user intervention) and indicated
+		{{MediaDevices}} capabilities were read (with user intervention) and indicated
 		a higher rate was supported.
 
 6. Does this specification enable new script execution/loading

--- a/index.bs
+++ b/index.bs
@@ -12291,6 +12291,33 @@ to Consider</a>
 	recording or music making environment). Excessive latency decreases usability and may be
 	an accessibility issue.
 
+    Fingerprining via the sample rate of the {{AudioContext}} is also possible.  We
+    recommend the following steps to be taken to minimize this:
+
+	1. 44.1 kHz and 48 kHz are allowed as default rates; the system will choose
+		between them for best applicability. (Obviously, if the audio device is
+		natively 44.1, 44.1 will be chosen, etc., but also the system may choose
+		the most "compatible" rat&mdash;e.g. if the system is natively 96kHz,
+		48kHz would likely be chosen, not 44.1kHz.
+	1. The system should resample to one of those two rates for devices that are
+		natively at different rates, despite the fact that this may cause extra
+		battery drain due to resampled audio. (Again, the system will choose the
+		most compatible rate&mdash;e.g. if the native system is 16kHz, it's
+		expected that 48kHz would be chosen.)
+	1. It is expected (though not mandated) that browsers would offer a user
+		affordance to force use of the native rate&mdash;e.g. by setting a flag in
+		the browser on the device. This setting would not be exposed in the API.
+	1. It is also expected behavior that a different rate could be explicitly
+		requested in the constructor for AudioContext (this is already in the
+		specification; it normally causes the audio rendering to be done at the
+		requested sampleRate, and then up- or down-scaled to the device output),
+		and if that rate is natively supported, the rendering could be passed
+		straight through. This would enable apps to render to higher rates without
+		user intervention (although it's not observable from Web Audio that the
+		audio output is not downsampled on output)&mdash;for example, if
+		MediaDevices capabilities were read (with user intervention) and indicated
+		a higher rate was supported.
+
 6. Does this specification enable new script execution/loading
 	mechanisms?
 

--- a/index.bs
+++ b/index.bs
@@ -12281,7 +12281,7 @@ to Consider</a>
 	Privacy &amp; Security appendix of High Resolution Time</a> should be consulted for further
 	information on clock resolution and drift.
 
-    Fingerprinting via latency is also possible; it might be possible to deduce this
+	Fingerprinting via latency is also possible; it might be possible to deduce this
 	from {{baseLatency}} and {{outputLatency}}. Mitigation
 	strategies include adding jitter (dithering) and quantization so that the exact
 	skew is incorrectly reported. Note however that most audio systems aim
@@ -12291,8 +12291,8 @@ to Consider</a>
 	recording or music making environment). Excessive latency decreases usability and may be
 	an accessibility issue.
 
-    Fingerprining via the sample rate of the {{AudioContext}} is also possible.  We
-    recommend the following steps to be taken to minimize this:
+	Fingerprining via the sample rate of the {{AudioContext}} is also possible.  We
+	recommend the following steps to be taken to minimize this:
 
 	1. 44.1 kHz and 48 kHz are allowed as default rates; the system will choose
 		between them for best applicability. (Obviously, if the audio device is
@@ -12317,6 +12317,12 @@ to Consider</a>
 		audio output is not downsampled on output)&mdash;for example, if
 		{{MediaDevices}} capabilities were read (with user intervention) and indicated
 		a higher rate was supported.
+
+	Fingerprinting via the number of output channels for the
+	{{AudioContext}} is possible as well.  We recommend that
+	{{AudioDestinationNode/maxChannelCount}} be set to two
+	(stereo).  Stereo is by far the most common number of
+	channels.
 
 6. Does this specification enable new script execution/loading
 	mechanisms?


### PR DESCRIPTION
Basically takes @cwilso's suggested [text](https://github.com/WebAudio/web-audio-api/issues/1457#issuecomment-640767256) with slight editorial modifications to handle privacy issues with sample rates being exposed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2223.html" title="Last updated on Jul 24, 2020, 3:53 PM UTC (7a5b15b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2223/ca76b67...rtoy:7a5b15b.html" title="Last updated on Jul 24, 2020, 3:53 PM UTC (7a5b15b)">Diff</a>