### PR TITLE
Fix #2251: Refine phrasing for "allowed to start"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1373,7 +1373,7 @@ interface AudioContext : BaseAudioContext {
 An {{AudioContext}} is said to be <dfn>allowed to start</dfn> if the user agent
 allows the context state to transition from "{{AudioContextState/suspended}}" to
 "{{AudioContextState/running}}". A user agent may disallow this initial transition,
-to allow it only when the {{AudioContext}}'s [=relevant global object=] has
+and to allow it only when the {{AudioContext}}'s [=relevant global object=] has
 [=sticky activation=].
 
 {{AudioContext}} has an internal slot:

--- a/index.bs
+++ b/index.bs
@@ -1372,7 +1372,7 @@ interface AudioContext : BaseAudioContext {
 
 An {{AudioContext}} is said to be <dfn>allowed to start</dfn> if the user agent
 allows the context state to transition from "{{AudioContextState/suspended}}" to
-"{{AudioContextState/running}}". A user agent may delay this initial transition,
+"{{AudioContextState/running}}". A user agent may disallow this initial transition,
 to allow it only when the {{AudioContext}}'s [=relevant global object=] has
 [=sticky activation=].
 


### PR DESCRIPTION
The phrasing using "delay" is confusing.  Replace it with "disallow" which reflects more precisely what happens.  When a context is not allowed to start, it isn't really "delayed"; it can only start under specific actions with a user-gesture.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2308.html" title="Last updated on Mar 11, 2021, 6:55 PM UTC (8d7af81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2308/d360708...rtoy:8d7af81.html" title="Last updated on Mar 11, 2021, 6:55 PM UTC (8d7af81)">Diff</a>