### PR TITLE
Fix #2309: OscillatorNode output is mono

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8276,6 +8276,8 @@ time integral of <a>computedOscFrequency</a>, assuming a phase angle
 of zero at the node's exact start time. Its <a>nominal range</a> is
 [-<a>Nyquist frequency</a>, <a>Nyquist frequency</a>].
 
+The single output of this node consists of one channel (mono).
+
 <pre class=include>
 path: audionode.include
 macros:


### PR DESCRIPTION
Add a sentence (like we have for `ConstantSourceNode`) that says the
`OscillatorNode` has a single output that is mono.

Not exactly sure where the best place is to put this sentence, though.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2310.html" title="Last updated on Mar 25, 2021, 9:27 PM UTC (75c2bd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2310/a7556a5...rtoy:75c2bd4.html" title="Last updated on Mar 25, 2021, 9:27 PM UTC (75c2bd4)">Diff</a>