### PR TITLE
Fix #2332: Use bikeshed to link to ErrorEvent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12690,6 +12690,7 @@ Change Log</h2>
   Since Candidate Recommendation of 14 January 2021
 </h3>
 <!-- Last updated: 2021-04-30 -->
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2334">PR 2334</a>: Use bikeshed to link to ErrorEvent
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2328">PR 2328</a>: MediaStream must be resampled to match the context sample rate
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2318">PR 2318</a>: Restore empty of pending processor construction data after successful initialization of AudioWorkProcessor#port.
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2317">PR 2317</a>: Standardize h3/h4 interface and dictionary markup

--- a/index.bs
+++ b/index.bs
@@ -10126,9 +10126,7 @@ the <a>rendering thread</a> will invoke the algorithm below:
 		1. <a spec=webidl lt=construct>Construct a callback function</a> from |processorCtor| with the argument
 			of |deserializedOptions|. If any exceptions are thrown in the callback, <a>queue a task</a> to
 			the <a>control thread</a> to <a spec="dom" lt="fire an event">fire an event</a> named
-			`processorerror` using
-			<a href="https://www.w3.org/TR/html50/webappapis.html#the-errorevent-interface">ErrorEvent</a>
-			at |nodeReference|.
+			`processorerror` using {{ErrorEvent}} at |nodeReference|.
 
 		1. Empty the [=pending processor construction data=] slot.
 	</div>


### PR DESCRIPTION
We used a direct link to the ErrorEvent interface but we should be using `{{ErrorEvent}}`.   I checked that this does link to the WhatWG version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2334.html" title="Last updated on Apr 30, 2021, 5:34 PM UTC (3e31c1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2334/2338298...rtoy:3e31c1e.html" title="Last updated on Apr 30, 2021, 5:34 PM UTC (3e31c1e)">Diff</a>