### PR TITLE
Fix #2244: update implementation report

### DIFF
--- a/implementation-report.html
+++ b/implementation-report.html
@@ -6,33 +6,34 @@
       Web Audio 1.0 Implementation report
     </title>
     <style type="text/css">
-            a {
-                                text-decoration: none
-                                }
-            a:hover {
-                                text-decoration: underline; 
-                                background: #FE9 
-                                }
+        a {
+          text-decoration: none
+        }
+        a:hover {
+          text-decoration: underline; 
+          background: #FE9 
+        }
                         
-                        #ua h3::before { 
-                                content: ""; 
-                                background-size: 1.2em 1.2em;
-                                background-repeat: no-repeat;
-                        display: inline-block;
-                        width: 2.2em; 
-                                height: 1.2em;}
-                        #webkit::before { 
-                                background-image: url('images/safari-logo.png'); 
-                                }
-                        #blink::before {
-                                background-image: url('images/chrome-logo.png')
-                        }
-                        #gecko::before {
-                                background-image: url('images/firefox-logo.png')
-                        }
-                        #edge::before {
-                                background-image: url('images/edge-logo.png')
-                        }
+        #ua h3::before { 
+          content: ""; 
+          background-size: 1.2em 1.2em;
+          background-repeat: no-repeat;
+          display: inline-block;
+          width: 2.2em; 
+          height: 1.2em;
+	 }
+        #webkit::before { 
+          background-image: url('images/safari-logo.png'); 
+        }
+        #blink::before {
+          background-image: url('images/chrome-logo.png')
+        }
+        #gecko::before {
+          background-image: url('images/firefox-logo.png')
+        }
+        #edge::before {
+          background-image: url('images/edge-logo.png')
+        }
     </style>
     <link href="https://www.w3.org/StyleSheets/TR/base.css" media="screen"
     type="text/css" rel="stylesheet">

--- a/implementation-report.html
+++ b/implementation-report.html
@@ -21,7 +21,7 @@
           display: inline-block;
           width: 2.2em; 
           height: 1.2em;
-	 }
+         }
         #webkit::before { 
           background-image: url('images/safari-logo.png'); 
         }
@@ -117,8 +117,9 @@
         Tests
       </h2>
       <p>
-	Perhaps the best indication of implementation status is the <a href="https://wpt.fyi/results/webaudio/idlharness.https.window.html?label=experimental&label=master&aligned">IDL test</a> for
-	WebAudio consisting of 1125 tests:
+        Perhaps the best indication of implementation status is the <a href=
+        "https://wpt.fyi/results/webaudio/idlharness.https.window.html?label=experimental&amp;label=master&amp;aligned">
+        IDL test</a> for WebAudio consisting of 1125 tests:
       </p>
       <table>
         <tr>
@@ -194,70 +195,101 @@
       </table>
       <p>
         These results indicates that Chrome is missing
-        <ul>
-          <li>
-            <a
-        href="https://webaudio.github.io/web-audio-api/#mediastreamtrackaudiosourcenode"><code>MediaStreamTrackSourceNode</code></a>
-          </li>
-          <li>
-            <a
-            href="https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency"><code>AudioContext.outputLatency</code></a>
-          </li>
-        </ul>
       </p>
+      <ul>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#mediastreamtrackaudiosourcenode">
+          <code>MediaStreamTrackSourceNode</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency">
+          <code>AudioContext.outputLatency</code></a>
+        </li>
+      </ul>
       <p>
         Firefox is missing
-        <ul>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-suspend"><code>OfflineAudioContext.suspend()</code></a>
-          </li>
-          <li>
-            <a href=""><code>OfflineAudioContext.resume()</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-resume"><code>AudioParam.automationRate</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelandholdattime"><code>AudioParam.cancelAndHoldAtTime</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-positionx"><code>AudioListener.positionX</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-positiony"><code>AudioListener.positionY</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-positionz"><code>AudioListener.positionZ</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardx"><code>AudioListener.forwardX</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardy"><code>AudioListener.forwardY</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardz"><code>AudioListener.forwardZ</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-upx"><code>AudioListener.upX</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-upy"><code>AudioListener.upY</code></a>
-          </li>
-          <li>
-            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-upz"><code>AudioListener.upZ</code></a>
-          </li>
-          <li>
-            <a
-            href="https://webaudio.github.io/web-audio-api/#audioprocessingevent">AudioProcessingEvent constructor</a>, which is currently deprecated
-          </li>
-        </ul>
       </p>
+      <ul>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-suspend">
+          <code>OfflineAudioContext.suspend()</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-resume">
+          <code>OfflineAudioContext.resume()</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-resume">
+          <code>AudioParam.automationRate</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelandholdattime">
+          <code>AudioParam.cancelAndHoldAtTime</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-positionx">
+          <code>AudioListener.positionX</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-positiony">
+          <code>AudioListener.positionY</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-positionz">
+          <code>AudioListener.positionZ</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardx">
+          <code>AudioListener.forwardX</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardy">
+          <code>AudioListener.forwardY</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardz">
+          <code>AudioListener.forwardZ</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-upx"><code>
+          AudioListener.upX</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-upy"><code>
+          AudioListener.upY</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#dom-audiolistener-upz"><code>
+          AudioListener.upZ</code></a>
+        </li>
+        <li>
+          <a href=
+          "https://webaudio.github.io/web-audio-api/#audioprocessingevent">AudioProcessingEvent
+          constructor</a>, which is currently deprecated
+        </li>
+      </ul>
       <p>
         In addition, there are currently <a href=
-        "https://github.com/web-platform-tests/wpt/tree/master/webaudio">about 6500
-        WebAudio API tests on WPT</a> that tests the functionality of the API.  The <a href=
-        "https://wpt.fyi/results/webaudio?complete=true">wpt.fyi results</a> are summarized below:
+        "https://github.com/web-platform-tests/wpt/tree/master/webaudio">about
+        6500 WebAudio API tests on WPT</a> that tests the functionality of the
+        API. The <a href=
+        "https://wpt.fyi/results/webaudio?complete=true">wpt.fyi results</a>
+        are summarized below:
       </p>
       <table>
         <tr>

--- a/implementation-report.html
+++ b/implementation-report.html
@@ -46,7 +46,7 @@
         Web Audio API 1.0 Implementation Report
       </h1>
       <h2>
-        2018-Sept-06
+        2020-Sept-01
       </h2>
       <hr>
     </div>
@@ -78,9 +78,7 @@
           prefix, and from version 34 onwards <a href=
           "https://developers.google.com/web/updates/2014/07/Web-Audio-Changes-in-m36">
           unprefixed</a>. Chrome for Android supports Web Audio API from
-          version 49 on. Blink has an <a href=
-          "https://groups.google.com/a/chromium.org/forum/#!msg/Blink-dev/kl8ct3ub3a8/-WfzBTkCAgAJ">
-          intent to implement worklet</a>.
+          version 49 on.
         </p>
         <p>
           Opera supports Web Audio API from version 15 on, with -webkit prefix,
@@ -101,9 +99,7 @@
           "https://platform-status.mozilla.org/#webaudio">version 23 onwards
           unprefixed</a>. Gecko has a <a href=
           "https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&amp;component=Web%20Audio">
-          bugtracker</a> including a <a href=
-          "https://bugzilla.mozilla.org/show_bug.cgi?id=1062849">bug to
-          implement AudioWorklets</a>.
+          bugtracker</a>.
         </p>
         <h3 id="edge">
           Edge
@@ -121,10 +117,8 @@
         Tests
       </h2>
       <p>
-        There are currently <a href=
-        "https://github.com/web-platform-tests/wpt/tree/master/webaudio">8426
-        WebAudio API tests on WPT</a>. <a href=
-        "https://wpt.fyi/results/webaudio?complete=true">wpt.fyi results</a>:
+	Perhaps the best indication of implementation status is the <a href="https://wpt.fyi/results/webaudio/idlharness.https.window.html?label=experimental&label=master&aligned">IDL test</a> for
+	WebAudio consisting of 1125 tests:
       </p>
       <table>
         <tr>
@@ -146,13 +140,13 @@
             Safari
           </td>
           <td>
-            11.1, OSX
+            112 preview, macOS 10.15
           </td>
           <td>
-            676
+            215
           </td>
           <td>
-            7750
+            910
           </td>
         </tr>
         <tr>
@@ -160,13 +154,13 @@
             Chrome
           </td>
           <td>
-            69, Linux 16.04
+            86, Linux 20.04
           </td>
           <td>
-            8409
+            1114
           </td>
           <td>
-            17
+            11
           </td>
         </tr>
         <tr>
@@ -174,13 +168,13 @@
             Firefox
           </td>
           <td>
-            63, Linux 16.04
+            82, Linux 20.04
           </td>
           <td>
-            6489
+            1091
           </td>
           <td>
-            1937
+            34
           </td>
         </tr>
         <tr>
@@ -188,20 +182,82 @@
             Edge
           </td>
           <td>
-            17, Win 10
+            86, Windows 10.0
           </td>
           <td>
-            2593
+            1114
           </td>
           <td>
-            5833
+            11
           </td>
         </tr>
       </table>
       <p>
-        In addition, <a href=
-        "https://github.com/mohayonao/web-audio-test-api">syntax-level DOM
-        test</a> has <em>338</em> automated tests.
+        These results indicates that Chrome is missing
+        <ul>
+          <li>
+            <a
+        href="https://webaudio.github.io/web-audio-api/#mediastreamtrackaudiosourcenode"><code>MediaStreamTrackSourceNode</code></a>
+          </li>
+          <li>
+            <a
+            href="https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency"><code>AudioContext.outputLatency</code></a>
+          </li>
+        </ul>
+      </p>
+      <p>
+        Firefox is missing
+        <ul>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-suspend"><code>OfflineAudioContext.suspend()</code></a>
+          </li>
+          <li>
+            <a href=""><code>OfflineAudioContext.resume()</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-resume"><code>AudioParam.automationRate</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelandholdattime"><code>AudioParam.cancelAndHoldAtTime</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-positionx"><code>AudioListener.positionX</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-positiony"><code>AudioListener.positionY</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-positionz"><code>AudioListener.positionZ</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardx"><code>AudioListener.forwardX</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardy"><code>AudioListener.forwardY</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-forwardz"><code>AudioListener.forwardZ</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-upx"><code>AudioListener.upX</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-upy"><code>AudioListener.upY</code></a>
+          </li>
+          <li>
+            <a href="https://webaudio.github.io/web-audio-api/#dom-audiolistener-upz"><code>AudioListener.upZ</code></a>
+          </li>
+          <li>
+            <a
+            href="https://webaudio.github.io/web-audio-api/#audioprocessingevent">AudioProcessingEvent constructor</a>, which is currently deprecated
+          </li>
+        </ul>
+      </p>
+      <p>
+        In addition, there are currently <a href=
+        "https://github.com/web-platform-tests/wpt/tree/master/webaudio">about 6500
+        WebAudio API tests on WPT</a> that tests the functionality of the API.  The <a href=
+        "https://wpt.fyi/results/webaudio?complete=true">wpt.fyi results</a> are summarized below:
       </p>
       <table>
         <tr>
@@ -219,53 +275,31 @@
           </th>
         </tr>
         <tr>
-          <td rowspan="2">
+          <td>
             Safari
           </td>
           <td>
-            9.1, OSX
+            112 preview, macOS 10.15
           </td>
           <td>
-            338
+            1267
           </td>
           <td>
-            0
+            706
           </td>
         </tr>
         <tr>
           <td>
-            9.1.1, OSX
-          </td>
-          <td>
-            337
-          </td>
-          <td title="MediaStream constructor() not work when 'new' directly">
-            1
-          </td>
-        </tr>
-        <tr>
-          <td rowspan="2">
             Chrome
           </td>
           <td>
-            71.0.3548.0, Win 10
+            86, Linux 20.04
           </td>
           <td>
-            336
+            6519
           </td>
           <td>
-            2
-          </td>
-        </tr>
-        <tr>
-          <td>
-            69.0.3497.86, Android
-          </td>
-          <td>
-            336
-          </td>
-          <td>
-            2
+            29
           </td>
         </tr>
         <tr>
@@ -273,13 +307,13 @@
             Firefox
           </td>
           <td>
-            64.0a1, Win 10
+            82, Linux 20.04
           </td>
           <td>
-            336
+            5625
           </td>
-          <td title="AnalyserNode constructor not work when 'new' directly">
-            2
+          <td>
+            419
           </td>
         </tr>
         <tr>
@@ -287,19 +321,22 @@
             Edge
           </td>
           <td>
-            18.17755, Win 10
+            86, Windows 10.0
           </td>
           <td>
-            337
+            6516
           </td>
-          <td title="AnalyserNode constructor not work when 'new' directly">
-            1
+          <td>
+            32
           </td>
         </tr>
       </table>
       <hr>
       <address>
         Chris Lilley
+      </address>
+      <address>
+        Raymond Toy
       </address>
     </div>
   </body>

--- a/implementation-report.html
+++ b/implementation-report.html
@@ -1,114 +1,305 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
   <head>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <title>Web Audio 1.0 Implementation report</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>
+      Web Audio 1.0 Implementation report
+    </title>
     <style type="text/css">
             a {
-				text-decoration: none
-				}
+                                text-decoration: none
+                                }
             a:hover {
-				text-decoration: underline; 
-				background: #FE9 
-				}
-			
-			#ua h3::before { 
-				content: ""; 
-				background-size: 1.2em 1.2em;
-				background-repeat: no-repeat;
-    			display: inline-block;
-    			width: 2.2em; 
-				height: 1.2em;}
-			#webkit::before { 
-				background-image: url('images/safari-logo.png'); 
-				}
-			#blink::before {
-				background-image: url('images/chrome-logo.png')
-			}
-			#gecko::before {
-				background-image: url('images/firefox-logo.png')
-			}
-			#edge::before {
-				background-image: url('images/edge-logo.png')
-			}
-        </style>
-    <link href="https://www.w3.org/StyleSheets/TR/base.css" media="screen" type="text/css" rel="stylesheet" />
+                                text-decoration: underline; 
+                                background: #FE9 
+                                }
+                        
+                        #ua h3::before { 
+                                content: ""; 
+                                background-size: 1.2em 1.2em;
+                                background-repeat: no-repeat;
+                        display: inline-block;
+                        width: 2.2em; 
+                                height: 1.2em;}
+                        #webkit::before { 
+                                background-image: url('images/safari-logo.png'); 
+                                }
+                        #blink::before {
+                                background-image: url('images/chrome-logo.png')
+                        }
+                        #gecko::before {
+                                background-image: url('images/firefox-logo.png')
+                        }
+                        #edge::before {
+                                background-image: url('images/edge-logo.png')
+                        }
+    </style>
+    <link href="https://www.w3.org/StyleSheets/TR/base.css" media="screen"
+    type="text/css" rel="stylesheet">
   </head>
   <body>
-    <div class="head"> <a href="https://www.w3.org/"> <img alt="W3C" src="https://www.w3.org/Icons/WWW/w3c_home" />
-      </a>
-      <h1>Web Audio API 1.0 Implementation Report</h1>
-      <h2>2018-Sept-06</h2>
-      <hr />
+    <div class="head">
+      <a href="https://www.w3.org/"><img alt="W3C" src=
+      "https://www.w3.org/Icons/WWW/w3c_home"></a>
+      <h1>
+        Web Audio API 1.0 Implementation Report
+      </h1>
+      <h2>
+        2018-Sept-06
+      </h2>
+      <hr>
     </div>
-
     <div class="main">
-    <p>This report will document the overall implementation status and detailed test results for Web Audio API 1.0. 
-		[<a href="http://caniuse.com/#feat=audio-api">CanIUse WebAudio</a>].
-	</p>
-    
-		<section id="ua">
-      <h2 id="UserAgents">User Agents</h2>
-	  
-      <h3 id="webkit">Safari</h3>
-	  <p>Safari 6 on OSX, and Safari on iOS6 onwards, 
-		  <a href="https://developer.apple.com/library/iad/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/PlayingandSynthesizingSounds/PlayingandSynthesizingSounds.html">support 
-		  the Web Audio API</a>. It has a <a href="https://bugs.webkit.org/enter_bug.cgi?product=WebKit&component=Web%20Audio">bugtracker</a>.
-      
-	  <h3 id="blink">Blink</h3>
-	  <p>Chrome supports Web Audio API from version 10 on, with -webkit prefix, and from version 
-		  34 onwards <a href="https://developers.google.com/web/updates/2014/07/Web-Audio-Changes-in-m36">unprefixed</a>. 
-		  Chrome for Android supports Web Audio API from version 49 on. Blink
-		  has an <a href="https://groups.google.com/a/chromium.org/forum/#!msg/Blink-dev/kl8ct3ub3a8/-WfzBTkCAgAJ">intent 
-		  to implement worklet</a>.</p>
-		  
-		  <p>Opera supports Web Audio API from version 15 on, with -webkit prefix, and from version 
-		  22 onwards unprefixed.</p>
-		 <p>The Blink implementation postdates the Webkit/Blink split, and should be considered a separate implementation.
-			 Blink has a <a href="https://bugs.chromium.org/p/chromium/issues/list?can=2&q=webaudio&x=m&y=releaseblock&cells=ids">bugtracker</a>.
-		 </p>
-		  
-		<h3 id="gecko">Firefox</h3>
-		<p>Firefox supports Web Audio API from version 15 on, with -webkit prefix, and from <a href="https://platform-status.mozilla.org/#webaudio">version 
-		  23 onwards unprefixed</a>. Gecko has a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Web%20Audio">bugtracker</a>
-			including a <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1062849">bug to implement AudioWorklets</a>.</p>
-		  
-		<h3 id="edge">Edge</h3>
-		<p>Edge supports Web Audio API <a href="https://msdn.microsoft.com/en-us/library/dn985708%28v=vs.85%29.aspx">from 
-		version 12 (build 10240) on</a>, unprefixed.</p>
-		  
-		  <!-- See Paul Adenot's implementation survey for the degree of separation between these code bases
-		  	http://padenot.github.io/web-audio-perf/#the-different-implementations
-			  -->
-	  	</section>
-      <h2 id="tests">Tests</h2>
-	    
-	    <p>There are currently <a href="https://github.com/web-platform-tests/wpt/tree/master/webaudio">8426 
-		    WebAudio API tests on WPT</a>. <a href="https://wpt.fyi/results/webaudio?complete=true">wpt.fyi results</a>:</p> 
-	    <table>
-		  <tr><th>Browser</th><th>Version</th><th>Passes</th><th>Fails</th></tr>
-		  <tr><td>Safari</td><td>11.1, OSX</td><td>676</td><td>7750</td></tr>
-		  <tr><td>Chrome</td><td>69, Linux 16.04</td><td>8409</td><td>17</td></tr>
-		  <tr><td>Firefox</td><td>63, Linux 16.04</td><td>6489</td><td>1937</td></tr>
-		  <tr><td>Edge</td><td>17, Win 10</td><td>2593</td><td>5833</td></tr>
-	  </table>
-      
-      <p>In addition, <a href="https://github.com/mohayonao/web-audio-test-api">syntax-level DOM test</a> has <em>338 </em> automated tests.</p>
-	  
-	  <table>
-		  <tr><th>Browser</th><th>Version</th><th>Passes</th><th>Fails</th></tr>
-		  <tr><td rowspan="2">Safari</td><td>9.1, OSX</td><td>338</td><td>0</td></tr>
-		  <tr><td>9.1.1, OSX</td><td>337</td><td title="MediaStream constructor() not work when 'new' directly">1</td></tr>
-		  <tr><td rowspan="2">Chrome</td><td>71.0.3548.0, Win 10</td><td>336</td><td>2</td></tr>
-		  <tr><td>69.0.3497.86, Android</td><td>336</td><td>2</td></tr>
-		  <tr><td>Firefox</td><td>64.0a1, Win 10</td><td>336</td><td title="AnalyserNode constructor not work when 'new' directly">2</td></tr>
-		  <tr><td>Edge</td><td>18.17755, Win 10</td><td>337</td><td title="AnalyserNode constructor not work when 'new' directly">1</td></tr>
-	  </table>
-	  
-	  
-      <hr />
-      <address>Chris Lilley </address>
+      <p>
+        This report will document the overall implementation status and
+        detailed test results for Web Audio API 1.0. [<a href=
+        "http://caniuse.com/#feat=audio-api">CanIUse WebAudio</a>].
+      </p>
+      <section id="ua">
+        <h2 id="UserAgents">
+          User Agents
+        </h2>
+        <h3 id="webkit">
+          Safari
+        </h3>
+        <p>
+          Safari 6 on OSX, and Safari on iOS6 onwards, <a href=
+          "https://developer.apple.com/library/iad/documentation/AudioVideo/Conceptual/Using_HTML5_Audio_Video/PlayingandSynthesizingSounds/PlayingandSynthesizingSounds.html">
+          support the Web Audio API</a>. It has a <a href=
+          "https://bugs.webkit.org/enter_bug.cgi?product=WebKit&amp;component=Web%20Audio">
+          bugtracker</a>.
+        </p>
+        <h3 id="blink">
+          Blink
+        </h3>
+        <p>
+          Chrome supports Web Audio API from version 10 on, with -webkit
+          prefix, and from version 34 onwards <a href=
+          "https://developers.google.com/web/updates/2014/07/Web-Audio-Changes-in-m36">
+          unprefixed</a>. Chrome for Android supports Web Audio API from
+          version 49 on. Blink has an <a href=
+          "https://groups.google.com/a/chromium.org/forum/#!msg/Blink-dev/kl8ct3ub3a8/-WfzBTkCAgAJ">
+          intent to implement worklet</a>.
+        </p>
+        <p>
+          Opera supports Web Audio API from version 15 on, with -webkit prefix,
+          and from version 22 onwards unprefixed.
+        </p>
+        <p>
+          The Blink implementation postdates the Webkit/Blink split, and should
+          be considered a separate implementation. Blink has a <a href=
+          "https://bugs.chromium.org/p/chromium/issues/list?can=2&amp;q=webaudio&amp;x=m&amp;y=releaseblock&amp;cells=ids">
+          bugtracker</a>.
+        </p>
+        <h3 id="gecko">
+          Firefox
+        </h3>
+        <p>
+          Firefox supports Web Audio API from version 15 on, with -webkit
+          prefix, and from <a href=
+          "https://platform-status.mozilla.org/#webaudio">version 23 onwards
+          unprefixed</a>. Gecko has a <a href=
+          "https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&amp;component=Web%20Audio">
+          bugtracker</a> including a <a href=
+          "https://bugzilla.mozilla.org/show_bug.cgi?id=1062849">bug to
+          implement AudioWorklets</a>.
+        </p>
+        <h3 id="edge">
+          Edge
+        </h3>
+        <p>
+          Edge supports Web Audio API <a href=
+          "https://msdn.microsoft.com/en-us/library/dn985708%28v=vs.85%29.aspx">
+          from version 12 (build 10240) on</a>, unprefixed.
+        </p>
+        <!-- See Paul Adenot's implementation survey for the degree of separation between these code bases
+                        http://padenot.github.io/web-audio-perf/#the-different-implementations
+                          -->
+      </section>
+      <h2 id="tests">
+        Tests
+      </h2>
+      <p>
+        There are currently <a href=
+        "https://github.com/web-platform-tests/wpt/tree/master/webaudio">8426
+        WebAudio API tests on WPT</a>. <a href=
+        "https://wpt.fyi/results/webaudio?complete=true">wpt.fyi results</a>:
+      </p>
+      <table>
+        <tr>
+          <th>
+            Browser
+          </th>
+          <th>
+            Version
+          </th>
+          <th>
+            Passes
+          </th>
+          <th>
+            Fails
+          </th>
+        </tr>
+        <tr>
+          <td>
+            Safari
+          </td>
+          <td>
+            11.1, OSX
+          </td>
+          <td>
+            676
+          </td>
+          <td>
+            7750
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Chrome
+          </td>
+          <td>
+            69, Linux 16.04
+          </td>
+          <td>
+            8409
+          </td>
+          <td>
+            17
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Firefox
+          </td>
+          <td>
+            63, Linux 16.04
+          </td>
+          <td>
+            6489
+          </td>
+          <td>
+            1937
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Edge
+          </td>
+          <td>
+            17, Win 10
+          </td>
+          <td>
+            2593
+          </td>
+          <td>
+            5833
+          </td>
+        </tr>
+      </table>
+      <p>
+        In addition, <a href=
+        "https://github.com/mohayonao/web-audio-test-api">syntax-level DOM
+        test</a> has <em>338</em> automated tests.
+      </p>
+      <table>
+        <tr>
+          <th>
+            Browser
+          </th>
+          <th>
+            Version
+          </th>
+          <th>
+            Passes
+          </th>
+          <th>
+            Fails
+          </th>
+        </tr>
+        <tr>
+          <td rowspan="2">
+            Safari
+          </td>
+          <td>
+            9.1, OSX
+          </td>
+          <td>
+            338
+          </td>
+          <td>
+            0
+          </td>
+        </tr>
+        <tr>
+          <td>
+            9.1.1, OSX
+          </td>
+          <td>
+            337
+          </td>
+          <td title="MediaStream constructor() not work when 'new' directly">
+            1
+          </td>
+        </tr>
+        <tr>
+          <td rowspan="2">
+            Chrome
+          </td>
+          <td>
+            71.0.3548.0, Win 10
+          </td>
+          <td>
+            336
+          </td>
+          <td>
+            2
+          </td>
+        </tr>
+        <tr>
+          <td>
+            69.0.3497.86, Android
+          </td>
+          <td>
+            336
+          </td>
+          <td>
+            2
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Firefox
+          </td>
+          <td>
+            64.0a1, Win 10
+          </td>
+          <td>
+            336
+          </td>
+          <td title="AnalyserNode constructor not work when 'new' directly">
+            2
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Edge
+          </td>
+          <td>
+            18.17755, Win 10
+          </td>
+          <td>
+            337
+          </td>
+          <td title="AnalyserNode constructor not work when 'new' directly">
+            1
+          </td>
+        </tr>
+      </table>
+      <hr>
+      <address>
+        Chris Lilley
+      </address>
     </div>
- 
   </body>
 </html>

--- a/implementation-report.html
+++ b/implementation-report.html
@@ -280,7 +280,9 @@
         <li>
           <a href=
           "https://webaudio.github.io/web-audio-api/#audioprocessingevent">AudioProcessingEvent
-          constructor</a>, which is currently deprecated
+          constructor</a>, But the <a href=
+          "https://webaudio.github.io/web-audio-api/#audioprocessingevent">AudioProcessingEvent</a>
+          API itself is deprecated.
         </li>
       </ul>
       <p>

--- a/tidyconf.txt
+++ b/tidyconf.txt
@@ -1,0 +1,5 @@
+char-encoding: utf8
+indent: yes
+wrap: 80
+tidy-mark: no
+literal-attributes: yes


### PR DESCRIPTION
Update the implementation report to show the current status of the implementation of the API.

I removed the section about the syntax-level DOM tests and replaced that with a link to the WebAudio IDL tests.

Also restored tidyconf.txt that we were using when the spec was respec so we can make the html report indented and wrapped nicely.