### PR TITLE
Fix #2338: Replace "present" with "exists"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6770,7 +6770,7 @@ Constructors</h4>
 		1. Set the attributes {{ConvolverNode/normalize}} to the inverse of the
 			value of {{ConvolverOptions/disableNormalization}}.
 		2. If {{ConvolverNode/buffer}}
-		        <a for=map>exists</a> , set the
+		        <a for=map>exists</a>, set the
 			{{ConvolverNode/buffer}} attribute to its value.
 
 			Note: This means that the buffer will be normalized according to the

--- a/index.bs
+++ b/index.bs
@@ -6769,8 +6769,8 @@ Constructors</h4>
 
 		1. Set the attributes {{ConvolverNode/normalize}} to the inverse of the
 			value of {{ConvolverOptions/disableNormalization}}.
-		2. If {{ConvolverNode/buffer}} is
-			<a href="https://heycam.github.io/webidl/#dfn-present">present</a>, set the
+		2. If {{ConvolverNode/buffer}}
+		        <a for=map>exists</a> , set the
 			{{ConvolverNode/buffer}} attribute to its value.
 
 			Note: This means that the buffer will be normalized according to the
@@ -6778,16 +6778,16 @@ Constructors</h4>
 			attribute.
 
 		3. Let <var>o</var> be new {{AudioNodeOptions}} dictionary.
-		4. If {{AudioNodeOptions/channelCount}} is
-			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+		4. If {{AudioNodeOptions/channelCount}}
+		        <a for=map>exists</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelCount}} on <var>o</var>
 			with the same value.
-		5. If {{AudioNodeOptions/channelCountMode}} is
-			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+		5. If {{AudioNodeOptions/channelCountMode}} 
+			<a for=map>exists</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelCountMode}} on
 			<var>o</var> with the same value.
-		6. If {{AudioNodeOptions/channelInterpretation}} is <a
-			href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+		6. If {{AudioNodeOptions/channelInterpretation}} 
+			<a for=map>exists</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelInterpretation}} on
 			<var>o</var> with the same value.
 		7. <a href="#audionode-constructor-init">Initialize the AudioNode</a>


### PR DESCRIPTION
The link
```
<a href="https://heycam.github.io/webidl/#dfn-present">present</a>
```
no longer exists and should be replaced with map-exists.  Instead of using the suggested replacement in #2338 of:
```
<a href="https://infra.spec.whatwg.org/#map-exists">present</a>
```
use the bikeshed-friendly:
```
<a for=map>exists</a>
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2348.html" title="Last updated on Jun 3, 2021, 5:57 PM UTC (c39485c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2348/b53d3d7...rtoy:c39485c.html" title="Last updated on Jun 3, 2021, 5:57 PM UTC (c39485c)">Diff</a>