### PR TITLE
Rework description of control thread state and rendering thread state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -678,6 +678,11 @@ initially empty ordered list of promises.
 Each {{BaseAudioContext}} has a unique
 <a href="https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source">
 media element event task source</a>.
+Additionally, a {{BaseAudioContext}} has two private slots <dfn attribute
+for="BaseAudioContext">[[rendering thread state]]</dfn> and <dfn attribute
+for="BaseAudioContext">[[control thread state]]</dfn> that take values from
+{{AudioContextState}}, and that are both initialy set to
+<code>"suspended"</code>.
 
 <pre class="idl">
 enum AudioContextState {
@@ -851,8 +856,8 @@ Attributes</h4>
 
 	: <dfn>state</dfn>
 	::
-		Describes the current state of the {{AudioContext}}. Its value is identical
-		to <a>control thread state</a>.
+		Describes the current state of the {{BaseAudioContext}}.  Getting this
+		attribute returns the contents of the {{[[control thread state]]}} slot.
 </dl>
 
 <h4 id="BaseAudioContent-methods">
@@ -11035,11 +11040,6 @@ is the thread on which the actual audio output is computed, in
 reaction to the calls from the <a>control thread</a>. It can be a
 real-time, callback-based audio thread, if computing audio for an
 {{AudioContext}}, or a normal thread if computing audio for an {{OfflineAudioContext}}.
-
-Each thread has an internal slot that indicates its current state.
-<dfn>control thread state</dfn> is the equivalent of {{BaseAudioContext/state}}
-and <dfn>rendering thread state</dfn> in the counterpart from the rendering
-thread. These slots have a value of {{AudioContextState}}.
 
 The <a>control thread</a> uses a traditional event loop, as described
 in [[HTML]].

--- a/index.bs
+++ b/index.bs
@@ -1211,7 +1211,7 @@ Methods</h4>
 			5. Otherwise:
 				1. Take the result, representing the decoded [=linear PCM=]
 					audio data, and resample it to the sample-rate of the
-					{{AudioContext}} if it is different from
+					{{BaseAudioContext}} if it is different from
 					the sample-rate of {{BaseAudioContext/decodeAudioData(audioData,
 					successCallback, errorCallback)/audioData!!argument}}.
 
@@ -1417,9 +1417,9 @@ Constructors</h4>
 			<span class="synchronous">When creating an {{AudioContext}},
 			execute these steps:</span>
 
-			1. Set a <a>control thread state</a> to <code>suspended</code> on the {{AudioContext}}.
+			1. Set a {{[[control thread state]]}} to <code>suspended</code> on the {{AudioContext}}.
 
-			2. Set a <a>rendering thread state</a> to <code>suspended</code> on the {{AudioContext}}.
+			2. Set a {{[[rendering thread state]]}} to <code>suspended</code> on the {{AudioContext}}.
 
 			3. Let <dfn attribute for="AudioContext">[[pending resume promises]]</dfn> be a
 				slot on this {{AudioContext}}, that is an initially empty ordered list of
@@ -1456,7 +1456,7 @@ Constructors</h4>
 			1. Attempt to <a href="#acquiring">acquire system resources</a>.
 				In case of failure, abort the following steps.
 
-			3. Set the <a>rendering thread state</a> to <code>running</code> on the {{AudioContext}}.
+			3. Set the {{[[rendering thread state]]}} to <code>running</code> on the {{AudioContext}}.
 
 			1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
 				queue a media element task</a> to execute the following steps:
@@ -1539,12 +1539,13 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			1. If the <a>control thread state</a> flag on the
+			1. If the {{[[control thread state]]}} flag on the
 				{{AudioContext}} is <code>closed</code> reject the promise
 				with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
 
-			1. Set the <a>control thread state</a> flag on the {{AudioContext}} to <code>closed</code>.
+			1. Set the {{[[control thread state]]}} flag on the {{AudioContext}} to
+				<code>closed</code>.
 
 			1. <a>Queue a control message</a> to close the {{AudioContext}}.
 
@@ -1558,7 +1559,7 @@ Methods</h4>
 
 			1. Attempt to <a>release system resources</a>.
 
-			2. Set the <a>rendering thread state</a> to <code>suspended</code>.
+			2. Set the {{[[rendering thread state]]}} to <code>suspended</code>.
 				<div class="note">
 					This will stop rendering.
 				</div>
@@ -1729,7 +1730,7 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			2. If the <a>control thread state</a> on the
+			2. If the {{[[control thread state]]}} on the
 				{{AudioContext}} is <code>closed</code> reject the
 				promise with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
@@ -1741,7 +1742,7 @@ Methods</h4>
 				{{AudioContext/[[pending resume promises]]}} and abort these steps, returning
 				<var>promise</var>.
 
-			5. Set the <a>control thread state</a> on the
+			5. Set the {{[[control thread state]]}} on the
 				{{AudioContext}} to <code>running</code>.
 
 			6. <a>Queue a control message</a> to resume the {{AudioContext}}.
@@ -1756,7 +1757,7 @@ Methods</h4>
 
 			1. Attempt to <a href="#acquiring">acquire system resources</a>.
 
-			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>running</code>.
+			2. Set the {{[[rendering thread state]]}} on the {{AudioContext}} to <code>running</code>.
 
 			3. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
@@ -1819,7 +1820,7 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			2. If the <a>control thread state</a> on the
+			2. If the {{[[control thread state]]}} on the
 				{{AudioContext}} is <code>closed</code> reject the promise
 				with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
@@ -1828,7 +1829,7 @@ Methods</h4>
 
 			4. Set {{[[suspended by user]]}} to <code>true</code>.
 
-			5. Set the <a>control thread state</a> on the {{AudioContext}} to <code>suspended</code>.
+			5. Set the {{[[control thread state]]}} on the {{AudioContext}} to <code>suspended</code>.
 
 			6. <a>Queue a control message</a> to suspend the {{AudioContext}}.
 
@@ -1842,7 +1843,7 @@ Methods</h4>
 
 			1. Attempt to <a>release system resources</a>.
 
-			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>suspended</code>.
+			2. Set the {{[[rendering thread state]]}} on the {{AudioContext}} to <code>suspended</code>.
 
 			3. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
 				queue a media element task</a> to execute the following steps:
@@ -2007,10 +2008,10 @@ Constructors</h4>
 			Let <var>c</var> be a new {{OfflineAudioContext}} object.
 			Initialize <var>c</var> as follows:
 
-			1. Set the <a>control thread state</a> for <var>c</var>
+			1. Set the {{[[control thread state]]}} for <var>c</var>
 				to <code>"suspended"</code>.
 
-			2. Set the <a>rendering thread state</a> for
+			2. Set the {{[[rendering thread state]]}} for
 				<var>c</var> to <code>"suspended"</code>.
 
 			3. Construct an {{AudioDestinationNode}} with its
@@ -2179,12 +2180,12 @@ Methods</h4>
 
 			1. Abort these steps and reject <var>promise</var> with
 				{{InvalidStateError}} when any of following conditions is true:
-				- The <a>control thread state</a> on the {{OfflineAudioContext}}
+				- The {{[[control thread state]]}} on the {{OfflineAudioContext}}
 					is <code>closed</code>.
 				- The {{[[rendering started]]}} slot on the {{OfflineAudioContext}}
 					is <em>false</em>.
 
-			1. Set the <a>control thread state</a> flag on the
+			1. Set the {{[[control thread state]]}} flag on the
 				{{OfflineAudioContext}} to <code>running</code>.
 
 			1. <a>Queue a control message</a> to resume the {{OfflineAudioContext}}.
@@ -2197,7 +2198,7 @@ Methods</h4>
 			{{OfflineAudioContext}} means running these steps on the
 			<a>rendering thread</a>:
 
-			1. Set the <a>rendering thread state</a> on the {{OfflineAudioContext}} to <code>running</code>.
+			1. Set the {{[[rendering thread state]]}} on the {{OfflineAudioContext}} to <code>running</code>.
 
 			2. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
@@ -4171,7 +4172,7 @@ Methods</h4>
 			5. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">start running its rendering thread</a> only when
 				all the following conditions are met:
-				1. The context's <a>control thread state</a> is
+				1. The context's {{[[control thread state]]}} is
 					"{{AudioContextState/suspended}}".
 				1. The context is <a>allowed to start</a>.
 				1. {{[[suspended by user]]}} flag is <code>false</code>.
@@ -4885,7 +4886,7 @@ Methods</h4>
 			1. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">start running its rendering thread</a> only when
 				all the following conditions are met:
-				1. The context's <a>control thread state</a> is
+				1. The context's {{[[control thread state]]}} is
 					{{AudioContextState/suspended}}.
 				1. The context is <a>allowed to start</a>.
 				1. {{[[suspended by user]]}} flag is <code>false</code>.
@@ -11207,7 +11208,7 @@ task queue=] of its associated {{BaseAudioContext}}.
 
 	4. Process a render quantum.
 
-		1. If the <a>rendering thread state</a> of the {{BaseAudioContext}} is not
+		1. If the {{[[rendering thread state]]}} of the {{BaseAudioContext}} is not
 			<code>running</code>, return false.
 
 		2. Order the {{AudioNode}}s of the {{BaseAudioContext}} to be processed.


### PR DESCRIPTION
This fixes #2280. I want with [Raymond's](https://github.com/WebAudio/web-audio-api/issues/2280#issuecomment-756909666) suggestion.

The first commit contains the real change. The second commit is simply a cleanup where I switch to using more bikeshed markup and `[[]]`` symbols, in line with what we do for other private slots.

I also took this opportunity to describe more formally the `state` getter.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2312.html" title="Last updated on Apr 1, 2021, 5:01 PM UTC (f2314d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2312/8865bba...f2314d1.html" title="Last updated on Apr 1, 2021, 5:01 PM UTC (f2314d1)">Diff</a>