### PR TITLE
Standardizing h3/h4/h4 interface and dictionary markup. See Issue #2316

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7817,7 +7817,7 @@ Methods</h4>
 </dl>
 
 <h4 dictionary lt="iirfilteroptions" id="IIRFilterOptions">
-IIRFilterOptions</h4>
+{{IIRFilterOptions}}</h4>
 
 The <code>IIRFilterOptions</code> dictionary is used to specify the
 filter coefficients of the {{IIRFilterNode}}.

--- a/index.bs
+++ b/index.bs
@@ -30,7 +30,7 @@ Abstract: This specification describes a high-level Web <abbr title="Application
 	where a number of {{AudioNode}} objects are connected together to define the overall audio rendering.
 	The actual processing will primarily take place in the underlying implementation
 	(typically optimized Assembly / C / C++ code),
-	but [[#audioworklet|direct script processing and synthesis]] is also supported.
+	but [[#AudioWorklet|direct script processing and synthesis]] is also supported.
 
 	The [[#introductory]] section covers the motivation behind this specification.
 
@@ -292,7 +292,7 @@ The API supports these primary features:
 		peer using a {{MediaStreamAudioDestinationNode}}
 		and [[!webrtc]].
 
-* Audio stream synthesis and processing [[#audioworklet|directly using scripts]].
+* Audio stream synthesis and processing [[#AudioWorklet|directly using scripts]].
 
 * [[#Spatialization|Spatialized audio]] supporting a wide
 	range of 3D games and immersive environments:
@@ -322,7 +322,7 @@ The API supports these primary features:
 
 * Dynamics compression for overall control and sweetening of the mix
 
-* Efficient [[#analysernode|real-time time-domain and frequency-domain analysis / music visualizer support]].
+* Efficient [[#AnalyserNode|real-time time-domain and frequency-domain analysis / music visualizer support]].
 
 * Efficient biquad filters for lowpass, highpass, and other common filters.
 

--- a/index.bs
+++ b/index.bs
@@ -1884,7 +1884,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 id="AudioContextOptions">
+<h4 dictionary lt="audiocontextoptions" id="AudioContextOptions">
 {{AudioContextOptions}}</h4>
 
 The {{AudioContextOptions}} dictionary is used to
@@ -1928,7 +1928,7 @@ Dictionary {{AudioContextOptions}} Members</h5>
 		this {{AudioContext}} is used.
 </dl>
 
-<h4 id="AudioTimestamp">
+<h4 dictionary lt="audiotimestamp" id="AudioTimestamp">
 {{AudioTimestamp}}</h4>
 
 <pre class="idl">
@@ -2255,7 +2255,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 id="OfflineAudioContextOptions">
+<h4 dictionary lt="offlineaudiocontextoptions" id="OfflineAudioContextOptions">
 {{OfflineAudioContextOptions}}</h4>
 
 This specifies the options to use in constructing an
@@ -2309,7 +2309,7 @@ Attributes</h5>
 		An {{AudioBuffer}} containing the rendered audio data.
 </dl>
 
-<h5 id="OfflineAudioCompletionEventInit">
+<h5 dictionary lt="offlineaudiocompletioneventinit" id="OfflineAudioCompletionEventInit">
 {{OfflineAudioCompletionEventInit}}</h5>
 
 <pre class="idl">
@@ -2597,7 +2597,7 @@ the content of an {{AudioBuffer}} currently in use by an
 since the {{AudioNode}} will continue to use the data previously
 acquired.
 
-<h4 id="AudioBufferOptions">
+<h4 dictionary lt="audiobufferoptions" id="AudioBufferOptions">
 {{AudioBufferOptions}}</h4>
 
 This specifies the options to use in constructing an
@@ -3299,7 +3299,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 dictionary lt="AudioNodeOptions">
+<h4 dictionary lt="audionodeoptions" id="AudioNodeOptions">
 {{AudioNodeOptions}}</h4>
 
 This specifies the options that can be used in constructing all
@@ -4487,7 +4487,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 dictionary lt="AnalyserOptions">
+<h4 dictionary lt="analyseroptions" id="AnalyserOptions">
 {{AnalyserOptions}}</h4>
 
 This specifies the options to be used when constructing an
@@ -4916,7 +4916,7 @@ Methods</h4>
 
 </dl>
 
-<h4 dictionary lt="AudioBufferSourceOptions">
+<h4 dictionary lt="audiobuffersourceoptions" id="AudioBufferSourceOptions">
 {{AudioBufferSourceOptions}}</h4>
 
 This specifies options for constructing a
@@ -5759,7 +5759,7 @@ Attributes</h4>
 		{{BaseAudioContext/currentTime}}.
 </dl>
 
-<h4 dictionary lt="AudioProcessingEventInit">
+<h4 dictionary lt="audioprocessingeventinit" id="AudioProcessingEventInit">
 {{AudioProcessingEventInit}}</h4>
 
 <pre class="idl">
@@ -6143,7 +6143,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 dictionary lt="BiquadFilterOptions">
+<h4 dictionary lt="biquadfilteroptions" id="BiquadFilterOptions">
 {{BiquadFilterOptions}}</h4>
 
 This specifies the options to be used when constructing a
@@ -6470,7 +6470,7 @@ Constructors</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="ChannelMergerOptions">
+<h4 dictionary lt="channelmergeroptions" id="ChannelMergerOptions">
 {{ChannelMergerOptions}}</h4>
 
 <pre class="idl">
@@ -6583,7 +6583,7 @@ Constructors</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="ChannelSplitterOptions">
+<h4 dictionary lt="channelsplitteroptions" id="ChannelSplitterOptions">
 {{ChannelSplitterOptions}}</h4>
 
 <pre class="idl">
@@ -6686,7 +6686,7 @@ Attributes</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="ConstantSourceOptions">
+<h4 dictionary lt="constantsourceoptions" id="ConstantSourceOptions">
 {{ConstantSourceOptions}}</h4>
 
 This specifies options for constructing a
@@ -6921,7 +6921,7 @@ Attributes</h4>
 		<var>normalizationScale</var>.
 </dl>
 
-<h4 dictionary lt="ConvolverOptions">
+<h4 dictionary lt="convolveroptions" id="ConvolverOptions">
 {{ConvolverOptions}}</h4>
 
 The specifies options for constructing a
@@ -7086,7 +7086,7 @@ Attributes</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="DelayOptions">
+<h4 dictionary lt="delayoptions" id="DelayOptions">
 {{DelayOptions}}</h4>
 
 This specifies options for constructing a
@@ -7311,7 +7311,7 @@ Attributes</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="DynamicsCompressorOptions">
+<h4 dictionary lt="dynamicscompressoroptions" id="DynamicsCompressorOptions">
 {{DynamicsCompressorOptions}}</h4>
 
 This specifies the options to use in constructing a
@@ -7699,7 +7699,7 @@ Attributes</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="GainOptions">
+<h4 dictionary lt="gainoptions" id="GainOptions">
 {{GainOptions}}</h4>
 
 This specifies options to use in constructing a
@@ -7816,7 +7816,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 dictionary lt="IIRFilterOptions">
+<h4 dictionary lt="iirfilteroptions" id="IIRFilterOptions">
 IIRFilterOptions</h4>
 
 The <code>IIRFilterOptions</code> dictionary is used to specify the
@@ -7971,7 +7971,7 @@ Attributes</h4>
 		{{MediaElementAudioSourceNode}}.
 </dl>
 
-<h4 dictionary lt="MediaElementAudioSourceOptions">
+<h4 dictionary lt="mediaelementaudiosourceoptions" id="MediaElementAudioSourceOptions">
 {{MediaElementAudioSourceOptions}}</h4>
 
 This specifies the options to use in constructing a
@@ -8165,7 +8165,7 @@ Attributes</h4>
 	:: The {{MediaStream}} used when constructing this {{MediaStreamAudioSourceNode}}.
 </dl>
 
-<h4 dictionary lt="MediaStreamAudioSourceOptions">
+<h4 dictionary lt="mediastreamaudiosourceoptions" id="MediaStreamAudioSourceOptions">
 {{MediaStreamAudioSourceOptions}}</h4>
 
 This specifies the options for constructing a {{MediaStreamAudioSourceNode}}.
@@ -8229,7 +8229,7 @@ Constructors</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="MediaStreamTrackAudioSourceOptions">
+<h4 dictionary lt="mediastreamtrackaudiosourceoptions" id="MediaStreamTrackAudioSourceOptions">
 {{MediaStreamTrackAudioSourceOptions}}</h4>
 
 This specifies the options for constructing a
@@ -8441,7 +8441,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 dictionary lt="OscillatorOptions">
+<h4 dictionary lt="oscillatoroptions" id="OscillatorOptions">
 {{OscillatorOptions}}</h4>
 
 This specifies the options to be used when constructing an
@@ -9010,7 +9010,7 @@ Methods</h4>
 		</div>
 </dl>
 
-<h4 dictionary lt="PannerOptions">
+<h4 dictionary lt="panneroptions" id="PannerOptions">
 {{PannerOptions}}</h3>
 
 This specifies options for constructing a
@@ -9151,7 +9151,7 @@ Constructors</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="PeriodicWaveConstraints">
+<h4 dictionary lt="periodicwaveconstraints" id="PeriodicWaveConstraints">
 {{PeriodicWaveConstraints}}</h4>
 
 The {{PeriodicWaveConstraints}} dictionary is used to
@@ -9174,7 +9174,7 @@ Dictionary {{PeriodicWaveConstraints}} Members</h5>
 		the waveform is normalized.
 </dl>
 
-<h4 dictionary lt="PeriodicWaveOptions">
+<h4 dictionary lt="periodicwaveoptions" id="PeriodicWaveOptions">
 {{PeriodicWaveOptions}}</h4>
 
 The {{PeriodicWaveOptions}} dictionary is used to specify
@@ -9474,7 +9474,7 @@ Attributes</h4>
 		</pre>
 </dl>
 
-<h4 dictionary lt="StereoPannerOptions">
+<h4 dictionary lt="stereopanneroptions" id="StereoPannerOptions">
 {{StereoPannerOptions}}</h4>
 
 This specifies the options to use in constructing a
@@ -9722,7 +9722,7 @@ Attributes</h4>
 		another.
 </dl>
 
-<h4 dictionary lt="WaveShaperOptions">
+<h4 dictionary lt="waveshaperoptions" id="WaveShaperOptions">
 {{WaveShaperOptions}}</h4>
 
 This specifies the options for constructing a
@@ -10332,7 +10332,7 @@ Attributes</h5>
 		resources to be [[html#ports-and-garbage-collection|collected]].
 </dl>
 
-<h5 dictionary lt="AudioWorkletNodeOptions">
+<h5 dictionary lt="audioworkletnodeoptions" id="AudioWorkletNodeOptions">
 {{AudioWorkletNodeOptions}}</h5>
 
 The {{AudioWorkletNodeOptions}} dictionary can be used
@@ -10660,7 +10660,7 @@ transferred.
 
 </dl>
 
-<h5 dictionary lt="AudioParamDescriptor">
+<h5 dictionary lt="audioparamdescriptor" id="AudioParamDescriptor">
 {{AudioParamDescriptor}}</h5>
 
 The {{AudioParamDescriptor}} dictionary is used to

--- a/index.bs
+++ b/index.bs
@@ -658,7 +658,7 @@ The Audio API</h2>
 ████████  ██     ██  ██████  ████████       ██     ██  ██████
 -->
 
-<h3 id="BaseAudioContext">
+<h3 interface lt="baseaudiocontext" id="BaseAudioContext">
 The {{BaseAudioContext}} Interface</h3>
 
 This interface represents a set of {{AudioNode}}
@@ -1319,7 +1319,7 @@ processing.
 ██     ██  ██████
 -->
 
-<h3 id="AudioContext">
+<h3 interface lt="audiocontext" id="AudioContext">
 The {{AudioContext}} Interface</h3>
 
 This interface represents an audio graph whose
@@ -1964,7 +1964,7 @@ Dictionary {{AudioTimestamp}} Members</h5>
  ███████  ██       ██       ████████ ████ ██    ██ ████████       ██     ██  ██████
 -->
 
-<h3 id="OfflineAudioContext">
+<h3 interface lt="offlineaudiocontext" id="OfflineAudioContext">
 The {{OfflineAudioContext}} Interface</h3>
 
 {{OfflineAudioContext}} is a particular type of
@@ -2286,7 +2286,7 @@ Dictionary {{OfflineAudioContextOptions}} Members</h5>
 		The sample rate for this {{OfflineAudioContext}}.
 </dl>
 
-<h4 id="OfflineAudioCompletionEvent">
+<h4 interface lt="offlineaudiocompletionevent" id="OfflineAudioCompletionEvent">
 The {{OfflineAudioCompletionEvent}} Interface</h4>
 
 This is an {{Event}} object which is dispatched to
@@ -2337,7 +2337,7 @@ Dictionary {{OfflineAudioCompletionEventInit}} Members</h6>
 ██     ██  ███████  ████████  ████  ███████  ████████   ███████  ██       ██       ████████ ██     ██
 -->
 
-<h3 id="AudioBuffer">
+<h3 interface lt="audiobuffer" id="AudioBuffer">
 The {{AudioBuffer}} Interface</h3>
 
 This interface represents a memory-resident audio asset. It can contain one or
@@ -2643,7 +2643,7 @@ The allowed values for the members of this dictionary are constrained.  See {{Ba
 -->
 
 
-<h3 interface lt=AudioNode>
+<h3 interface lt="audionode" id="AudioNode">
 The {{AudioNode}} Interface</h3>
 
 {{AudioNode}}s are the building blocks of an {{AudioContext}}. This interface
@@ -3338,7 +3338,7 @@ Dictionary {{AudioNodeOptions}} Members</h5>
 ██     ██  ███████  ████████  ████  ███████  ██        ██     ██ ██     ██ ██     ██ ██     ██
 -->
 
-<h3 id="AudioParam" interface lt="AudioParam">
+<h3 interface lt="audioparam" id="AudioParam">
 The {{AudioParam}} Interface</h3>
 
 {{AudioParam}} controls an individual aspect of an
@@ -4084,7 +4084,7 @@ http://googlechrome.github.io/web-audio-samples/samples/audio/timeline.html -->
 ██     ██  ██████   ██████  ██    ██  ███████  ████████  ████████
 -->
 
-<h3 id="AudioScheduledSourceNode" interface lt="AudioScheduledSourceNode">
+<h3 interface lt="audioscheduledsourcenode" id="AudioScheduledSourceNode">
 The {{AudioScheduledSourceNode}} Interface</h3>
 
 The interface represents the common features of source nodes such
@@ -4246,7 +4246,7 @@ Methods</h4>
 ██     ██ ██    ██ ██     ██ ████████    ██     ██████  ████████ ██     ██ ██    ██  ███████  ████████  ████████
 -->
 
-<h3 interface lt="AnalyserNode">
+<h3 interface lt="analysernode" id="AnalyserNode">
 The {{AnalyserNode}} Interface</h3>
 
 This interface represents a node which is able to provide real-time
@@ -4657,7 +4657,7 @@ In the following, let \(N\) be the value of the
 ██     ██ ████████   ██████   ███████   ███████  ██     ██  ██████  ████████ ██    ██  ███████  ████████  ████████
 -->
 
-<h3 interface lt="AudioBufferSourceNode" id="AudioBufferSourceNode">
+<h3 interface lt="audiobuffersourcenode" id="AudioBufferSourceNode">
 The {{AudioBufferSourceNode}} Interface</h3>
 
 This interface represents an audio source from an in-memory audio
@@ -5313,7 +5313,7 @@ were references to exact sample frames:
 ████████  ████████  ██████     ██    ████ ██    ██ ██     ██    ██    ████  ███████  ██    ██
 -->
 
-<h3 interface lt="AudioDestinationNode" id="AudioDestinationNode">
+<h3 interface lt="audiodestinationnode" id="AudioDestinationNode">
 The {{AudioDestinationNode}} Interface</h3>
 
 This is an {{AudioNode}} representing the final audio
@@ -5408,7 +5408,7 @@ Attributes</h4>
 ████████ ████  ██████     ██    ████████ ██    ██ ████████ ██     ██
 -->
 
-<h3 interface lt="AudioListener">
+<h3 interface lt="audiolistener" id="AudioListener">
 The {{AudioListener}} Interface</h3>
 
 This interface represents the position and orientation of the person
@@ -5703,7 +5703,7 @@ the graph have the {{AudioListener}} as input.
 ██        ██     ██  ███████   ██████  ████████  ██████   ██████  ████ ██    ██  ██████
 -->
 
-<h3 interface lt="AudioProcessingEvent">
+<h3 interface lt="audioprocessingevent" id="AudioProcessingEvent">
 The {{AudioProcessingEvent}} Interface - DEPRECATED</h3>
 
 This is an {{Event}} object which is dispatched to
@@ -5790,7 +5790,7 @@ Dictionary {{AudioProcessingEventInit}} Members</h5>
 		of the event.
 </dl>
 
-<h3 interface lt="BiquadFilterNode">
+<h3 interface lt="biquadfilternode" id="BiquadFilterNode">
 The {{BiquadFilterNode}} Interface</h3>
 
 {{BiquadFilterNode}} is an
@@ -6390,7 +6390,7 @@ filter type, are:
 ██     ██ ████████ ██     ██  ██████   ████████ ██     ██
 -->
 
-<h3 interface lt="ChannelMergerNode">
+<h3 interface lt="channelmergernode" id="ChannelMergerNode">
 The {{ChannelMergerNode}} Interface</h3>
 
 The {{ChannelMergerNode}} is for use in more advanced
@@ -6506,7 +6506,7 @@ Dictionary {{ChannelMergerOptions}} Members</h5>
  ██████  ██        ████████ ████    ██       ██    ████████ ██     ██
 -->
 
-<h3 interface lt="ChannelSplitterNode">
+<h3 interface lt="channelsplitternode" id="ChannelSplitterNode">
 The {{ChannelSplitterNode}} Interface</h3>
 
 The {{ChannelSplitterNode}} is for use in more advanced
@@ -6619,7 +6619,7 @@ Dictionary {{ChannelSplitterOptions}} Members</h5>
  ██████   ███████   ███████  ██     ██  ██████  ████████
 -->
 
-<h3 interface lt="ConstantSourceNode" id="ConstantSourceNode">
+<h3 interface lt="constantsourcenode" id="ConstantSourceNode">
 The {{ConstantSourceNode}} Interface</h3>
 
 This interface represents a constant audio source whose output is
@@ -6719,7 +6719,7 @@ Dictionary {{ConstantSourceOptions}} Members</h5>
  ██████   ███████  ██    ██    ███     ███████  ████████    ███    ████████ ██     ██
 -->
 
-<h3 interface lt="ConvolverNode" id="ConvolverNode">
+<h3 interface lt="convolvernode" id="ConvolverNode">
 The {{ConvolverNode}} Interface</h3>
 
 This interface represents a processing node which applies a linear
@@ -6993,7 +6993,7 @@ Note: The diagrams below show the outputs when [=actively processing=].
 ████████  ████████ ████████ ██     ██    ██
 -->
 
-<h3 interface lt="DelayNode" id="DelayNode">
+<h3 interface lt="delaynode" id="DelayNode">
 The {{DelayNode}} Interface</h3>
 
 A delay-line is a fundamental building block in audio applications.
@@ -7162,7 +7162,7 @@ has passed.
  ██████   ███████  ██     ██ ██        ██     ██ ████████  ██████   ██████   ███████  ██     ██
 -->
 
-<h3 interface lt="DynamicsCompressorNode">
+<h3 interface lt="dynamicscompressornode" id="DynamicsCompressorNode">
 The {{DynamicsCompressorNode}} Interface</h3>
 
 {{DynamicsCompressorNode}} is an
@@ -7631,7 +7631,7 @@ of the same shape.
  ██████   ██     ██ ████ ██    ██ ██    ██  ███████  ████████  ████████
 -->
 
-<h3 interface lt="GainNode">
+<h3 interface lt="gainnode" id="GainNode">
 The {{GainNode}} Interface</h3>
 
 Changing the gain of an audio signal is a fundamental operation in
@@ -7731,7 +7731,7 @@ Dictionary {{GainOptions}} Members</h5>
 ████ ████ ██     ██ ██       ████ ████████    ██    ████████ ██     ██
 -->
 
-<h3 interface lt="IIRFilterNode">
+<h3 interface lt="iirfilternode" id="IIRFilterNode">
 The {{IIRFilterNode}} Interface</h3>
 
 {{IIRFilterNode}} is an {{AudioNode}}
@@ -7894,7 +7894,7 @@ Note: The UA may produce a warning to notify the user that NaN values have occur
 ██     ██  ███████  ████████  ████  ███████   ██████   ███████   ███████  ██     ██  ██████  ████████
 -->
 
-<h3 interface lt="MediaElementAudioSourceNode">
+<h3 interface lt="mediaelementaudiosourcenode" id="MediaElementAudioSourceNode">
 The {{MediaElementAudioSourceNode}} Interface</h3>
 
 This interface represents an audio source from an <{audio}>
@@ -8015,7 +8015,7 @@ algorithm</a> [[!FETCH]] labeled the resource as
 <!-- Big Text: Audio -->
 <!-- Big Text: Destination -->
 
-<h3 interface lt="MediaStreamAudioDestinationNode">
+<h3 interface lt="mediastreamaudiodestinationnode" id="MediaStreamAudioDestinationNode">
 The {{MediaStreamAudioDestinationNode}} Interface</h3>
 
 This interface is an audio destination representing a
@@ -8079,7 +8079,7 @@ Attributes</h4>
 <!-- Big Text: MediaStream -->
 <!-- Big Text: AudioSource -->
 
-<h3 interface lt="MediaStreamAudioSourceNode">
+<h3 interface lt="mediastreamaudiosourcenode" id="MediaStreamAudioSourceNode">
 The {{MediaStreamAudioSourceNode}} Interface</h3>
 
 This interface represents an audio source from a
@@ -8189,7 +8189,7 @@ Dictionary {{MediaStreamAudioSourceOptions}} Members</h5>
 <!-- Big Text: TrackAudio -->
 <!-- Big Text: Source -->
 
-<h3 interface lt="MediaStreamTrackAudioSourceNode">
+<h3 interface lt="mediastreamtrackaudiosourcenode" id="MediaStreamTrackAudioSourceNode">
 The {{MediaStreamTrackAudioSourceNode}} Interface</h3>
 
 This interface represents an audio source from a {{MediaStreamTrack}}.
@@ -8257,7 +8257,7 @@ Dictionary {{MediaStreamTrackAudioSourceOptions}} Members</h5>
 
 <!-- Big Text: Oscillator -->
 
-<h3 interface lt="OscillatorNode">
+<h3 interface lt="oscillatornode" id="OscillatorNode">
 The {{OscillatorNode}} Interface</h3>
 
 {{OscillatorNode}} represents an audio source
@@ -8558,7 +8558,7 @@ basic waveforms.
 
 <!-- Big Text: Panner -->
 
-<h3 interface lt="PannerNode">
+<h3 interface lt="pannernode" id="PannerNode">
 The {{PannerNode}} Interface</h3>
 
 This interface represents a processing node which
@@ -9092,7 +9092,7 @@ to {{PannerNode}}.
 
 <!-- Big Text: Periodic -->
 
-<h3 interface lt="PeriodicWave">
+<h3 interface lt="periodicwave" id="PeriodicWave">
 The {{PeriodicWave}} Interface</h3>
 
 {{PeriodicWave}} represents an arbitrary periodic waveform to be used
@@ -9329,7 +9329,7 @@ for \(n \ge 1\) is specified below.
 <!-- Big Text: Script -->
 <!-- Big Text: Processor -->
 
-<h3 interface lt="ScriptProcessorNode">
+<h3 interface lt="scriptprocessornode" id="ScriptProcessorNode">
 The {{ScriptProcessorNode}} Interface - DEPRECATED</h3>
 
 This interface is an {{AudioNode}} which can
@@ -9401,7 +9401,7 @@ Attributes</h4>
 <!-- Big Text: Stereo -->
 <!-- Big Text: Panner -->
 
-<h3 interface lt="StereoPannerNode">
+<h3 interface lt="stereopannernode" id="StereoPannerNode">
 The {{StereoPannerNode}} Interface</h3>
 
 This interface represents a processing node which positions an
@@ -9511,7 +9511,7 @@ approaches to panning and mixing.
 <!-- Big Text: Wave -->
 <!-- Big Text: Shaper -->
 
-<h3 interface lt="WaveShaperNode">
+<h3 interface lt="waveshapernode" id="WaveShaperNode">
 The {{WaveShaperNode}} Interface</h3>
 
 {{WaveShaperNode}} is an
@@ -9750,7 +9750,7 @@ Dictionary {{WaveShaperOptions}} Members</h5>
 
 <!-- Big Text: AudioWorklet -->
 
-<h3 interface lt="AudioWorklet">
+<h3 interface lt="audioworklet" id="AudioWorklet">
 The {{AudioWorklet}} Interface</h3>
 
 <pre class="idl">
@@ -9841,7 +9841,7 @@ created in {{AudioWorkletGlobalScope}}. These two objects
 communicate via the asynchronous message passing described in
 [[#processing-model]].
 
-<h4 interface lt="AudioWorkletGlobalScope">
+<h4 interface lt="audioworkletglobalscope" id="AudioWorkletGlobalScope">
 The {{AudioWorkletGlobalScope}} Interface</h4>
 
 This special execution context is designed to enable the
@@ -10116,7 +10116,7 @@ the <a>rendering thread</a> will invoke the algorithm below:
 		1. Empty the [=pending processor construction data=] slot.
 	</div>
 
-<h4 interface lt="AudioWorkletNode">
+<h4 interface lt="audioworkletnode" id="AudioWorkletNode">
 The {{AudioWorkletNode}} Interface</h4>
 
 This interface represents a user-defined {{AudioNode}} which
@@ -10437,7 +10437,7 @@ used to configure various channel configurations.
 			<var>node</var> to 1 and return.
 </div>
 
-<h4 interface lt="AudioWorkletProcessor">
+<h4 interface lt="audioworkletprocessor" id="AudioWorkletProcessor">
 The {{AudioWorkletProcessor}} Interface</h4>
 
 This interface represents an audio processing code that runs on the


### PR DESCRIPTION
For more info, see Issue #2316 

I've updated the markup for 37 interfaces and 29 dictionaries.  For a list of links, please see the following gist:
https://gist.github.com/skratchdot/6f98d30ae8d7a3de01feb475c4b6df93#file-updated-idls-md

Out of the 37 interfaces in the spec, this PR standardizes the markup for the 36 interfaces that have
header tags (and show up in the left navigation).  There is 1 interface in the spec that does not have
it's own header/left nav entry:
- AudioParamMap

Here is the script I used to update the `index.bs` file:
https://gist.github.com/skratchdot/6f98d30ae8d7a3de01feb475c4b6df93#file-update-index-sh
```
#!/bin/bash

interfaces="AnalyserNode AudioBuffer AudioBufferSourceNode AudioContext AudioDestinationNode AudioListener AudioNode AudioParam AudioParamMap AudioProcessingEvent AudioScheduledSourceNode AudioWorklet AudioWorkletGlobalScope AudioWorkletNode AudioWorkletProcessor BaseAudioContext BiquadFilterNode ChannelMergerNode ChannelSplitterNode ConstantSourceNode ConvolverNode DelayNode DynamicsCompressorNode GainNode IIRFilterNode MediaElementAudioSourceNode MediaStreamAudioDestinationNode MediaStreamAudioSourceNode MediaStreamTrackAudioSourceNode OfflineAudioCompletionEvent OfflineAudioContext OscillatorNode PannerNode PeriodicWave ScriptProcessorNode StereoPannerNode WaveShaperNode"
dictionaries="AnalyserOptions AudioBufferOptions AudioBufferSourceOptions AudioContextOptions AudioNodeOptions AudioParamDescriptor AudioProcessingEventInit AudioTimestamp AudioWorkletNodeOptions BiquadFilterOptions ChannelMergerOptions ChannelSplitterOptions ConstantSourceOptions ConvolverOptions DelayOptions DynamicsCompressorOptions GainOptions IIRFilterOptions MediaElementAudioSourceOptions MediaStreamAudioSourceOptions MediaStreamTrackAudioSourceOptions OfflineAudioCompletionEventInit OfflineAudioContextOptions OscillatorOptions PannerOptions PeriodicWaveConstraints PeriodicWaveOptions StereoPannerOptions WaveShaperOptions"

for i in $interfaces; do
  lcase="$(tr [A-Z] [a-z] <<< "$i")"
  gsed -i -E "s/^<h3 .*[=\"]$i[\" \>].*$/<h3 interface lt=\"$lcase\" id=\"$i\">/" index.bs
  gsed -i -E "s/^<h4 .*[=\"]$i[\" \>].*$/<h4 interface lt=\"$lcase\" id=\"$i\">/" index.bs
done

for i in $dictionaries; do
  lcase="$(tr [A-Z] [a-z] <<< "$i")"
  gsed -i -E "s/^<h4 .*[=\"]$i[\" \>].*$/<h4 dictionary lt=\"$lcase\" id=\"$i\">/" index.bs
  gsed -i -E "s/^<h5 .*[=\"]$i[\" \>].*$/<h5 dictionary lt=\"$lcase\" id=\"$i\">/" index.bs
done
```

If we ever need to change the h3/h4/h4 markup again, we can probably re-use something similar.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 13, 2021, 11:17 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWebAudio%2Fweb-audio-api%2Fpull%2F2317%2Fe29a1cd.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fskratchdot%2Fweb-audio-api%2Fpull%2F2317.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232317.)._
</details>
