### PR TITLE
Move some steps from AudioWorkletProcessor constructor to the instantiation algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10074,9 +10074,14 @@ the <a>rendering thread</a> will invoke the algorithm below:
 			of this {{AudioWorkletGlobalScope}}'s
 			[=pending processor construction data=] respectively.
 
-		1. <a spec=webidl lt=construct>Construct a callback function</a>
-			from <var>processorCtor</var> with the argument of
-			<var>deserializedOptions</var>.
+		1. <a spec=webidl lt=construct>Construct a callback function</a> from |processorCtor| with the argument
+			of |deserializedOptions|. If any exceptions are thrown in the callback, <a>queue a task</a> to
+			the <a>control thread</a> to <a spec="dom" lt="fire an event">fire an event</a> named
+			`processorerror` using
+			<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
+			at |nodeReference|.
+
+		1. Empty the [=pending processor construction data=] slot.
 	</div>
 
 <h4 interface lt="AudioWorkletNode">
@@ -10454,22 +10459,6 @@ Constructors</h5>
 				Throw a {{TypeError}} exception if the slot is
 				empty.
 
-			1. If any of following steps throws any exception,
-				perform these substeps:
-
-				1. Empty the
-					[=pending processor construction data=]
-					slot.
-
-				2. Abort the rest of the constructor algorithm
-					and <a>queue a task</a> to the
-					<a>control thread</a>
-					to <a spec="dom" lt="fire an event">fire
-					an event</a> named
-					<code>processorerror</code> using
-					<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-					at <var>nodeReference</var>.
-
 			1. Let <var>processor</var> be the
 				<a spec="webidl" lt="this">this</a> value.
 
@@ -10488,9 +10477,6 @@ Constructors</h5>
 			1. Set <var>processor</var>’s
 				{{AudioWorkletProcessor/port}}
 				to <var>deserializedPort</var>.
-
-			1. Empty the [=pending processor construction data=]
-				slot.
 		</div>
 </dl>
 


### PR DESCRIPTION
Fixes #2119.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2306.html" title="Last updated on Mar 10, 2021, 4:21 PM UTC (9f783e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2306/d360708...hoch:9f783e4.html" title="Last updated on Mar 10, 2021, 4:21 PM UTC (9f783e4)">Diff</a>