### PR TITLE
Adjust the steps to process a context's regular task queue

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11168,9 +11168,16 @@ task queue=] of its associated {{BaseAudioContext}}.
 
 	3. Process the {{BaseAudioContext}}'s [=associated task queue=].
 
-		1. Let <var>task count</var> be the number of tasks in the task queue of the {{AudioContext}} being rendered.
 
-		2. Spin the event loop until <var>task count</var> tasks have been executed.
+		1. Let <var>task queue</var> be the {{BaseAudioContext}}'s [=associated task queue=].
+		2. Let <var>task count</var> be the number of tasks in the in <var>task queue</var>
+		3. While <var>task count</var> is not equal to 0, execute the following steps:
+			1. Let <var>oldest task</var> be the first runnable task in <var>task queue</var>, and remove it from <var>task queue</var>.
+			2. Set the rendering loop's currently running task to <var>oldest task</var>.
+			3. Perform <var>oldest task</var>'s steps.
+			4. Set the rendering loop currently running task back to <code>null</code>.
+			6. Decrement <var>task count</var>
+			5. Perform a microtask checkpoint.
 
 	4. Process a render quantum.
 


### PR DESCRIPTION
Thanks to Gregory Terzian for reporting and outlining the patch.

This fixes #2302.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 26, 2021, 10:08 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWebAudio%2Fweb-audio-api%2Ff143c4b0737389865fd5ba4560f24cfacba1abc6%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232311.)._
</details>
