### PR TITLE
Restore empty of pending processor construction data after successful…

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10509,6 +10509,9 @@ Constructors</h5>
 			1. Set <var>processor</var>’s
 				{{AudioWorkletProcessor/port}}
 				to <var>deserializedPort</var>.
+
+			1. Empty the [=pending processor construction data=]
+				slot.
 		</div>
 </dl>
 


### PR DESCRIPTION
… initialization of AudioWorkletProcessor#port

https://github.com/WebAudio/web-audio-api/pull/2306/files moved two "Empty the [=pending processor construction data=] slot" steps from the AudioWorkletProcessor constructor into one step in "The instantiation of AudioWorkletProcessor" algorithm.

However, we need to keep one of the steps in the AudioWorkletProcessor constructor in order to keep the behavior of allowing only one AudioWorkletProcessor with the construction data, as intended in https://github.com/WebAudio/web-audio-api/pull/2049#pullrequestreview-280367894 and tested in https://github.com/web-platform-tests/wpt/pull/21454

Followup for https://github.com/WebAudio/web-audio-api/issues/2119


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 13, 2021, 8:22 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWebAudio%2Fweb-audio-api%2Fpull%2F2318%2Fe29a1cd.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkarlt%2Fweb-audio-api%2Fpull%2F2318.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232318.)._
</details>
