### PR TITLE
Fix #2291: Add script to create a zip file for a CR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ python:
 
 install:
   # Setup bikeshed. See https://tabatkins.github.io/bikeshed/#install-final
-  # - pip3 install bikeshed && bikeshed update
+  - pip3 install bikeshed && bikeshed update
   # Or do a clone.  The above method is preferred, but see issue #2262.
-  - git clone https://github.com/tabatkins/bikeshed.git
+  # - git clone https://github.com/tabatkins/bikeshed.git
   - (cd bikeshed; pip3 install -e .)
   - bikeshed update
   - bikeshed --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ install:
   - pip3 install bikeshed && bikeshed update
   # Or do a clone.  The above method is preferred, but see issue #2262.
   # - git clone https://github.com/tabatkins/bikeshed.git
-  - (cd bikeshed; pip3 install -e .)
-  - bikeshed update
+  # - (cd bikeshed; pip3 install -e .)
+  # - bikeshed update
+  # Just print the version for reference and debugging.
   - bikeshed --version
 
 script:

--- a/create-cr.sh
+++ b/create-cr.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Create a zip file containing everything we need to publish a CR.
+# This assumes you've updated index.bs to add/change:
+#   Status: CR
+#   Date: <cr date>
+#   Deadline: <one month past date>
+#   Prepare for TR: yes
+
+# Compile the spec, exit immediately if compile.sh fails
+set -e
+./compile.sh
+
+# Create zip file of the things we need.  First the basic stuff.
+rm -f cr.zip
+zip cr index.html style.css implementation-report.html favicon.png
+# Now add all the images, but we don't need the graffle sources.
+zip cr `find images | grep -v graffle`

--- a/create-cr.sh
+++ b/create-cr.sh
@@ -13,6 +13,6 @@ set -e
 
 # Create zip file of the things we need.  First the basic stuff.
 rm -f cr.zip
-zip cr index.html style.css implementation-report.html favicon.png
+zip cr index.html style.css implementation-report.html test-report.html favicon.png
 # Now add all the images, but we don't need the graffle sources.
 zip cr `find images | grep -v graffle`


### PR DESCRIPTION
This script compiles the spec and zips up all the files needed to
create a CR ready for publication.  It assumes you've updated index.bs
appropriately for CR.