### PR TITLE
Prohibit arbitrary termination of AudioWorkletGlobalScopes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -764,7 +764,7 @@ Attributes</h4>
 	::
 		Allows access to the <code>Worklet</code> object that can import
 		a script containing {{AudioWorkletProcessor}}
-		class definitions via the algorithms defined by [[!worklets-1]]
+		class definitions via the algorithms defined by [[!HTML]]
 		and {{AudioWorklet}}.
 
 	: <dfn>currentTime</dfn>
@@ -9787,7 +9787,10 @@ with {{AudioWorkletNode}}s in the main scope.
 Exactly one {{AudioWorkletGlobalScope}} exists for each
 {{AudioContext}} that contains one or more
 {{AudioWorkletNode}}s. The running of imported scripts is
-performed by the UA as defined in [[!worklets-1]].
+performed by the UA as defined in [[!HTML]]. Overriding the default
+specified in [[!HTML]], {{AudioWorkletGlobalScope}}s must not be
+[=terminate a worklet global scope|terminated=] arbitrarily by the user
+agent.
 
 An {{AudioWorkletGlobalScope}} has the following internal slots:
 
@@ -12351,7 +12354,7 @@ to Consider</a>
 6. Does this specification enable new script execution/loading
 	mechanisms?
 
-	No. It does use the [[worklets-1]] script execution method,
+	No. It does use the [[HTML]] script execution method,
 	defined in that specification.
 
 7. Does this specification allow an origin access to a user’s


### PR DESCRIPTION
Part of https://github.com/w3c/css-houdini-drafts/issues/470 and https://github.com/whatwg/html/pull/6072.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/domenic/web-audio-api/pull/2266.html" title="Last updated on Oct 16, 2020, 6:03 PM UTC (ab5af97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2266/a2ade4a...domenic:ab5af97.html" title="Last updated on Oct 16, 2020, 6:03 PM UTC (ab5af97)">Diff</a>