### PR TITLE
Fix #2339: Fix ecma262 completion links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11354,7 +11354,7 @@ task queue=] of its associated {{BaseAudioContext}}.
 					IsCallable</a>(|processCallback|) is `false`, then:
 
 					1. Set |completion| to new
-						<a href="https://tc39.es/ecma262/#sec-completion">Completion</a>
+						<a href="https://tc39.es/ecma262/#sec-throwcompletion">Completion</a>
 						{\[[Type]]: throw, \[[Value]]: a newly created
 						<a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">
 						TypeError</a> object, \[[Target]]: empty}.
@@ -11398,7 +11398,7 @@ task queue=] of its associated {{BaseAudioContext}}.
 
 				1. <b id="audio-worklet-render-return">Return:</b> at this point |completion|
 					will be set to an ECMAScript
-					<a href="https://tc39.es/ecma262/#sec-completion">completion</a> value.
+					<a href="https://tc39.es/ecma262/#sec-completion-record-type-specification-type">completion</a> value.
 
 					1. [=Clean up after running a callback=] with the [=current settings object=].
 

--- a/index.bs
+++ b/index.bs
@@ -9963,31 +9963,31 @@ Methods</h5>
 				<span class="synchronous">throw a
 				{{NotSupportedError}}</span>.
 
-			1. If <var>name</var> alredy exists as a key in the
+			1. If <var>name</var> already exists as a key in the
 				<a>node name to processor constructor map</a>,
 				<span class="synchronous">throw a
 				{{NotSupportedError}}</span>.
 
 			1. If the result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-isconstructor">IsConstructor</a>(argument=<var>processorCtor</var>)</code>
+				<code><a href="https://tc39.es/ecma262#sec-isconstructor">IsConstructor</a>(argument=<var>processorCtor</var>)</code>
 				is <code>false</code>,
 				<span class="synchronous">throw a {{TypeError}}
 				</span>.
 
 			1. Let <code><em>prototype</em></code> be the result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">
+				<code><a href="https://tc39.es/ecma262#sec-get-o-p">
 				Get</a>(O=<i>processorCtor</i>,
 				P="prototype")</code>.
 
 			1. If the result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-data-types-and-values">Type</a>(argument=<i>prototype</i>)</code>
+				<code><a href="https://tc39.es/ecma262#sec-ecmascript-data-types-and-values">Type</a>(argument=<i>prototype</i>)</code>
 				is not <code>Object</code>,
 				<span class="synchronous">throw a {{TypeError}}
 				</span>.
 
 			1. Let <var>parameterDescriptorsValue</var> be the
 				result of
-				<code><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p">Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
+				<code><a href="https://tc39.es/ecma262#sec-get-o-p">Get</a>(O=<i>processorCtor</i>, P="parameterDescriptors")</code>.
 
 			1. If <var>parameterDescriptorsValue</var> is not {{undefined}},
 				execute the following steps:


### PR DESCRIPTION
Fix links as mentioned by @svgeesus in #2339.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2350.html" title="Last updated on Jun 3, 2021, 6:02 PM UTC (d8af143)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2350/1d4ff8a...rtoy:d8af143.html" title="Last updated on Jun 3, 2021, 6:02 PM UTC (d8af143)">Diff</a>