### PR TITLE
Fix #2262: Clone bikeshed and install it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ python:
 
 install:
   # Setup bikeshed. See https://tabatkins.github.io/bikeshed/#install-final
-  - pip3 install bikeshed && bikeshed update
+  # - pip3 install bikeshed && bikeshed update
+  # Or do a clone.  The above method is preferred, but see issue #2262.
+  - git clone https://github.com/tabatkins/bikeshed.git
+  - (cd bikeshed; pip3 install -e .)
+  - bikeshed update
+  - bikeshed --version
 
 script:
   - bash ./compile.sh


### PR DESCRIPTION
As a workaround, clone the bikeshed repo and install bikeshed from the repo.

Ideally, want just want to use the version with pip3 instead of cloning the current version of bikeshed, but that's producing unexpected errors.  We'll do this for now and recheck at some later date when bikeshed is updated and revert to the old version.