### PR TITLE
Fix #2322:  MediaStream must resampled to match the context sample rate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12691,7 +12691,8 @@ Change Log</h2>
 <h3 id="changes-2021-01-14">
   Since Candidate Recommendation of 14 January 2021
 </h3>
-<!-- Last updated: 2021-04-29 -->
+<!-- Last updated: 2021-04-30 -->
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2328">PR 2328</a>: MediaStream must be resampled to match the context sample rate
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2318">PR 2318</a>: Restore empty of pending processor construction data after successful initialization of AudioWorkProcessor#port.
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2317">PR 2317</a>: Standardize h3/h4 interface and dictionary markup
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2312">PR 2312</a>: Rework description of control thread state and rendering thread state

--- a/index.bs
+++ b/index.bs
@@ -7915,6 +7915,11 @@ channels of the media referenced by the
 <code>src</code> attribute can change the number of channels output
 by this node.
 
+If the sample rate of the {{HTMLMediaElement}} differs from the sample
+rate of the associated {{AudioContext}}, then the output from the
+{{HTMLMediaElement}} must be resampled to match the context's
+{{BaseAudioContext/sampleRate|sample rate}}.
+
 A {{MediaElementAudioSourceNode}} is created given an
 {{HTMLMediaElement}} using the {{AudioContext}}
 {{createMediaElementSource()}} method or the {{MediaElementAudioSourceOptions/mediaElement}} member of the {{MediaElementAudioSourceOptions}} dictionary for the {{MediaElementAudioSourceNode/MediaElementAudioSourceNode()|constructor}}.
@@ -8099,6 +8104,11 @@ the {{MediaStreamTrack}}. When the
 {{MediaStreamTrack}} ends, this
 {{AudioNode}} outputs one channel of silence.
 
+If the sample rate of the {{MediaStreamTrack}} differs from the sample
+rate of the associated {{AudioContext}}, then the output of the
+{{MediaStreamTrack}} is resampled to match the context's
+{{BaseAudioContext/sampleRate|sample rate}}.
+
 <pre class="idl">
 [Exposed=Window]
 interface MediaStreamAudioSourceNode : AudioNode {
@@ -8204,7 +8214,12 @@ macros:
 </pre>
 
 The number of channels of the output corresponds to the number of
-channels of the {{MediaStreamTrack}}.
+channels of the {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}}.
+
+If the sample rate of the {{MediaStreamTrack}} differs from the sample
+rate of the associated {{AudioContext}}, then the output of the
+{{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}} is resampled
+to match the context's {{BaseAudioContext/sampleRate|sample rate}}.
 
 <pre class="idl">
 [Exposed=Window]


### PR DESCRIPTION
This also applies to the MediaStreamAudioSourceNode and MediaStreamTrackAudioSourceNode.  The  MediaElementAudioSourceNode must also be resampled.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2328.html" title="Last updated on Apr 30, 2021, 4:23 PM UTC (c73ace4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2328/9a605b6...rtoy:c73ace4.html" title="Last updated on Apr 30, 2021, 4:23 PM UTC (c73ace4)">Diff</a>