### PR TITLE
Fix #2240: Align with Web IDL specification

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -10,9 +10,5 @@ LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(
 LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find method '['AudioWorkletProcessor/process(inputs, outputs, parameters))']'.
-LINK ERROR: No 'idl-name' refs found for 'void'.
-<a class="n" data-link-type="idl-name" data-lt="void">void</a>
-LINK ERROR: No 'idl' refs found for 'void'.
-{{void}}
 LINE: No 'idl' refs found for 'process(inputs, outputs, parameters))'.
  ✔  Successfully generated, but fatal errors were suppressed

--- a/index.bs
+++ b/index.bs
@@ -2330,11 +2330,11 @@ interface AudioBuffer {
 	readonly attribute unsigned long numberOfChannels;
 	Float32Array getChannelData (unsigned long channel);
 	undefined copyFromChannel (Float32Array destination,
-	                      unsigned long channelNumber,
-	                      optional unsigned long bufferOffset = 0);
+	                           unsigned long channelNumber,
+	                           optional unsigned long bufferOffset = 0);
 	undefined copyToChannel (Float32Array source,
-	                    unsigned long channelNumber,
-	                    optional unsigned long bufferOffset = 0);
+	                         unsigned long channelNumber,
+	                         optional unsigned long bufferOffset = 0);
 };
 </pre>
 
@@ -2642,8 +2642,8 @@ interface AudioNode : EventTarget {
 	undefined disconnect (AudioNode destinationNode);
 	undefined disconnect (AudioNode destinationNode, unsigned long output);
 	undefined disconnect (AudioNode destinationNode,
-	                 unsigned long output,
-	                 unsigned long input);
+	                      unsigned long output,
+	                      unsigned long input);
 	undefined disconnect (AudioParam destinationParam);
 	undefined disconnect (AudioParam destinationParam, unsigned long output);
 	readonly attribute BaseAudioContext context;
@@ -4677,8 +4677,8 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
 	attribute double loopStart;
 	attribute double loopEnd;
 	undefined start (optional double when = 0,
-	            optional double offset,
-	            optional double duration);
+	                 optional double offset,
+	                 optional double duration);
 };
 </pre>
 
@@ -5921,8 +5921,8 @@ interface BiquadFilterNode : AudioNode {
 	readonly attribute AudioParam Q;
 	readonly attribute AudioParam gain;
 	undefined getFrequencyResponse (Float32Array frequencyHz,
-	                           Float32Array magResponse,
-	                           Float32Array phaseResponse);
+	                                Float32Array magResponse,
+	                                Float32Array phaseResponse);
 };
 </pre>
 
@@ -7688,8 +7688,8 @@ channels of the input.
 interface IIRFilterNode : AudioNode {
 	constructor (BaseAudioContext context, IIRFilterOptions options);
 	undefined getFrequencyResponse (Float32Array frequencyHz,
-	                           Float32Array magResponse,
-	                           Float32Array phaseResponse);
+	                                Float32Array magResponse,
+	                                Float32Array phaseResponse);
 };
 </pre>
 
@@ -9808,7 +9808,7 @@ callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object option
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {
 	undefined registerProcessor (DOMString name,
-	                        AudioWorkletProcessorConstructor processorCtor);
+	                             AudioWorkletProcessorConstructor processorCtor);
 	readonly attribute unsigned long long currentFrame;
 	readonly attribute double currentTime;
 	readonly attribute float sampleRate;

--- a/index.bs
+++ b/index.bs
@@ -688,9 +688,9 @@ enum AudioContextState {
 </div>
 
 <xmp class="idl">
-callback DecodeErrorCallback = void (DOMException error);
+callback DecodeErrorCallback = undefined (DOMException error);
 
-callback DecodeSuccessCallback = void (AudioBuffer decodedData);
+callback DecodeSuccessCallback = undefined (AudioBuffer decodedData);
 
 [Exposed=Window]
 interface BaseAudioContext : EventTarget {
@@ -1336,9 +1336,9 @@ interface AudioContext : BaseAudioContext {
 	readonly attribute double baseLatency;
 	readonly attribute double outputLatency;
 	AudioTimestamp getOutputTimestamp ();
-	Promise<void> resume ();
-	Promise<void> suspend ();
-	Promise<void> close ();
+	Promise<undefined> resume ();
+	Promise<undefined> suspend ();
+	Promise<undefined> close ();
 	MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
 	MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
 	MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (
@@ -1555,7 +1555,7 @@ Methods</h4>
 			<em>No parameters.</em>
 		</div>
 		<div>
-			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
+			<em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
 		</div>
 
 	: <dfn>createMediaElementSource(mediaElement)</dfn>
@@ -1748,7 +1748,7 @@ Methods</h4>
 		</div>
 
 		<div>
-			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
+			<em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
 		</div>
 
 	: <dfn>suspend()</dfn>
@@ -1830,7 +1830,7 @@ Methods</h4>
 			<em>No parameters.</em>
 		</div>
 		<div>
-			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
+			<em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
 		</div>
 </dl>
 
@@ -1930,8 +1930,8 @@ interface OfflineAudioContext : BaseAudioContext {
 	constructor(OfflineAudioContextOptions contextOptions);
 	constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
 	Promise<AudioBuffer> startRendering();
-	Promise<void> resume();
-	Promise<void> suspend(double suspendTime);
+	Promise<undefined> resume();
+	Promise<undefined> suspend(double suspendTime);
 	readonly attribute unsigned long length;
 	attribute EventHandler oncomplete;
 };
@@ -2173,7 +2173,7 @@ Methods</h4>
 		</div>
 
 		<div>
-			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
+			<em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
 		</div>
 
 	: <dfn>suspend(suspendTime)</dfn>
@@ -2196,7 +2196,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> {{Promise}}&lt;{{void}}&gt;
+			<em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
 		</div>
 </dl>
 
@@ -2329,10 +2329,10 @@ interface AudioBuffer {
 	readonly attribute double duration;
 	readonly attribute unsigned long numberOfChannels;
 	Float32Array getChannelData (unsigned long channel);
-	void copyFromChannel (Float32Array destination,
+	undefined copyFromChannel (Float32Array destination,
 	                      unsigned long channelNumber,
 	                      optional unsigned long bufferOffset = 0);
-	void copyToChannel (Float32Array source,
+	undefined copyToChannel (Float32Array source,
 	                    unsigned long channelNumber,
 	                    optional unsigned long bufferOffset = 0);
 };
@@ -2421,7 +2421,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>copyToChannel(source, channelNumber, bufferOffset)</dfn>
@@ -2450,7 +2450,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>getChannelData(channel)</dfn>
@@ -2636,16 +2636,16 @@ interface AudioNode : EventTarget {
 	AudioNode connect (AudioNode destinationNode,
 	                   optional unsigned long output = 0,
 	                   optional unsigned long input = 0);
-	void connect (AudioParam destinationParam, optional unsigned long output = 0);
-	void disconnect ();
-	void disconnect (unsigned long output);
-	void disconnect (AudioNode destinationNode);
-	void disconnect (AudioNode destinationNode, unsigned long output);
-	void disconnect (AudioNode destinationNode,
+	undefined connect (AudioParam destinationParam, optional unsigned long output = 0);
+	undefined disconnect ();
+	undefined disconnect (unsigned long output);
+	undefined disconnect (AudioNode destinationNode);
+	undefined disconnect (AudioNode destinationNode, unsigned long output);
+	undefined disconnect (AudioNode destinationNode,
 	                 unsigned long output,
 	                 unsigned long input);
-	void disconnect (AudioParam destinationParam);
-	void disconnect (AudioParam destinationParam, unsigned long output);
+	undefined disconnect (AudioParam destinationParam);
+	undefined disconnect (AudioParam destinationParam, unsigned long output);
 	readonly attribute BaseAudioContext context;
 	readonly attribute unsigned long numberOfInputs;
 	readonly attribute unsigned long numberOfOutputs;
@@ -3136,7 +3136,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect()</dfn>
@@ -3148,7 +3148,7 @@ Methods</h4>
 			<em>No parameters.</em>
 		</div>
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect(output)</dfn>
@@ -3163,7 +3163,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect(destinationNode)</dfn>
@@ -3176,7 +3176,7 @@ Methods</h4>
 			destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. It disconnects all outgoing connections to the given <code>destinationNode</code>. <span class="synchronous">If there is no connection to the <code>destinationNode</code>, an {{InvalidAccessError}} exception MUST be thrown.</span>
 		</pre>
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect(destinationNode, output)</dfn>
@@ -3191,7 +3191,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect(destinationNode, output, input)</dfn>
@@ -3207,7 +3207,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect(destinationParam)</dfn>
@@ -3223,7 +3223,7 @@ Methods</h4>
 			destinationParam: The <code>destinationParam</code> parameter is the {{AudioParam}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationParam</code>, an {{InvalidAccessError}} exception MUST be thrown.</span>
 		</pre>
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>disconnect(destinationParam, output)</dfn>
@@ -3240,7 +3240,7 @@ Methods</h4>
 			output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to disconnect. <span class="synchronous">If the <code>parameter</code> is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
 		</pre>
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 
@@ -4057,8 +4057,8 @@ set to false.
 [Exposed=Window]
 interface AudioScheduledSourceNode : AudioNode {
 	attribute EventHandler onended;
-	void start(optional double when = 0);
-	void stop(optional double when = 0);
+	undefined start(optional double when = 0);
+	undefined stop(optional double when = 0);
 };
 </pre>
 
@@ -4128,7 +4128,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> {{void}}
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>stop(when)</dfn>
@@ -4170,7 +4170,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> {{void}}
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -4208,10 +4208,10 @@ macros:
 [Exposed=Window]
 interface AnalyserNode : AudioNode {
 	constructor (BaseAudioContext context, optional AnalyserOptions options = {});
-	void getFloatFrequencyData (Float32Array array);
-	void getByteFrequencyData (Uint8Array array);
-	void getFloatTimeDomainData (Float32Array array);
-	void getByteTimeDomainData (Uint8Array array);
+	undefined getFloatFrequencyData (Float32Array array);
+	undefined getByteFrequencyData (Uint8Array array);
+	undefined getFloatTimeDomainData (Float32Array array);
+	undefined getByteTimeDomainData (Uint8Array array);
 	attribute unsigned long fftSize;
 	readonly attribute unsigned long frequencyBinCount;
 	attribute double minDecibels;
@@ -4341,7 +4341,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
@@ -4374,7 +4374,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
@@ -4402,7 +4402,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
@@ -4422,7 +4422,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 
@@ -4676,7 +4676,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
 	attribute boolean loop;
 	attribute double loopStart;
 	attribute double loopEnd;
-	void start (optional double when = 0,
+	undefined start (optional double when = 0,
 	            optional double offset,
 	            optional double duration);
 };
@@ -4836,7 +4836,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> {{void}}
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 </dl>
@@ -5369,8 +5369,8 @@ interface AudioListener {
 	readonly attribute AudioParam upX;
 	readonly attribute AudioParam upY;
 	readonly attribute AudioParam upZ;
-	void setPosition (float x, float y, float z);
-	void setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
+	undefined setPosition (float x, float y, float z);
+	undefined setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
 };
 </pre>
 
@@ -5574,7 +5574,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>setPosition(x, y, z)</dfn>
@@ -5920,7 +5920,7 @@ interface BiquadFilterNode : AudioNode {
 	readonly attribute AudioParam detune;
 	readonly attribute AudioParam Q;
 	readonly attribute AudioParam gain;
-	void getFrequencyResponse (Float32Array frequencyHz,
+	undefined getFrequencyResponse (Float32Array frequencyHz,
 	                           Float32Array magResponse,
 	                           Float32Array phaseResponse);
 };
@@ -6064,7 +6064,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 
@@ -7687,7 +7687,7 @@ channels of the input.
 [Exposed=Window]
 interface IIRFilterNode : AudioNode {
 	constructor (BaseAudioContext context, IIRFilterOptions options);
-	void getFrequencyResponse (Float32Array frequencyHz,
+	undefined getFrequencyResponse (Float32Array frequencyHz,
 	                           Float32Array magResponse,
 	                           Float32Array phaseResponse);
 };
@@ -7729,7 +7729,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 
@@ -8265,7 +8265,7 @@ interface OscillatorNode : AudioScheduledSourceNode {
 	attribute OscillatorType type;
 	readonly attribute AudioParam frequency;
 	readonly attribute AudioParam detune;
-	void setPeriodicWave (PeriodicWave periodicWave);
+	undefined setPeriodicWave (PeriodicWave periodicWave);
 };
 </pre>
 
@@ -8352,7 +8352,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 
@@ -8645,8 +8645,8 @@ interface PannerNode : AudioNode {
 	attribute double coneInnerAngle;
 	attribute double coneOuterAngle;
 	attribute double coneOuterGain;
-	void setPosition (float x, float y, float z);
-	void setOrientation (float x, float y, float z);
+	undefined setPosition (float x, float y, float z);
+	undefined setOrientation (float x, float y, float z);
 };
 </pre>
 
@@ -8887,7 +8887,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 
 	: <dfn>setPosition(x, y, z)</dfn>
@@ -8921,7 +8921,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 
@@ -9807,7 +9807,7 @@ callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object option
 
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {
-	void registerProcessor (DOMString name,
+	undefined registerProcessor (DOMString name,
 	                        AudioWorkletProcessorConstructor processorCtor);
 	readonly attribute unsigned long long currentFrame;
 	readonly attribute double currentTime;
@@ -9952,7 +9952,7 @@ Methods</h5>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>void</code>
+			<em>Return type:</em> <code>undefined</code>
 		</div>
 </dl>
 


### PR DESCRIPTION
This builds on PR #2238 by applying everything done there and also fixing the bikeshed error about `void` not existing. These are replaced by `undefined`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2241.html" title="Last updated on Aug 19, 2020, 2:57 PM UTC (af372bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2241/a9c900f...rtoy:af372bc.html" title="Last updated on Aug 19, 2020, 2:57 PM UTC (af372bc)">Diff</a>