### PR TITLE
Replace "queue a task" with "queue a media element task"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11302,51 +11302,6 @@ task queue=] of its associated {{BaseAudioContext}}.
 				1. Let |processor| be the associated {{AudioWorkletProcessor}}
 					instance of {{AudioWorkletNode}}.
 
-<<<<<<< HEAD
-				1. If {{[[callable process]]}} of <var>processor</var> is `true`,
-					execute the following steps:
-
-					1. Let <var>processFunction</var> be the result of
-						<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
-						Get</a>(O=<i><var>processor</var></i>, P="process")</code>.
-
-					1. Set {{[[callable process]]}} to be the return value of
-						<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-iscallable">
-						IsCallable</a>(argument=<i><var>processFunction</var></i>)</code>.
-
-					1. If {{[[callable process]]}} is `true`,
-						invoke <var>processFunction</var> to
-						[=Computing a block of audio|compute a block of audio=] with the
-						argument of [=input buffer=], output buffer and
-						[=input AudioParam buffer=]. A buffer containing copies of the
-            					elements of the {{Float32Array}}s passed via the
-            					{{AudioWorkletProcessCallback/outputs!!argument}} parameter to <var>processFunction</var> is
-						<a href="#available-for-reading">made available for reading</a>.
-
-					1. At the conclusion of <var>processFunction</var>,
-						<a href="https://tc39.github.io/ecma262/#sec-toboolean"><code>ToBoolean</code></a>
-						is applied to the return value and the result is
-						assigned to the associated {{AudioWorkletProcessor}}'s
-						<a>active source</a> flag. This in turn affects whether
-						subsequent invocations of [=process()=] occur, and has
-						an impact on the lifetime of the node.
-
-					1. Else if {{[[callable process]]}} is `false`,
-						<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-						queue a media element task</a> to <a spec="dom" lt="fire an event">fire
-						</a> an
-						<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
-						ErrorEvent</a> named `processorerror` at the associated
-						{{AudioWorkletNode}}.
-
-				1. If {{[[callable process]]}} of <var>processor</var> is `false`,
-					execute the following steps:
-
-					1. [=Making a buffer available for reading|Make a silent output buffer available for reading=].
-
-				1. Any {{Promise}} resolved within the execution of process method will
-					be queued into the microtask queue in the {{AudioWorkletGlobalScope}}.
-=======
 				1. Let |O| be the ECMAScript object corresponding to |processor|.
 
 				1. Let |processCallback| be an uninitialized variable.
@@ -11437,7 +11392,6 @@ task queue=] of its associated {{BaseAudioContext}}.
 							<a spec="dom" lt="fire an event">fire</a> an
 							{{ErrorEvent}} named <code>processorerror</code> at the
 							associated {{AudioWorkletNode}}.
->>>>>>> upstream/main
 
 			5. If this {{AudioNode}} is a <a>destination node</a>,
 				[=Recording the input|record the input=] of this {{AudioNode}}.

--- a/index.bs
+++ b/index.bs
@@ -675,6 +675,9 @@ but is instead extended by the concrete interfaces
 <dfn attribute for="BaseAudioContext">[[pending promises]]</dfn>  that is an
 initially empty ordered list of promises.
 
+Each {{BaseAudioContext}} has a unique
+<a href="https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source">
+media element event task source</a>.
 
 <pre class="idl">
 enum AudioContextState {

--- a/index.bs
+++ b/index.bs
@@ -1185,9 +1185,9 @@ Methods</h4>
 				errorCallback)/audioData!!argument}} into [=linear PCM=]. In case of
 				failure, set <var>can decode</var> to <em>false</em>.
 
-			4. If <var>can decode</var> is <em>false</em>, <a>queue a task</a> to
-				execute the following step, on the <a>control thread</a>'s
-				event loop:
+			4. If |can decode| is `false`,
+				<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
 
 				1. Let <var>error</var> be a <code>DOMException</code>
 					whose name is {{EncodingError}}.
@@ -1207,8 +1207,8 @@ Methods</h4>
 					the sample-rate of {{BaseAudioContext/decodeAudioData(audioData,
 					successCallback, errorCallback)/audioData!!argument}}.
 
-				2. <a>Queue a task</a> on the <a>control thread</a>'s event loop
-					to execute the following steps:
+				2. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+					queue a media element task</a> to execute the following steps:
 
 					1. Let <var>buffer</var> be an
 						{{AudioBuffer}} containing the final result
@@ -1450,11 +1450,14 @@ Constructors</h4>
 
 			3. Set the <a>rendering thread state</a> to <code>running</code> on the {{AudioContext}}.
 
-			4. <a>Queue a task</a> on the <a>control thread</a> event loop, to execute these steps:
+			1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
 
 				1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
-				2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+				1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+					queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
+					</a> named `statechange` at the {{AudioContext}}.
 		</div>
 
 		Note: It is unfortunately not possible to programatically notify
@@ -1558,11 +1561,16 @@ Methods</h4>
 					There is no need to notify the control thread in this case.
 				</div>
 
-			4. <a>Queue a task</a> on the <a>control thread</a>'s event loop, to execute these steps:
+			4. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
+
 				1. Resolve <em>promise</em>.
 				2. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is not already "{{AudioContextState/closed}}":
 					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/closed}}".
-					2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+
+					1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+						queue a media element task</a> to <a spec="dom" lt="fire an event">fire
+						an event</a> named `statechange` at the {{AudioContext}}.
 		</div>
 
 		When an {{AudioContext}} is closed, any
@@ -1744,8 +1752,9 @@ Methods</h4>
 
 			3. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
-			4. In case of failure, queue a task on the <a>control thread</a> to execute the following,
-				and abort these steps:
+			4. In case of failure,
+				<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
 
 				1. Reject all promises from {{AudioContext/[[pending resume promises]]}}
 					in order, then clear {{AudioContext/[[pending resume promises]]}}.
@@ -1753,9 +1762,8 @@ Methods</h4>
 				2. Additionally, remove those promises from {{BaseAudioContext/[[pending
 					promises]]}}.
 
-			5. Queue a task on the <a>control thread</a>'s event loop, to
-				execute these steps:
-
+			5. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
 
 				1. Resolve all promises from {{AudioContext/[[pending resume promises]]}} in order.
 				1. Clear {{AudioContext/[[pending resume promises]]}}. Additionally, remove those
@@ -1767,7 +1775,9 @@ Methods</h4>
 
 					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
-					2. Queue a task to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+					1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+						queue a media element task</a> to <a spec="dom" lt="fire an event">fire
+						an event </a> named `statechange` at the {{AudioContext}}.
 		</div>
 
 		<div>
@@ -1826,7 +1836,8 @@ Methods</h4>
 
 			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>suspended</code>.
 
-			3. <a>Queue a task</a> on the <a>control thread</a>'s event loop, to execute these steps:
+			3. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
 
 				1. Resolve <em>promise</em>.
 
@@ -1834,7 +1845,10 @@ Methods</h4>
 					attribute of the {{AudioContext}} is not already "{{AudioContextState/suspended}}":
 
 					1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/suspended}}".
-					2. <a>Queue a task</a> to fire a simple event named <code>statechange</code> at the {{AudioContext}}.
+
+					1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+						queue a media element task</a> to <a spec="dom" lt="fire an event">fire
+						an event </a> named `statechange` at the {{AudioContext}}.
 		</div>
 
 		While an {{AudioContext}} is suspended,
@@ -2113,17 +2127,19 @@ Methods</h4>
 				<li>If a suspended context is resumed, continue to render the
 				buffer.
 
-				<li>Once the rendering is complete, <a>queue a task</a> on the
-				<a>control thread</a>'s event loop to perform the following
-				steps:
+				<li>Once the rendering is complete,
+					<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+					queue a media element task</a> to execute the following steps:
+
 					<ol>
 						<li>Resolve the <var ignore>promise</var> created by {{startRendering()}} with {{[[rendered buffer]]}}.
 
-						<li><a>Queue a task</a> to fire an event named
-						<code>complete</code> at this instance, using an instance
-						of {{OfflineAudioCompletionEvent}} whose
-						<code>renderedBuffer</code> property is set to
-						{{[[rendered buffer]]}}.
+						<li><a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+							queue a media element task</a> to
+							<a spec="dom" lt="fire an event">fire an event</a> named
+							`complete` using an instance of {{OfflineAudioCompletionEvent}}
+							whose `renderedBuffer` property is set to
+							{{[[rendered buffer]]}}.
 
 					</ol>
 
@@ -2177,11 +2193,12 @@ Methods</h4>
 
 			2. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
-			3. In case of failure, queue a task on the <a>control thread</a> to
-				reject <var>promise</var> and abort these steps:
+			3. In case of failure,
+				<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to reject |promise| and abort the remaining steps.
 
-			4. Queue a task on the <a>control thread</a>'s event loop, to
-				execute these steps:
+			4. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to execute the following steps:
 
 				1. Resolve <var>promise</var>.
 
@@ -2191,8 +2208,10 @@ Methods</h4>
 					1. Set the {{BaseAudioContext/state}} attribute of the
 						{{OfflineAudioContext}} to "{{AudioContextState/running}}".
 
-					2. Queue a task to fire a simple event named <code>statechange</code>
-						at the {{OfflineAudioContext}}.
+					1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+						queue a media element task</a> to <a spec="dom" lt="fire an event">fire
+						an event</a> named `statechange` at the {{OfflineAudioContext}}.
+
 		</div>
 
 		<div>
@@ -9995,11 +10014,10 @@ Methods</h5>
 				<a>node name to processor constructor map</a>
 				of the associated {{AudioWorkletGlobalScope}}.
 
-			1. <a>Queue a task</a> to the <a>control thread</a> to
-				append the key-value pair <var>name</var> →
-				<var>parameterDescriptorSequence</var> to
-				the <a>node name to parameter descriptor map</a>
-				of the associated {{BaseAudioContext}}.
+			1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+				queue a media element task</a> to append the key-value pair |name| →
+				|parameterDescriptorSequence| to the <a>node name to parameter descriptor map</a> of the
+				associated {{BaseAudioContext}}.
 		</div>
 
 		Note: The class constructor should only be looked up once, thus it
@@ -10261,8 +10279,8 @@ Attributes</h5>
 		When an unhandled exception is thrown from the processor's
 		<code>constructor</code>, <code>process</code> method,
 		or any user-defined class method, the processor will
-		<a>queue a task</a> to <a spec="dom" lt="fire an event">
-		fire an event</a> named <code>processorerror</code> using
+		<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">	queue a media
+		element task</a> to <a spec="dom" lt="fire an event">fire an event</a> named `processorerror` using
 		<a href="https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface">
 		ErrorEvent</a> at the associated {{AudioWorkletNode}}.
 
@@ -10464,14 +10482,12 @@ Constructors</h5>
 					[=pending processor construction data=]
 					slot.
 
-				2. Abort the rest of the constructor algorithm
-					and <a>queue a task</a> to the
-					<a>control thread</a>
-					to <a spec="dom" lt="fire an event">fire
-					an event</a> named
-					<code>processorerror</code> using
-					<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-					at <var>nodeReference</var>.
+				2. Abort the rest of the constructor algorithm and
+					<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+					queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
+					</a> named `processorerror` using
+					<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
+					ErrorEvent</a> at |nodeReference|.
 
 			1. Let <var>processor</var> be the
 				<a spec="webidl" lt="this">this</a> value.
@@ -11323,10 +11339,11 @@ task queue=] of its associated {{BaseAudioContext}}.
 						an impact on the lifetime of the node.
 
 					1. Else if {{[[callable process]]}} is `false`,
-						<a>queue a task</a> to the <a>control thread</a>
-						<a spec="dom" lt="fire an event">fire</a> an
-						<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-						named <code>processorerror</code> at the associated
+						<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+						queue a media element task</a> to <a spec="dom" lt="fire an event">fire
+						</a> an
+						<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">
+						ErrorEvent</a> named `processorerror` at the associated
 						{{AudioWorkletNode}}.
 
 				1. If {{[[callable process]]}} of <var>processor</var> is `false`,

--- a/index.bs
+++ b/index.bs
@@ -1154,7 +1154,10 @@ Methods</h4>
 				1. Let <var>error</var> be a {{DataCloneError}}.
 				2. Reject <var>promise</var> with <var>error</var>, and remove it from
 					{{BaseAudioContext/[[pending promises]]}}.
-				3. <a>Queue a task</a> to invoke {{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with <var>error</var>.
+
+				3. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+					Queue a media element task</a> to invoke
+					{{BaseAudioContext/decodeAudioData()/errorCallback!!argument}} with |error|.
 
 			5. Return <var>promise</var>.
 		</div>


### PR DESCRIPTION
Fixes #2095.

This replaces all instances of "queue a task" with "queue a media element task" to clarify the task source. See https://github.com/WebAudio/web-audio-api/issues/2095#issuecomment-796905208.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2307.html" title="Last updated on Mar 29, 2021, 7:32 PM UTC (a47a7c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2307/c9886cd...hoch:a47a7c1.html" title="Last updated on Mar 29, 2021, 7:32 PM UTC (a47a7c1)">Diff</a>