### PR TITLE
Fix #2225: Remove mention of non-interleaved

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2285,10 +2285,11 @@ Dictionary {{OfflineAudioCompletionEventInit}} Members</h6>
 <h3 id="AudioBuffer">
 The {{AudioBuffer}} Interface</h3>
 
-This interface represents a memory-resident audio asset. Its format is non-interleaved
-32-bit floating-point [=linear PCM=] values with a normal range of \([-1,
-1]\), but values are not limited to this range. It can contain one or
-more channels. Typically, it would be expected that the length of the
+This interface represents a memory-resident audio asset. It can contain one or
+more channels with each channel appearing to be 32-bit floating-point
+[=linear PCM=] values with a nominal range of \([-1,1]\) but the
+values are not limited to this range. Typically, it would be expected
+that the length of the
 PCM data would be fairly short (usually somewhat less than a minute).
 For longer sounds, such as music soundtracks, streaming should be
 used with the <{audio}> element and


### PR DESCRIPTION
Per the comment in https://github.com/WebAudio/web-audio-api/issues/2225#issuecomment-663102040, remove the word "non-interleaved".

For better readability, rearrange the sentences slightly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2230.html" title="Last updated on Jul 28, 2020, 4:32 PM UTC (96f7fe0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2230/0a3ea91...rtoy:96f7fe0.html" title="Last updated on Jul 28, 2020, 4:32 PM UTC (96f7fe0)">Diff</a>