### PR TITLE
Fix #2340: Fix more ECMA262 links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -9963,31 +9963,31 @@ Methods</h5>
 				<span class="synchronous">throw a
 				{{NotSupportedError}}</span>.
 
-			1. If <var>name</var> alredy exists as a key in the
+			1. If <var>name</var> already exists as a key in the
 				<a>node name to processor constructor map</a>,
 				<span class="synchronous">throw a
 				{{NotSupportedError}}</span>.
 
 			1. If the result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-isconstructor">IsConstructor</a>(argument=<var>processorCtor</var>)</code>
+				<code><a href="https://tc39.es/ecma262#sec-isconstructor">IsConstructor</a>(argument=<var>processorCtor</var>)</code>
 				is <code>false</code>,
 				<span class="synchronous">throw a {{TypeError}}
 				</span>.
 
 			1. Let <code><em>prototype</em></code> be the result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+				<code><a href="https://tc39.es/ecma262#sec-get-o-p">
 				Get</a>(O=<i>processorCtor</i>,
 				P="prototype")</code>.
 
 			1. If the result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">Type</a>(argument=<i>prototype</i>)</code>
+				<code><a href="https://tc39.es/ecma262#sec-ecmascript-data-types-and-values">Type</a>(argument=<i>prototype</i>)</code>
 				is not <code>Object</code>,
 				<span class="synchronous">throw a {{TypeError}}
 				</span>.
 
 			1. Let <var>parameterDescriptorsValue</var> be the
 				result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
+				<code><a href="https://tc39.es/ecma262#sec-get-o-p">Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
 
 			1. If <var>parameterDescriptorsValue</var> is not {{undefined}},
 				execute the following steps:


### PR DESCRIPTION
See
https://github.com/WebAudio/web-audio-api/issues/2340#issuecomment-832723050
for the other links that have been updated to `tc39.es`.

Also fixed a typo: "alredy" -> "already".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2344.html" title="Last updated on May 5, 2021, 11:01 PM UTC (f9e8086)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2344/1d4ff8a...rtoy:f9e8086.html" title="Last updated on May 5, 2021, 11:01 PM UTC (f9e8086)">Diff</a>