### PR TITLE
Fix #2032:  ABSN extrapolates the last output

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5040,6 +5040,11 @@ function playbackSignal(position) {
 		algorithm that interpolates between sample frames in the neighborhood of
 		position.
 
+		If the buffer is not looping and if |position| is not on an exact sample
+		frame in the buffer and is past the end of the buffer (or specified
+		duration), extrapolation using the previous values in the buffer is used
+		to compute the output.  The extrapolation method is UA-specific.
+
 		If position is greater than or equal to loopEnd and there is no subsequent
 		sample frame in buffer, then interpolation should be based on the sequence
 		of subsequent frames beginning at loopStart.

--- a/index.bs
+++ b/index.bs
@@ -5056,11 +5056,11 @@ function playbackSignal(position) {
 		location of an exact sample frame in the buffer, this function returns
 		that frame. Otherwise, its return value is determined by a UA-supplied
 		algorithm that interpolates sample frames in the neighborhood of
-		position.
+		|position|.
 
-		If position is greater than or equal to loopEnd and there is no subsequent
+		If |position| is greater than or equal to |loopEnd| and there is no subsequent
 		sample frame in buffer, then interpolation should be based on the sequence
-		of subsequent frames beginning at loopStart.
+		of subsequent frames beginning at |loopStart|.
 	 */
 	 ...
 }

--- a/index.bs
+++ b/index.bs
@@ -5055,13 +5055,8 @@ function playbackSignal(position) {
 		values, one for each output channel. If |position| corresponds to the
 		location of an exact sample frame in the buffer, this function returns
 		that frame. Otherwise, its return value is determined by a UA-supplied
-		algorithm that interpolates between sample frames in the neighborhood of
+		algorithm that interpolates sample frames in the neighborhood of
 		position.
-
-		If the buffer is not looping and if |position| is not on an exact sample
-		frame in the buffer and is past the end of the buffer (or specified
-		duration), extrapolation using the previous values in the buffer is used
-		to compute the output.  The extrapolation method is UA-specific.
 
 		If position is greater than or equal to loopEnd and there is no subsequent
 		sample frame in buffer, then interpolation should be based on the sequence


### PR DESCRIPTION
Update `playbackSignal` to mention that extrapolation is used to compute the output sample when the buffer is not looping and we're at the end of the buffer but need output a sample after the end of the buffer but before the next output sample frame.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2256.html" title="Last updated on Nov 6, 2020, 7:08 PM UTC (d911d4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2256/d50c68f...rtoy:d911d4b.html" title="Last updated on Nov 6, 2020, 7:08 PM UTC (d911d4b)">Diff</a>