### PR TITLE
Fix #2231; Define internal slot [[curve set]] for WaveShaperNode

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -108,8 +108,6 @@ LINK ERROR: No 'argument' refs found for 'context' with for='WaveShaperNode/Wave
 <a data-lt="context" data-link-type="argument" data-link-for="WaveShaperNode/WaveShaperNode(context, options), WaveShaperNode/constructor(context, options), WaveShaperNode/WaveShaperNode(context), WaveShaperNode/constructor(context)">context</a>
 LINK ERROR: No 'argument' refs found for 'options' with for='WaveShaperNode/WaveShaperNode(context, options)'.
 <a data-lt="options" data-link-type="argument" data-link-for="WaveShaperNode/WaveShaperNode(context, options), WaveShaperNode/constructor(context, options), WaveShaperNode/WaveShaperNode(context), WaveShaperNode/constructor(context)">options</a>
-LINK ERROR: No 'idl' refs found for '[[curve set]]'.
-{{WaveShaperNode/[[curve set]]}}
 LINK ERROR: No 'argument' refs found for 'context' with for='AudioWorkletNode/AudioWorkletNode(context, name, options)'.
 <a data-lt="context" data-link-type="argument" data-link-for="AudioWorkletNode/AudioWorkletNode(context, name, options), AudioWorkletNode/constructor(context, name, options), AudioWorkletNode/AudioWorkletNode(context, name), AudioWorkletNode/constructor(context, name)">context</a>
 LINK ERROR: No 'argument' refs found for 'name' with for='AudioWorkletNode/AudioWorkletNode(context, name, options)'.

--- a/index.bs
+++ b/index.bs
@@ -9494,6 +9494,11 @@ Constructors</h4>
 			path: audionode-init.include
 		</pre>
 
+		Also, let <dfn attribute for="WaveShaperNode">[[curve set]]</dfn> be an internal
+		slot of this {{WaveShaperNode}}.  Initialize this slot to <code>false</code>.  If
+		{{WaveShaperNode/constructor(context, options)/options}} is given and specifies a
+		{{WaveShaperOptions/curve}}, set {{[[curve set]]}} to <code>true</code>.
+
 		<pre class=argumentdef for="WaveShaperNode/constructor(context, options)">
 			context: The {{BaseAudioContext}} this new {{WaveShaperNode}} will be <a href="#associated">associated</a> with.
 			options: Optional initial parameter value for this {{WaveShaperNode}}.


### PR DESCRIPTION
Defines the internal slot `[[curve set]]` for `WaveShaperNode` using basically the text from #1896.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2232.html" title="Last updated on Jul 28, 2020, 7:18 PM UTC (3fe4751)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2232/0a3ea91...rtoy:3fe4751.html" title="Last updated on Jul 28, 2020, 7:18 PM UTC (3fe4751)">Diff</a>