### PR TITLE
Fix #2324: Don't need full path to impl report

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,7 +22,7 @@ Editor: Hongchan Choi, Google (https://www.google.com/), hongchan@google.com, w3
 Former Editor: Raymond Toy (until Oct 2018)
 Former Editor: Chris Wilson (Until Jan 2016)
 Former Editor: Chris Rogers (Until Aug 2013)
-Implementation report: https://webaudio.github.io/web-audio-api/implementation-report.html
+Implementation Report: implementation-report.html
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webaudio
 Repository: WebAudio/web-audio-api
 Abstract: This specification describes a high-level Web <abbr title="Application Programming Interface">API</abbr>


### PR DESCRIPTION
We don't need to specify the full path to the implementation report.
The file name is good enough to get the link to the report.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2327.html" title="Last updated on Apr 29, 2021, 10:27 PM UTC (27ad9aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2327/3177aa1...rtoy:27ad9aa.html" title="Last updated on Apr 29, 2021, 10:27 PM UTC (27ad9aa)">Diff</a>