### PR TITLE
Fix #2061: Mandate anti-fingerprinting of audio outputs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12269,7 +12269,7 @@ to Consider</a>
 
 	In practice however, this merely allows deduction of information
 	already readily available by easier means (User Agent string),
-	such as "this is Chrome running on an x86".  However, to reduce the
+	such as "this is browser X running on platform Y".  However, to reduce the
 	possibility of additional fingerprinting, we mandate browsers take
 	action to mitigate fingerprinting issues that might be possible from the
 	output of any node.

--- a/index.bs
+++ b/index.bs
@@ -12269,7 +12269,16 @@ to Consider</a>
 
 	In practice however, this merely allows deduction of information
 	already readily available by easier means (User Agent string),
-	such as "this is Chrome running on an x86".
+	such as "this is Chrome running on an x86".  However, to reduce the
+	possibility of additional fingerprinting, we mandate browsers take
+	action to mitigate fingerprinting issues.  The exact approach is not
+	prescribed, but one possible approach is described in the paper by
+	Pierre Laperdrix, Benoit Baudry, Vikas Mishra. <a
+	href="https://hal.inria.fr/hal-01527580/document">"FPRandom: Randomizing
+	core browser objects to break advanced device fingerprinting
+	techniques"</a>, ESSoS 2017 - 9th International Symposium on Engineering
+	Secure Software and Systems, Jul 2017, Bonn,
+	Germany. pp.17. hal-01527580.
 
 	Fingerprinting via clock skew
 	<a href="http://sec.cs.ucl.ac.uk/users/smurdoch/talks/eurobsdcon07hotornot.pdf">has

--- a/index.bs
+++ b/index.bs
@@ -12271,14 +12271,8 @@ to Consider</a>
 	already readily available by easier means (User Agent string),
 	such as "this is Chrome running on an x86".  However, to reduce the
 	possibility of additional fingerprinting, we mandate browsers take
-	action to mitigate fingerprinting issues.  The exact approach is not
-	prescribed, but one possible approach is described in the paper by
-	Pierre Laperdrix, Benoit Baudry, Vikas Mishra. <a
-	href="https://hal.inria.fr/hal-01527580/document">"FPRandom: Randomizing
-	core browser objects to break advanced device fingerprinting
-	techniques"</a>, ESSoS 2017 - 9th International Symposium on Engineering
-	Secure Software and Systems, Jul 2017, Bonn,
-	Germany. pp.17. hal-01527580.
+	action to mitigate fingerprinting issues that might be possible from the
+	output of any node.
 
 	Fingerprinting via clock skew
 	<a href="http://sec.cs.ucl.ac.uk/users/smurdoch/talks/eurobsdcon07hotornot.pdf">has


### PR DESCRIPTION
Mandates browsers take action against fingerprinting of audio outputs, but leave the approach unspecified.  We mention one possible approach is dithering the output of audio nodes as described in the referenced paper.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2224.html" title="Last updated on Jul 22, 2020, 2:37 PM UTC (39d44d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2224/ca76b67...rtoy:39d44d7.html" title="Last updated on Jul 22, 2020, 2:37 PM UTC (39d44d7)">Diff</a>