### PR TITLE
Fix #2336: Fix broken link to hot-or-not

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12454,7 +12454,7 @@ Per the [[security-privacy-questionnaire#questions]]:
 	output of any node.
 
 	Fingerprinting via clock skew
-	<a href="http://sec.cs.ucl.ac.uk/users/smurdoch/talks/eurobsdcon07hotornot.pdf">has
+	<a href="https://murdoch.is/talks/eurobsdcon07hotornot.pdf">has
 	been described by Steven J Murdoch and Sebastian Zander</a>. It might be possible
 	to determine this from {{getOutputTimestamp}}. Skew-based fingerprinting has also
 	been demonstrated


### PR DESCRIPTION
Address updated according to #2336.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2341.html" title="Last updated on May 5, 2021, 5:24 PM UTC (7f54b11)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2341/e1d04b7...rtoy:7f54b11.html" title="Last updated on May 5, 2021, 5:24 PM UTC (7f54b11)">Diff</a>