### PR TITLE
Fix typo "atleast"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -864,8 +864,7 @@ Methods</h4>
 
 		<pre class=argumentdef for="BaseAudioContext/createBuffer()">
 		numberOfChannels: Determines how many channels the buffer will have. An implementation MUST support at least 32 channels.
-		length: Determines the size of the buffer in sample-frames.  This MUST be at
-			least 1.
+		length: Determines the size of the buffer in sample-frames.  This MUST be at least 1.
 		sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in the buffer in sample-frames per second. An implementation MUST support sample rates in at least the range 8000 to 96000.
 		</pre>
 		<div>


### PR DESCRIPTION
This isn't really a typo but an issue with bikeshed not leaving a space at line breaks.  See tabatkins/bikeshed#1470.

This should also fix #2257.

Do *NOT* merge until bikeshed is updated to fix tabatkins/bikeshed#1791 is available  in pip3 since that's how our Travis CI gets the latest version of bikeshed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2259.html" title="Last updated on Oct 6, 2020, 10:30 PM UTC (2ee9b7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2259/8be6b43...rtoy:2ee9b7f.html" title="Last updated on Oct 6, 2020, 10:30 PM UTC (2ee9b7f)">Diff</a>