### PR TITLE
Fix #2337: Fix broken link to capturestream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1589,7 +1589,7 @@ Methods</h4>
 		that were connected to an {{AudioContext}} will have their
 		output ignored. That is, these will no longer cause any output
 		to speakers or other output devices. For more flexibility in
-		behavior, consider using <a href="https://www.w3.org/TR/mediacapture-fromelement/#dom-htmlmediaelement-capturestream()">
+		behavior, consider using <a href="https://www.w3.org/TR/mediacapture-fromelement/#dom-htmlmediaelement-capturestream">
 		<code>HTMLMediaElement.captureStream()</code></a>.
 
 		Note: When an {{AudioContext}} has been closed, implementation can


### PR DESCRIPTION
Address updated according to #2337.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2342.html" title="Last updated on May 5, 2021, 5:26 PM UTC (7298715)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2342/e1d04b7...rtoy:7298715.html" title="Last updated on May 5, 2021, 5:26 PM UTC (7298715)">Diff</a>