### PR TITLE
Update previous version to include latest CR

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,8 @@ Status: ED
 ED: https://webaudio.github.io/web-audio-api/
 TR: https://www.w3.org/TR/webaudio/
 Favicon: favicon.png
-Previous Version: https://www.w3.org/TR/2018/CR-webaudio-20200611/
+Previous Version: https://www.w3.org/TR/2021/CR-webaudio-20210114/
+Previous Version: https://www.w3.org/TR/2020/CR-webaudio-20200611/
 Previous Version: https://www.w3.org/TR/2018/CR-webaudio-20180918/
 Previous Version: https://www.w3.org/TR/2018/WD-webaudio-20180619/
 Previous Version: https://www.w3.org/TR/2015/WD-webaudio-20151208/


### PR DESCRIPTION
Also fix typo for the CR of 20200611 which had the wrong directory
name (2018 instead of the correct 2020).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2295.html" title="Last updated on Jan 27, 2021, 11:01 PM UTC (d2c48d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2295/2f9f719...rtoy:d2c48d6.html" title="Last updated on Jan 27, 2021, 11:01 PM UTC (d2c48d6)">Diff</a>