### PR TITLE
Fix #2329: Add MIMESniff to normative references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12676,7 +12676,8 @@ Change Log</h2>
 <h3 id="changes-2021-01-14">
   Since Candidate Recommendation of 14 January 2021
 </h3>
-<!-- Last updated: 2021-04-29 -->
+<!-- Last updated: 2021-04-30 -->
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2331">PR 2331</a>: Add MIMESniff to normative references
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2318">PR 2318</a>: Restore empty of pending processor construction data after successful initialization of AudioWorkProcessor#port.
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2317">PR 2317</a>: Standardize h3/h4 interface and dictionary markup
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2312">PR 2312</a>: Rework description of control thread state and rendering thread state

--- a/index.bs
+++ b/index.bs
@@ -1130,7 +1130,7 @@ Methods</h4>
 		<{audio}> element. The buffer passed to
 		{{BaseAudioContext/decodeAudioData()}} has its
 		content-type determined by sniffing, as described in
-		[[mimesniff]].
+		[[!mimesniff]].
 
 		Although the primary method of interfacing with this function
 		is via its promise return value, the callback parameters are


### PR DESCRIPTION
Just replaces `[[mimesniff]]` with `[[!mimesniff]]` as suggested in the issue.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2331.html" title="Last updated on Apr 30, 2021, 5:46 PM UTC (29d7a5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2331/e520b43...rtoy:29d7a5a.html" title="Last updated on Apr 30, 2021, 5:46 PM UTC (29d7a5a)">Diff</a>