### PR TITLE
Fix #2324:  Update link-defaults and add impl report

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,7 @@ Editor: Hongchan Choi, Google (https://www.google.com/), hongchan@google.com, w3
 Former Editor: Raymond Toy (until Oct 2018)
 Former Editor: Chris Wilson (Until Jan 2016)
 Former Editor: Chris Rogers (Until Aug 2013)
+Implementation report: https://webaudio.github.io/web-audio-api/implementation-report.html
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webaudio
 Repository: WebAudio/web-audio-api
 Abstract: This specification describes a high-level Web <abbr title="Application Programming Interface">API</abbr>
@@ -46,9 +47,10 @@ Markup Shorthands: markdown on, dfn on, css off
 spec: ECMAScript; url: https://tc39.github.io/ecma262/#sec-data-blocks; type: dfn; text: data block;
 url: https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia; type: method; for: MediaDevices; text: getUserMedia()
 </pre>
-<!-- We want {{object}} to go to the WebIDL object -->
+<!-- We want {{object}} and {{Promise}} to go to the WebIDL object -->
 <pre class=link-defaults>
 spec:webidl; type:interface; text:object
+spec:webidl; type:interface; text:Promise
 </pre>
 <link rel="preload" href="https://www.w3.org/scripts/MathJax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML" as="script">
 <link rel="preload" href="https://www.w3.org/scripts/MathJax/2.7.5/jax/output/HTML-CSS/jax.js?rev=2.7.5" as="script">


### PR DESCRIPTION
Add the Implementation Report metadata entry (useful for CR), and update the link-defaults so `Promise` refers to webIDL, not CSS.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2325.html" title="Last updated on Apr 29, 2021, 9:31 PM UTC (fc12303)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2325/0bc0ccf...rtoy:fc12303.html" title="Last updated on Apr 29, 2021, 9:31 PM UTC (fc12303)">Diff</a>