### PR TITLE
Define when and how regular tasks are processed wrt the processing model

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11119,7 +11119,7 @@ in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.
 </div>
 
 The audio callback is also queued as a task in the <a
-	href="#control-message-queue">control message queue</a>. The UA MUST perform
+href="#control-message-queue">control message queue</a>. The UA MUST perform
 the following algorithms to process render quanta to fulfill such task by
 filling up the requested buffer size. Along with the <a>control message
 queue</a>, each {{AudioContext}} has a regular <a

--- a/index.bs
+++ b/index.bs
@@ -11118,17 +11118,20 @@ in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.
 	finished.
 </div>
 
-The audio callback is also queued as a task in the
-<a href="#control-message-queue">control message queue</a>. The UA MUST perform
+The audio callback is also queued as a task in the <a
+	href="#control-message-queue">control message queue</a>. The UA MUST perform
 the following algorithms to process render quanta to fulfill such task by
-filling up the requested buffer size. Along with the primary message queue, each
-{{AudioContext}} has a regular task queue for tasks that are posted to
-the rendering thread from the control thread. An additional microtask checkpoint
-is performed after processing a render quantum to run any microtasks that might
-have been queued during the execution of the `process` methods of
-{{AudioWorkletProcessor}}.
+filling up the requested buffer size. Along with the <a>control message
+queue</a>, each {{AudioContext}} has a regular <a
+href="https://html.spec.whatwg.org/multipage/webappapis.html#task-queue">task
+queue</a>, called its <dfn for="BaseAudioContext">associated task queue</dfn>
+for tasks that are posted to the rendering thread from the control thread. An
+additional microtask checkpoint is performed after processing a render quantum
+to run any microtasks that might have been queued during the execution of the
+`process` methods of {{AudioWorkletProcessor}}.
 
-All tasks posted from an {{AudioWorkletNode}} are posted to this task queue.
+All tasks posted from an {{AudioWorkletNode}} are posted to the [=associated
+task queue=] of its associated {{BaseAudioContext}}.
 
 <div id="rendering-initialization" algorithm="initialize rendering loop">
 	The following step MUST be performed once before the rendering loop starts.
@@ -11139,7 +11142,7 @@ All tasks posted from an {{AudioWorkletNode}} are posted to this task queue.
 </div>
 
 <div id="rendering-a-graph" algorithm="rendering a graph">
-  The following sterp MUST be performed when rendering a single render quantum.
+  The following steps MUST be performed when rendering a render quantum.
 
 	1. Let <var>render result</var> be <code>false</code>.
 
@@ -11158,10 +11161,9 @@ All tasks posted from an {{AudioWorkletNode}} are posted to this task queue.
 			2. Remove the [=oldest message=] of <var>Q<sub>rendering</sub></var>.
 
 
-	3. Process the regular event queue.
+	3. Process the {{BaseAudioContext}}'s [=associated task queue=].
 
-		1. Let <var>task count</var> be the number of tasks in the task queue of
-			the task queue of the {{AudioContext}} being rendered.
+		1. Let <var>task count</var> be the number of tasks in the task queue of the {{AudioContext}} being rendered.
 
 		2. Spin the event loop until <var>task count</var> tasks have been executed.
 

--- a/index.bs
+++ b/index.bs
@@ -10085,6 +10085,9 @@ Every {{AudioWorkletProcessor}} has an associated <dfn>active source</dfn> flag,
 the node to be retained in memory and perform audio processing in
 the absence of any connected inputs.
 
+All tasks posted from an {{AudioWorkletNode}} are posted to the task queue of
+its associated {{BaseAudioContext}}.
+
 <xmp class="idl">
 [Exposed=Window]
 interface AudioParamMap {
@@ -11118,9 +11121,14 @@ in the algorithm of <a href="#rendering-a-graph">rendering a graph</a>.
 The audio callback is also queued as a task in the
 <a href="#control-message-queue">control message queue</a>. The UA MUST perform
 the following algorithms to process render quanta to fulfill such task by
-filling up the requested buffer size. Along with the primary message queue, the
-<a>rendering thread</a> has another task queue for microtasks for any microtask
-operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
+filling up the requested buffer size. Along with the primary message queue, each
+{{AudioContext}} has a regular task queue for tasks that are posted to
+the rendering thread from the control thread. An additional microtask checkpoint
+is performed after processing a render quantum to run any microtasks that might
+have been queued during the execution of the `process` methods of
+{{AudioWorkletProcessor}}.
+
+All tasks posted from an {{AudioWorkletNode}} are posted to this task queue.
 
 <div id="rendering-initialization" algorithm="initialize rendering loop">
 	The following step MUST be performed once before the rendering loop starts.
@@ -11131,6 +11139,8 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 </div>
 
 <div id="rendering-a-graph" algorithm="rendering a graph">
+  The following sterp MUST be performed when rendering a single render quantum.
+
 	1. Let <var>render result</var> be <code>false</code>.
 
 	2. Process the [=control message queue=].
@@ -11147,7 +11157,15 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 			2. Remove the [=oldest message=] of <var>Q<sub>rendering</sub></var>.
 
-	3. Process a render quantum.
+
+	3. Process the regular event queue.
+
+		1. Let <var>task count</var> be the number of tasks in the task queue of
+			the task queue of the {{AudioContext}} being rendered.
+
+		2. Spin the event loop until <var>task count</var> tasks have been executed.
+
+	4. Process a render quantum.
 
 		1. If the <a>rendering thread state</a> of the {{BaseAudioContext}} is not
 			<code>running</code>, return false.
@@ -11311,9 +11329,9 @@ operation such as resolution of {{Promise}}s in the {{AudioWorkletGlobalScope}}.
 
 		7. Set <var>render result</var> to <code>true</code>.
 
-	4. [=Perform a microtask checkpoint=].
+	5. [=Perform a microtask checkpoint=].
 
-	5. Return <var>render result</var>.
+	6. Return <var>render result</var>.
 </div>
 
 <dfn id="mute">Muting</dfn> an {{AudioNode}} means that its


### PR DESCRIPTION
A first cut for this, after reading lots of WHATWG text. Step 3.1 is necessary to avoid DOSing the render thread. I don't know if we want to be more precise for dispatching tasks, but considering the existence of an `implied event loop`, we're probably good.

This fixes #2008.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2301.html" title="Last updated on Feb 19, 2021, 5:43 PM UTC (61d56a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2301/12411f1...61d56a4.html" title="Last updated on Feb 19, 2021, 5:43 PM UTC (61d56a4)">Diff</a>