### PR TITLE
fix: Bikeshed HTML validation issues

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6753,24 +6753,23 @@ Attributes</h4>
 <dl dfn-type=attribute dfn-for="ConvolverNode">
 	: <dfn>buffer</dfn>
 	::
-
 		At the time when this attribute is set, the {{ConvolverNode/buffer}} and
 		the state of the {{normalize}} attribute will be used to
 		configure the {{ConvolverNode}} with this
 		impulse response having the given normalization. The initial
 		value of this attribute is null.
 
-<div algorithm="set convolver buffer">
-	When setting the <dfn>buffer attribute</dfn>, execute the following <span
-		class="synchronously">steps synchronously</span>:
-	1. If the buffer {{AudioBuffer/numberOfChannels|number of channels}} is not 1, 2, 4, or if the
-		{{AudioBuffer/sampleRate|sample-rate}} of the buffer is not the same as the
-		{{BaseAudioContext/sampleRate|sample-rate}} of its <a
-			href="#associated">associated</a> {{BaseAudioContext}}, a
-		{{NotSupportedError}} MUST be thrown.
-	2. <a href="#acquire-the-content">Acquire the content</a> of the
-		{{AudioBuffer}}.
-</div>
+		<div algorithm="set convolver buffer">
+			When setting the <dfn>buffer attribute</dfn>, execute the following <span
+				class="synchronously">steps synchronously</span>:
+			1. If the buffer {{AudioBuffer/numberOfChannels|number of channels}} is not 1, 2, 4, or if the
+				{{AudioBuffer/sampleRate|sample-rate}} of the buffer is not the same as the
+				{{BaseAudioContext/sampleRate|sample-rate}} of its <a
+					href="#associated">associated</a> {{BaseAudioContext}}, a
+				{{NotSupportedError}} MUST be thrown.
+			2. <a href="#acquire-the-content">Acquire the content</a> of the
+				{{AudioBuffer}}.
+		</div>
 
 		Note: If the {{ConvolverNode/buffer}} is set to an new
 		buffer, audio may glitch.  If this is undesirable, it
@@ -9164,7 +9163,8 @@ Dictionary {{PeriodicWaveOptions}} Members</h5>
 		<code>cosine</code> terms. The first element (index 0) is the
 		DC-offset of the periodic waveform. The second element
 		(index 1) represents the fundmental frequency.  The
-		third represents the first overtone and so on.  </dl>
+		third represents the first overtone and so on.
+</dl>
 
 <h4 id="waveform-generation">
 Waveform Generation</h4>
@@ -10357,7 +10357,7 @@ used to configure various channel configurations.
 			{{AudioWorkletNodeOptions/outputChannelCount}}.
 
 		1. Otherwise set the channel count of the <em>k</em>th output
-			of the <node>node</node> to the <em>k</em>th element
+			of the <var>node</var> to the <em>k</em>th element
 			of {{AudioWorkletNodeOptions/outputChannelCount}}
 			sequence and return.
 


### PR DESCRIPTION
- `<node>` element instead of `<var>`
- Trailing `<dl>` as part of `<dd>`
- Indenting of notice inside `<dd>`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nschonni/web-audio-api/pull/2298.html" title="Last updated on Feb 8, 2021, 12:41 AM UTC (19d7a65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2298/12411f1...nschonni:19d7a65.html" title="Last updated on Feb 8, 2021, 12:41 AM UTC (19d7a65)">Diff</a>