### PR TITLE
Fix typo in "messsage"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4112,15 +4112,10 @@ Methods</h4>
 
 			4. <a>Queue a control message</a> to start the
 				{{AudioScheduledSourceNode}}, including the parameter
-				values in the messsage.
+				values in the message.
 
 			5. Send a <a>control message</a> to the associated {{AudioContext}} to
-				<a href="#context-resume">run it in the rendering thread</a> only when
-				the following conditions are met:
-				1. The context's <a>control thread state</a> is
-					<code>suspended</code>.
-				2. The context is <a>allowed to start</a>.
-				3. {{[[suspended by user]]}} flag is <code>false</code>.
+				<a href="#context-resume">run it in the rendering thread</a>.
 		</div>
 
 		<pre class=argumentdef for="AudioScheduledSourceNode/start(when)">
@@ -4155,7 +4150,7 @@ Methods</h4>
 
 			3. <a>Queue a control message</a> to stop the
 				{{AudioScheduledSourceNode}}, including the parameter
-				values in the messsage.
+				values in the message.
 		</div>
 
 		<div algorithm="run a control message to stop the AudioBufferSourceNode">
@@ -4814,7 +4809,7 @@ Methods</h4>
 
 			3. <a>Queue a control message</a> to start the
 				{{AudioBufferSourceNode}}, including the parameter values
-				in the messsage.
+				in the message.
 
 			4. <a>Acquire the contents</a> of the
 				{{AudioBufferSourceNode/buffer}} if the


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2255.html" title="Last updated on Oct 2, 2020, 6:00 PM UTC (37e1290)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2255/5777fcf...rtoy:37e1290.html" title="Last updated on Oct 2, 2020, 6:00 PM UTC (37e1290)">Diff</a>