### PR TITLE
Fix #2242: Use {{undefined}} instead of <code>undefined</code>

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1151,7 +1151,7 @@ Methods</h4>
 				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
 				errorCallback)/audioData!!argument}}, using
 				[[mimesniff#matching-an-audio-or-video-type-pattern]]. If the audio or
-				video type pattern matching algorithm returns <code>undefined</code>,
+				video type pattern matching algorithm returns {{undefined}},
 				set <var>can decode</var> to <em>false</em>.
 
 			3. If <var>can decode</var> is <em>true</em>, attempt to decode the encoded
@@ -2421,7 +2421,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>copyToChannel(source, channelNumber, bufferOffset)</dfn>
@@ -2450,7 +2450,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>getChannelData(channel)</dfn>
@@ -3136,7 +3136,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect()</dfn>
@@ -3148,7 +3148,7 @@ Methods</h4>
 			<em>No parameters.</em>
 		</div>
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect(output)</dfn>
@@ -3163,7 +3163,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect(destinationNode)</dfn>
@@ -3176,7 +3176,7 @@ Methods</h4>
 			destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. It disconnects all outgoing connections to the given <code>destinationNode</code>. <span class="synchronous">If there is no connection to the <code>destinationNode</code>, an {{InvalidAccessError}} exception MUST be thrown.</span>
 		</pre>
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect(destinationNode, output)</dfn>
@@ -3191,7 +3191,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect(destinationNode, output, input)</dfn>
@@ -3207,7 +3207,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect(destinationParam)</dfn>
@@ -3223,7 +3223,7 @@ Methods</h4>
 			destinationParam: The <code>destinationParam</code> parameter is the {{AudioParam}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationParam</code>, an {{InvalidAccessError}} exception MUST be thrown.</span>
 		</pre>
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>disconnect(destinationParam, output)</dfn>
@@ -3240,7 +3240,7 @@ Methods</h4>
 			output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to disconnect. <span class="synchronous">If the <code>parameter</code> is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
 		</pre>
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -4341,7 +4341,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
@@ -4374,7 +4374,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
@@ -4402,7 +4402,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
@@ -4422,7 +4422,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -5574,7 +5574,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>setPosition(x, y, z)</dfn>
@@ -6064,7 +6064,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -7729,7 +7729,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -8352,7 +8352,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -8887,7 +8887,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 
 	: <dfn>setPosition(x, y, z)</dfn>
@@ -8921,7 +8921,7 @@ Methods</h4>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -9883,7 +9883,7 @@ Methods</h5>
 				result of
 				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
 
-			1. If <var>parameterDescriptorsValue</var> is not <code>undefined</code>,
+			1. If <var>parameterDescriptorsValue</var> is not {{undefined}},
 				execute the following steps:
 
 				1. Let <var>parameterDescriptorSequence</var>
@@ -9952,7 +9952,7 @@ Methods</h5>
 		</pre>
 
 		<div>
-			<em>Return type:</em> <code>undefined</code>
+			<em>Return type:</em> {{undefined}}
 		</div>
 </dl>
 
@@ -10504,7 +10504,7 @@ of {{AudioParamDescriptor}}s.
 			return value is provided from an implementation of
 			{{process()}}, the effect is identical to returning
 			<code>false</code> (since the effective return value is the falsy
-			value <code>undefined</code>). This is a reasonable behavior for
+			value {{undefined}}). This is a reasonable behavior for
 			any {{AudioWorkletProcessor}} that is active only when it has
 			active inputs.
 		</div>


### PR DESCRIPTION
Replaces `<code>undefined</code>` with `{{undefined}}` for consistency.  This was done using a simple global search and replace.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 10, 2020, 3:59 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Frtoy%2Fweb-audio-api%2F9a3373313cec273d1f1bb7778bec041f984536a0%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232246.)._
</details>
