### PR TITLE
Address #2185: Fix some bikeshed errors

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -80,8 +80,6 @@ LINK ERROR: No 'argument' refs found for 'context' with for='MediaStreamAudioSou
 <a data-lt="context" data-link-type="argument" data-link-for="MediaStreamAudioSourceNode/MediaStreamAudioSourceNode(context, options), MediaStreamAudioSourceNode/constructor(context, options)">context</a>
 LINK ERROR: No 'argument' refs found for 'options' with for='MediaStreamAudioSourceNode/MediaStreamAudioSourceNode(context, options)'.
 <a data-lt="options" data-link-type="argument" data-link-for="MediaStreamAudioSourceNode/MediaStreamAudioSourceNode(context, options), MediaStreamAudioSourceNode/constructor(context, options)">options</a>
-LINK ERROR: No 'argument' refs found for 'options' with for='MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()'.
-{{MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()/options!!argument}}
 LINK ERROR: No 'argument' refs found for 'context' with for='MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode(context, options)'.
 <a data-lt="context" data-link-type="argument" data-link-for="MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode(context, options), MediaStreamTrackAudioSourceNode/constructor(context, options)">context</a>
 LINK ERROR: No 'argument' refs found for 'options' with for='MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode(context, options)'.
@@ -98,8 +96,6 @@ LINK ERROR: No 'argument' refs found for 'context' with for='PeriodicWave/Period
 <a data-lt="context" data-link-type="argument" data-link-for="PeriodicWave/PeriodicWave(context, options), PeriodicWave/constructor(context, options), PeriodicWave/PeriodicWave(context), PeriodicWave/constructor(context)">context</a>
 LINK ERROR: No 'argument' refs found for 'options' with for='PeriodicWave/PeriodicWave(context, options)'.
 <a data-lt="options" data-link-type="argument" data-link-for="PeriodicWave/PeriodicWave(context, options), PeriodicWave/constructor(context, options), PeriodicWave/PeriodicWave(context), PeriodicWave/constructor(context)">options</a>
-LINK ERROR: No 'argument' refs found for 'options' with for='PeriodicWave/PeriodicWave(context, options)'.
-{{PeriodicWave/PeriodicWave(context, options)/options!!argument}}
 LINK ERROR: No 'argument' refs found for 'context' with for='StereoPannerNode/StereoPannerNode(context, options)'.
 <a data-lt="context" data-link-type="argument" data-link-for="StereoPannerNode/StereoPannerNode(context, options), StereoPannerNode/constructor(context, options), StereoPannerNode/StereoPannerNode(context), StereoPannerNode/constructor(context)">context</a>
 LINK ERROR: No 'argument' refs found for 'options' with for='StereoPannerNode/StereoPannerNode(context, options)'.

--- a/index.bs
+++ b/index.bs
@@ -8028,7 +8028,7 @@ Constructors</h4>
 	: <dfn>MediaStreamAudioSourceNode(context, options)</dfn>
 	::
 			1. If the {{MediaStreamAudioSourceOptions/mediaStream}} member of
-				{{MediaStreamAudioSourceNode/MediaStreamAudioSourceNode()/options!!argument}} does not reference a
+				{{MediaStreamAudioSourceNode/constructor(context, options)/options!!argument}} does not reference a
 				{{MediaStream}} that has at least one
 				{{MediaStreamTrack}} whose
 				<code>kind</code> attribute has the value <code>"audio"</code>,

--- a/index.bs
+++ b/index.bs
@@ -9031,7 +9031,7 @@ Constructors</h4>
 		<div algorithm="construct periodic wave">
 			1. Let <var>p</var> be a new {{PeriodicWave}} object. Let <dfn attribute for="PeriodicWave">\[[real]]</dfn> and <dfn attribute for="PeriodicWave">\[[imag]]</dfn> be two internal slots of type {{Float32Array}}, and let <dfn attribute for="PeriodicWave">\[[normalize]]</dfn> be an internal slot.
 
-			1. Process {{PeriodicWave/PeriodicWave(context, options)/options!!argument}} according to one of the following cases:
+			1. Process {{PeriodicWave/constructor(context, options)/options!!argument}} according to one of the following cases:
 				1. If both {{PeriodicWaveOptions/real|options.real}} and {{PeriodicWaveOptions/imag|options.imag}} are present
 					1. <span class="synchronous">If the lengths of {{PeriodicWaveOptions/real|options.real}} and {{PeriodicWaveOptions/imag|options.imag}} are different or if either length is less than 2, throw an {{IndexSizeError}} and abort this algorithm.</span>
 					1. Set {{[[real]]}} and {{[[imag]]}} to new arrays with the same length as {{PeriodicWaveOptions/real|options.real}}.


### PR DESCRIPTION
Fixing links to parameters to the constructor. Basically, we
previously had something like
```
{{PeriodicWave/PeriodicWave(context, options)/options!!argument}}
```
and replace it with
```
{{PeriodicWave/constructor(context, options)/options!!argument}}
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2233.html" title="Last updated on Jul 28, 2020, 8:45 PM UTC (1b1022d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2233/0a3ea91...rtoy:1b1022d.html" title="Last updated on Jul 28, 2020, 8:45 PM UTC (1b1022d)">Diff</a>