### PR TITLE
Address #2185: Update expected errors

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -20,9 +20,5 @@ LINK ERROR: No 'argument' refs found for 'length' with for='OfflineAudioContext/
 <a data-lt="length" data-link-type="argument" data-link-for="OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate), OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)">length</a>
 LINK ERROR: No 'argument' refs found for 'sampleRate' with for='OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate)'.
 <a data-lt="sampleRate" data-link-type="argument" data-link-for="OfflineAudioContext/OfflineAudioContext(numberOfChannels, length, sampleRate), OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)">sampleRate</a>
-LINK ERROR: No 'idl-name' refs found for 'sequence<unsigned long>'.
-<a data-link-type="idl-name" data-lt="sequence&lt;unsigned long&gt;">sequence&lt;unsigned long&gt;</a>
-LINK ERROR: No 'idl-name' refs found for 'record<DOMString, double>'.
-<a data-link-type="idl-name" data-lt="record&lt;DOMString, double&gt;">record&lt;DOMString, double&gt;</a>
 LINE: No 'idl' refs found for 'process(inputs, outputs, parameters))'.
  ✔  Successfully generated, but fatal errors were suppressed


### PR DESCRIPTION
The latest veresion of bikeshed has fixed the errors printed for `<sequence<unsigned long>` and `record<DOMString, double>`, so we can remove these lines.