### PR TITLE
Clarify units used in threshold & knee value calculations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7522,12 +7522,17 @@ of the same shape.
 		units=] and sampled at the time of processing of this
 		block (as [=k-rate=] parameters).
 		
-	1. Let <var>knee end threshold</var> have the value of
-		{{DynamicsCompressorNode/threshold}} plus
-		{{DynamicsCompressorNode/knee}}, also
+	1. Let <var>knee end threshold</var> have the value, also
 		[=decibels to linear gain unit|converted to linear
-		units=] and sampled at the time of processing of this
-		block (as [=k-rate=] parameters).
+		units=] after calculation, of
+		{{DynamicsCompressorNode/threshold}} plus
+		{{DynamicsCompressorNode/knee}} sampled at the time of
+		processing of this block (as [=k-rate=] parameters).
+		
+		Note: for clarity, the decibel values of
+		{{DynamicsCompressorNode/threshold}} and
+		{{DynamicsCompressorNode/knee}} should be added, not the
+		linear unit values.
 
 	1. Let <var>ratio</var> have the value of the
 		{{DynamicsCompressorNode/ratio}}, sampled at the time

--- a/index.bs
+++ b/index.bs
@@ -7521,18 +7521,14 @@ of the same shape.
 		[=decibels to linear gain unit|converted to linear
 		units=] and sampled at the time of processing of this
 		block (as [=k-rate=] parameters).
+	
+	1. Calculate the sum of {{DynamicsCompressorNode/threshold}} plus
+		{{DynamicsCompressorNode/knee}} also sampled at the time
+		of processing of this block (as [=k-rate=] parameters).
 		
-	1. Let <var>knee end threshold</var> have the value, also
-		[=decibels to linear gain unit|converted to linear
-		units=] after calculation, of
-		{{DynamicsCompressorNode/threshold}} plus
-		{{DynamicsCompressorNode/knee}} sampled at the time of
-		processing of this block (as [=k-rate=] parameters).
-		
-		Note: for clarity, the decibel values of
-		{{DynamicsCompressorNode/threshold}} and
-		{{DynamicsCompressorNode/knee}} should be added, not the
-		linear unit values.
+	1. Let <var>knee end threshold</var> have the value of this
+		sum [=decibels to linear gain unit|converted to linear
+		units=].
 
 	1. Let <var>ratio</var> have the value of the
 		{{DynamicsCompressorNode/ratio}}, sampled at the time

--- a/index.bs
+++ b/index.bs
@@ -7521,6 +7521,13 @@ of the same shape.
 		[=decibels to linear gain unit|converted to linear
 		units=] and sampled at the time of processing of this
 		block (as [=k-rate=] parameters).
+		
+	1. Let <var>knee end threshold</var> have the value of
+		{{DynamicsCompressorNode/threshold}} plus
+		{{DynamicsCompressorNode/knee}}, also
+		[=decibels to linear gain unit|converted to linear
+		units=] and sampled at the time of processing of this
+		block (as [=k-rate=] parameters).
 
 	1. Let <var>ratio</var> have the value of the
 		{{DynamicsCompressorNode/ratio}}, sampled at the time
@@ -7530,9 +7537,10 @@ of the same shape.
 	1. This function is the identity up to the value of the linear
 		<var>threshold</var> (i.e., \(f(x) = x\)).
 
-	1. From the <var>threshold</var> up to the <var>threshold</var> +
-		<var>knee</var>, User-Agents can choose the curve shape. The whole
-		function MUST be monotonically increasing and continuous.
+	1. From the <var>threshold</var> up to the
+		<var>knee end threshold</var>, User-Agents can choose the
+		curve shape. The whole function MUST be monotonically
+		increasing and continuous.
 
 		Note: If the <var>knee</var> is 0, the
 		{{DynamicsCompressorNode}} is called a hard-knee compressor.


### PR DESCRIPTION
I believe the current specification of the [compression curve](https://www.w3.org/TR/webaudio/#compression-curve) incorrectly asks implementers to add [linear gain unit](https://www.w3.org/TR/webaudio/#decibels-to-linear-gain-unit) `threshold` and `knee` values, while implementers should be adding the default, decibel versions.

This change updates the compression curve algorithm to define `knee end threshold` as the sum of the decibel `threshold` and `knee` values (*then* linearized) and uses that for the range calculations.

I believe this error came about because the units used in the compression curve algorithm were not well specified when #1568 updated the algorithm to be clearer.

## Why?

There are a few reasons I think that the sum should be done on the decibel versions:

* [threshold](https://www.w3.org/TR/webaudio/#dom-dynamicscompressornode-threshold) ranges from -100 to 0, while [knee](https://www.w3.org/TR/webaudio/#dom-dynamicscompressornode-knee) ranges from 0 to 40, suggesting that knee is meant to be a direct increase to the threshold
* 0 is meant to be a `hard-knee` compressor (effectively no knee). Adding `decibel threshold + 0` has that effect, whereas adding the linearized threshold to linearized knee of 0 always produces a number greater than 1, which I believe is invalid (db knee of 0 linearizes to 1).
* linearizing 40 decibels produces 100; I'm pretty sure linear gain units can only range from 0-1, so this would also be invalid.

I am not expert here, so I welcome feedback.

Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/citelao/web-audio-api/pull/2273.html" title="Last updated on Nov 30, 2020, 8:05 PM UTC (5940334)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2273/d50c68f...citelao:5940334.html" title="Last updated on Nov 30, 2020, 8:05 PM UTC (5940334)">Diff</a>