### PR TITLE
Fix #2257: Make channel ordering table visible in dark mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -90,6 +90,16 @@ window.addEventListener("DOMContentLoaded", function () {
 });
 </script>
 <style>
+@media (prefers-color-scheme: light) {
+:root {
+	--div-info-fg-color: #178217;
+}
+}
+@media (prefers-color-scheme: dark) {
+:root {
+	--div-info-fg-color: springgreen;
+}
+}
 .todo {
 	border: 1px solid red;
 	background-color: rgba(255, 0, 0, 0.3);
@@ -124,12 +134,20 @@ table.channels td {
 	width:60px;
 	text-align:center;
 }
+@media (prefers-color-scheme: light) {
 table.channels tr:nth-child(even) {
 	background: #EEE;
 }
 table.channels tr:nth-child(odd) {
 	background: #FFF;
 }
+}
+@media (prefers-color-scheme: dark) {
+table.channels tr:nth-child(even) {
+	background: var(--assertion-border)
+}
+}
+
 div.node-info {
 	padding-left: 4em;
 	padding-right: 4em;
@@ -150,8 +168,8 @@ div.node-info > table > tbody > tr > td {
 div.node-info > table > thead > tr > th {
 	line-height: 2em;
 	font-weight: 600;
-	color: #178217;
 	border-bottom: 1px solid #707070;
+	color: var(--div-info-fg-color);
 }
 div.audioparam-info {
 	padding-left: 4em;
@@ -173,8 +191,8 @@ div.audioparam-info > table > tbody > tr > td {
 div.audioparam-info > table > thead > tr > th {
 	line-height: 2em;
 	font-weight: 600;
-	color: #178217;
 	border-bottom: 1px solid #707070;
+	color: var(--div-info-fg-color);
 }
 div.enum-description > table {
 	border-collapse: collapse;
@@ -192,7 +210,7 @@ div.enum-description > table > tbody > tr > td {
 div.enum-description > table > thead > tr > th {
 	line-height: 2em;
 	font-weight: 600;
-	color: #178217;
+	color: var(--div-info-fg-color);
 	border-bottom: 1px solid #707070;
 }
 code.nobreak {


### PR DESCRIPTION
When using dark mode, use a different background color for the even rows of the channel ordering table so that the entries are visible.

While we're at it, make the headings for the audio node properties table, the audio param values table, and the enumeration description table look a little better in dark mode.  This is done by specifying a brighter green to make it a bit more legible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2264.html" title="Last updated on Oct 13, 2020, 10:58 PM UTC (f53b171)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2264/47a04f5...rtoy:f53b171.html" title="Last updated on Oct 13, 2020, 10:58 PM UTC (f53b171)">Diff</a>