### PR TITLE
Expose AudioBuffer to DedicatedWorker

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2317,7 +2317,7 @@ An {{AudioBuffer}} may be used by one or more
 </dl>
 
 <pre class="idl">
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface AudioBuffer {
 	constructor (AudioBufferOptions options);
 	readonly attribute float sampleRate;


### PR DESCRIPTION
This updates AudioBuffer exposure to match WebCodecs.

WebCodecs uses AudioBuffer as a container of unencoded audio.
https://wicg.github.io/web-codecs/#dom-audioframe-buffer

WebCodecs AudioDecoder and AudioEncoder classes are exposed to
DedicatedWorker to facilitate offloaded codec IO.

Fixes #2288


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chcunningham/web-audio-api/pull/2289.html" title="Last updated on Jan 5, 2021, 7:56 PM UTC (feb4109)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2289/ca76b67...chcunningham:feb4109.html" title="Last updated on Jan 5, 2021, 7:56 PM UTC (feb4109)">Diff</a>