### PR TITLE
Fix #2333: Update links to point to W3C

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1589,7 +1589,7 @@ Methods</h4>
 		that were connected to an {{AudioContext}} will have their
 		output ignored. That is, these will no longer cause any output
 		to speakers or other output devices. For more flexibility in
-		behavior, consider using <a href="https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream()">
+		behavior, consider using <a href="https://www.w3.org/TR/mediacapture-fromelement/#dom-htmlmediaelement-capturestream()">
 		<code>HTMLMediaElement.captureStream()</code></a>.
 
 		Note: When an {{AudioContext}} has been closed, implementation can
@@ -1670,7 +1670,7 @@ Methods</h4>
 		corresponding to the stored <code>contextTime</code> value was
 		rendered by the audio output device, in the same units and
 		origin as <code>performance.now()</code> (described in
-		[[!hr-time-2]]).
+		[[!hr-time-3]]).
 
 		If the context's rendering graph has not yet processed a block
 		of audio, then {{getOutputTimestamp}} call
@@ -1953,7 +1953,7 @@ Dictionary {{AudioTimestamp}} Members</h5>
 	::
 		Represents a point in the time coordinate system of a
 		<code>Performance</code> interface implementation (described in
-		[[!hr-time-2]]).
+		[[!hr-time-3]]).
 </dl>
 
 <!--
@@ -12394,12 +12394,7 @@ more work than is possible in real-time given the CPU's speed.
 <h2 id="priv-sec">
 Security and Privacy Considerations</h2>
 
-The W3C TAG is developing a <a href="https://w3ctag.github.io/security-questionnaire/">Self-Review
-Questionnaire: Security and Privacy</a> for editors of specifications
-to informatively answer.
-
-Per the <a href="https://w3ctag.github.io/security-questionnaire/#questions">Questions
-to Consider</a>
+Per the [[security-privacy-questionnaire#questions]]:
 
 1. Does this specification deal with personally-identifiable information?
 
@@ -12464,8 +12459,7 @@ to Consider</a>
 	to determine this from {{getOutputTimestamp}}. Skew-based fingerprinting has also
 	been demonstrated
 	<a href="https://pdfs.semanticscholar.org/cfd2/6a17234696593919df3f880a235d6ac5871d.pdf">
-	by Nakibly et. al. for HTML</a>. The <a href="https://w3c.github.io/hr-time/#sec-privacy-security">
-	Privacy &amp; Security appendix of High Resolution Time</a> should be consulted for further
+	by Nakibly et. al. for HTML</a>. The [[hr-time-3#sec-privacy-security]] section should be consulted for further
 	information on clock resolution and drift.
 
 	Fingerprinting via latency is also possible; it might be possible to deduce this

--- a/index.bs
+++ b/index.bs
@@ -12684,6 +12684,7 @@ Change Log</h2>
   Since Candidate Recommendation of 14 January 2021
 </h3>
 <!-- Last updated: 2021-04-30 -->
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2333">PR 2333</a>: Update links to point to W3C versions
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2334">PR 2334</a>: Use bikeshed to link to ErrorEvent
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2331">PR 2331</a>: Add MIMESniff to normative references
  * <a href="https://github.com/WebAudio/web-audio-api/pull/2328">PR 2328</a>: MediaStream must be resampled to match the context sample rate


### PR DESCRIPTION
This replaces the links to https://w3c.github.io/hr-time/ with
`[[hr-time-3]]`.  We also replaced all uses of `[[hr-time-2]]` with
`[[hr-time-3]]`.

Links to https://w3ctag.github.io/security-questionnaire/ have been
replaced with `[[security-privacy-questionnaire#]]`.  Also the paragraph about the W3C TAG "developing a self-review questionnaire" has been deleted, since the questionnaire is done.

Finally, https://w3c.github.io/mediacapture-fromelement/ is replaced
by https://www.w3.org/TR/mediacapture-fromelement/.  (I don't know how
to get bikeshed to do that.)

The link to the Audio EQ cookbook is unchanged right now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2335.html" title="Last updated on May 3, 2021, 8:23 PM UTC (0495b95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2335/4780f39...rtoy:0495b95.html" title="Last updated on May 3, 2021, 8:23 PM UTC (0495b95)">Diff</a>