### PR TITLE
Fix #2227: Mention ABSN.start acquires the contents of the buffer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4808,13 +4808,19 @@ Methods</h4>
 				{{InvalidStateError}} exception MUST be thrown.</span>
 
 			2. Check for any errors that must be thrown due to parameter
-				constraints described below.
+				constraints described below.  If any
+				exception is thrown during this step,
+				abort those steps.
 
 			3. <a>Queue a control message</a> to start the
 				{{AudioBufferSourceNode}}, including the parameter values
 				in the messsage.
 
-			4. Send a <a>control message</a> to the associated {{AudioContext}} to
+			4. <a>Acquire the contents</a> of the
+			{{AudioBufferSourceNode/buffer}} if the
+			{{AudioBufferSourceNode/buffer}} has been set.
+
+			5. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">run it in the rendering thread</a> only when
 				the following conditions are met:
 				1. The context's <a>control thread state</a> is

--- a/index.bs
+++ b/index.bs
@@ -4817,8 +4817,8 @@ Methods</h4>
 				in the messsage.
 
 			4. <a>Acquire the contents</a> of the
-			{{AudioBufferSourceNode/buffer}} if the
-			{{AudioBufferSourceNode/buffer}} has been set.
+				{{AudioBufferSourceNode/buffer}} if the
+				{{AudioBufferSourceNode/buffer}} has been set.
 
 			5. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">run it in the rendering thread</a> only when


### PR DESCRIPTION
Just make it more explicit that calling `start()` will acquire the
contents of the buffer.  Without this, you kind of have to know that
this is described in the algorithm for acquiring the contents.

Also missed a minor issue in the start algorithm to abort the steps if
any exceptions are thrown because of parameter issues, as we say for
`AudioScheduledSourceNode.start()`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2249.html" title="Last updated on Sep 18, 2020, 4:17 PM UTC (6644e1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2249/908dcc7...rtoy:6644e1d.html" title="Last updated on Sep 18, 2020, 4:17 PM UTC (6644e1d)">Diff</a>