### PR TITLE
Fix #2252: Resolve [[pending resume promises]] when resuming

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1730,6 +1730,7 @@ Methods</h4>
 				execute these steps:
 
 
+				1. Resolve all promises from {{AudioContext/[[pending resume promises]]}} in order.
 				1. Clear {{AudioContext/[[pending resume promises]]}}. Additionally, remove those
 					promises from {{BaseAudioContext/[[pending promises]]}}.
 


### PR DESCRIPTION
When running a control message to resume an AudioContext and we queue a task on the control thread's event loop, we want to resolve all pending resume promises, in addition to clearing them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2265.html" title="Last updated on Oct 14, 2020, 8:28 PM UTC (15ff584)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2265/47a04f5...rtoy:15ff584.html" title="Last updated on Oct 14, 2020, 8:28 PM UTC (15ff584)">Diff</a>