### PR TITLE
Address WebAudio/web-audio-api-v2#13: Explainer for user-selectable render size

### DIFF
--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -1,5 +1,5 @@
 # User-Selectable Render Size
-Raymond Toy
+Raymond Toy (rtoy@chromium.org)
 
 ## Background
 Historically, WebAudio has always rendered the graph in chunks of 128 frames,

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -1,0 +1,150 @@
+# User-Selectable Render Size
+Raymond Toy
+
+## Background
+Historically, WebAudio has always rendered the graph in chunks of 128 frames,
+called a [render
+quantum](https://webaudio.github.io/web-audio-api/#render-quantum) in the specification.
+This was probably a trade-off between function-call overhead and latency.
+A smaller number would reduce latency, but the function call overhead would
+increase.  With a larger value, the overhead is reduced, but the latency
+increases because any change takes 128 frames to before reaching the output.  In
+addition, Mac OS probably processed 128 frames at a time anyway.
+
+## Issues
+This has worked well over time, especially on desktop, but is particularly bad
+on Android where 128 may not fit in well with Android's audio processing.  The
+main problem is illustrated very well from the example from Paul Adenot in a
+[comment to issue #13](https://github.com/WebAudio/web-audio-api-v2/issues/13#issuecomment-572469654),
+reproduced below.
+
+The example is an Android phone that has a native processing buffer size
+of 192.  Since WebAudio processes 128 frames we have the following behavior:
+
+|iteration | #	number of frames to render |	number of buffers to render |	leftover frames|
+------------------------------------------------------------------------------------------------
+|0|	192|	2|	64|
+|1|	192|	1|	0|
+|2|	192|	2|	64|
+|3|	192|	1|	0|
+|4|	192|	2|	64|
+|5|	192|	1|	0|
+
+At a sample rate of 48 kHz, 128 frames would require 2.666 ms.  The net result
+is that the **peak** CPU usage is twice has high as might be expected since,
+every other time, you need to render the graph twice in 2.666 ms instead of once.
+Then the max complexity of the graph is unexpectedly limited because of this.
+
+However, if the WebAudio rendered 192 frames at a time, the CPU usage would
+remain constant, and more complex graphs could be rendered because the peak CPU
+would be same as the average.  This does increase latency a bit, but since
+Android is already using a size of 192, there is no actual additional latency.
+
+Finally, some applications do not need these low latency requirements, and may
+also want AudioWorklets to process larger blocks to reduce function call
+overhead.  In this case allowing render sizes of 1024 or 2048 could be
+appropriate.
+
+## API
+To allow user-selectable render size, we propose the following API:
+
+```idl
+// New enum
+enum AudioContextRenderSizeCategory {
+  "default",
+  "hardware"
+};
+
+dictionary AudioContextOptions {
+  (AudioContextLatencyCategory or double) latencyHint = "interactive";
+  float sampleRate;
+
+  // New addition
+  (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
+};
+
+dictionary OfflineAudioContextOptions {
+  unsigned long numberOfChannels = 1;
+  required unsigned long length;
+  required float sampleRate;
+  
+  // New addition
+  (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
+};
+
+partial interface BaseAudioContext {
+  unsigned long renderSize;
+};
+```
+
+This API assumes that we'll update `AudioContextOptions` and
+`OfflineAudioContextOptions` with a new member, `renderSizeHint`, instead of
+defining a new dictionary.
+
+The "default" category means WebAudio will use its default render size of 128
+as it currently does.
+
+When a value is given for `renderSizeHint`, the UA is allowed to modify the
+requested size to any appropriate size in a UA-specific way.
+
+In any case, the actual render size used by the UA is reported by the attribute
+`renderSize` of the `BaseAudioContext`.
+
+
+### "hardware" Category
+#### AudioContext
+For an `AudioContext`, the "hardware" category means WebAudio will ask the
+system for the appropriate render size for the output device.  The UA is allowed
+to choose the "hardware" value as appropriate; it does not necessary reflect
+what the OS may say is the hardware size.
+
+#### OfflineAudioContext
+For an 'OfflineAudioContext', there's no concept of "hardware", so "hardware" is
+equivalent to "default".  Allowing an `OfflineAudioContext` to have a selectable
+size enables testing of the render size.
+
+We explicitly do not support selecting a render size when using the 
+[3-arg constructor](https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate) for the `OfflineAudioContext`.
+
+## Requirements
+### Supported Sizes
+All UA's must support a `renderSize` that is a power of two between 32 and 2048,
+inclusive.
+
+It is highly recommended that other sizes that are not a power of two be
+supported.  This is particularly important on Android where sizes of 96, 144,
+192, and 240 are quite common.  The the problem isn't limited to Android.
+Windows generally wants 10 ms buffers so we want sizes of 440 or 480 for 44.1
+kHz and 48 kHz, respectively.
+
+### ScriptProcessorNode
+The [construction of a `ScriptProcessorNode`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor)
+requires a
+[`bufferSize`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize)
+argument that must be a power of two.  This is fine with appropriate buffering,
+but perhaps it would be better if the buffer sizes are defined to be a power of
+two times the render size.  So, while the current allowed sizes are 0, `128*2`,
+`128*2^2`, `128*2^3`, `128*2^4`, `128*2^5`, `128*2^6`, and `128*2^7`, we may
+want to specify the sizes as 0, `r*2`, `r*2^2`, `r*2^3`, `r*2^4`, `r*2^5`,
+`r*2^6`, and `r*2^7`, where `r` is the `renderSize`.
+
+
+# Implementation Issues
+Conceptually this change is relatively simple, but some nodes may have
+additional complexities.  It is up to the UA to handle these appropriately.
+
+## AnalyserNode Implementation
+The `AnalyserNode` currently specifies powers of two both for the size of the
+returned time-domain data and for the size of the frequency domain data.  This
+is probably ok.
+
+## ConvolverNode Implementation
+For efficiency, the `ConvolverNode` is often implemented using FFTs.  Typically,
+only power-of-two FFTs have been used because the render size was 128.  To
+support user-selectable sizes, either more complex algorithms are needed to
+buffer the data appropriately, or more general FFTs are required to support
+sizes that are not a power of two.  It is up to the discretion of the UA to
+implement this appropriately.
+
+## ScriptProcessorNode Implementation
+We've already proposed a change for the `ScriptProcessorNode`.

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -94,28 +94,42 @@ For an OfflineAudioContext, there's no concept of "hardware", so using
 
 ### New Dictionary Members
 #### AudioContextOptions
-```
-renderSizeHint, of type (AudioContextRenderSizeCategory or unsigned long),
-defaulting to "default"
-```
-Identifies the render size for the context.  The preferred value of the
-`renderSizeHint` is one of the values from the
-`AudioContextRenderSizeCategory`.  However, an unsigned long value may be given
-to request an exact number of frames to use for rendering.  Powers of two
-between 64 and 2048, inclusive MUST be supported.  It is recommended that UA's support
-values that are not a power of two.
+<dl>
+  <dt> renderSizeHint, of type (AudioContextRenderSizeCategory or unsigned long), defaulting to "default"
+  </dt>
 
-If the requested value is not supported by the UA, the UA MUST round the value
-up to the next smallest value that is supported.  If this exceeds the maximum
-supported value, it is clamped to the max.
+  <dd>
+  Identifies the render size for the context.  The preferred value of the
+  `renderSizeHint` is one of the values from the
+  `AudioContextRenderSizeCategory`.  However, an unsigned long value may be
+  given to request an exact number of frames to use for rendering.  Powers of
+  two between 64 and 2048, inclusive MUST be supported.  It is recommended that
+  UA's support values that are not a power of two.
+
+  If the requested value is not supported by the UA, the UA MUST round the value
+  up to the next smallest value that is supported.  If this exceeds the maximum
+  supported value, it is clamped to the max.
+  </dd>
+</dl>
+
 
 #### OfflineAudioContextOptions
-```
-renderSizeHint, of type (AudioContextRenderSizeCategory or unsigned long),
-defaulting to "default"
-```
-Same meaning and properties as for `AudioContextOptions`, except the "hardware"
-category is the same as the "default" category.
+<dl>
+  <dt> renderSizeHint, of type (AudioContextRenderSizeCategory or unsigned long), defaulting to "default"
+  </dt>
+
+  <dd>
+  Identifies the render size for the context.  The preferred value of the
+  `renderSizeHint` is one of the values from the
+  `AudioContextRenderSizeCategory`.  However, an unsigned long value may be
+  given to request an exact number of frames to use for rendering.  Powers of
+  two between 64 and 2048, inclusive MUST be supported.  It is recommended that
+  UA's support values that are not a power of two.
+
+  For an OfflineContext, the value of "hardware" is the same as "default".
+  </dd>
+</dl>
+
 
 ### BaseAudioContext New Attributes
 

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -77,11 +77,11 @@ partial interface BaseAudioContext {
 };
 ```
 
-### Enumeration description
+### Enumeration Description
 |Value|Description|
 |--|--|
 |"default"  | Default rendering size of 128 frames |
-|"hardware" | Use the appropriate value for the hardware |
+|"hardware" | Use an appropriate value for the hardware for an AudioContext or the default for an OfflineAudioContext|
 
 #### AudioContext
 For an AudioContext, the "hardware" category means a size is chosen that is

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -198,6 +198,13 @@ If, however, a render size of 1024 is selected, we have:
   larger than 1024.
 
 
+# Security and Privacy Issues
+When the user requests "hardware" for the render size, the user's hardware
+capability can be exposed and can be used to finger print the user.  While no UA
+is required to return exactly the hardware value, it is most beneficial if it
+actually did, as explained #issues.  But for privacy reasons, a UA can return a
+different value.
+
 # Implementation Issues
 Conceptually this change is relatively simple, but some nodes may have
 additional complexities.  It is up to the UA to handle these appropriately.
@@ -226,10 +233,3 @@ two times the render size.  So, while the current allowed sizes are 0, and
 `128*2^n`, for `n` = 1, 2, ..., 7., we may want to specify the sizes as 0,
 `r*2^n`, where `r` is the `renderSize`.
 
-
-# Security and Privacy Issues
-When the user requests "hardware" for the render size, the user's hardware
-capability can be exposed and can be used to finger print the user.  While no UA
-is required to return exactly the hardware value, it is most beneficial if it
-actually did, as explained <a href="#issues">issues</a>.  But for privacy reasons, a UA can return a
-different value.

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -164,11 +164,11 @@ way.  In particular, UAs that don't double buffer WebAudio's output, the
 
 However, for UAs that do double buffer, then, roughly, the `renderSize` chooses
 the minimum possible latency, and the `latencyHint` can increase this
-appropriately when possible.
+appropriately if needed.
 
 * If `renderSize` is "default", then 128 frames is used to render the graph and
   `latencyHint` behaves as before.
-* If 'renderSize` is "hardware", then the graph is rendered using the hardware
+* If `renderSize` is "hardware", then the graph is rendered using the hardware
   size.  The latency value is chosen appropriately but the resulting latency
   value cannot be smaller than the hardware size.
 * If `renderSize` is a number, the graph is rendered using the appropriate

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -234,6 +234,13 @@ buffer the data appropriately, or more general FFTs are required to support
 sizes that are not a power of two.  It is up to the discretion of the UA to
 implement this appropriately for all the supported render sizes.
 
+## DelayNode Implementation
+Since render size may be different from 128 frames, the minimum delay for a
+`DelayNode` in a loop is adjusted to match the selected render size.  Thus, if
+the render size is 256, loops containing a delay node must have a delay greater
+than or equal to this.  See step 4.2.6.1 in the processing algorithm in
+[Sec. 2.4. Rendering an Audio Graph](https://webaudio.github.io/web-audio-api/#rendering-loop). 
+
 ### ScriptProcessorNode
 The [construction of a
 `ScriptProcessorNode`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor)

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -5,7 +5,7 @@ Raymond Toy (rtoy@chromium.org)
 Historically, WebAudio has always rendered the graph in chunks of 128 frames,
 called a [render
 quantum](https://webaudio.github.io/web-audio-api/#render-quantum) in the
-specification.  This was probably a trade-off between function-call overhead and
+specification.  This was a trade-off between function-call overhead and
 latency.  A smaller number would reduce latency, but the function call overhead
 would increase.  With a larger value, the overhead is reduced, but the latency
 increases because any change takes more audio frames to reach the output.  In
@@ -37,7 +37,8 @@ Then the max complexity of the graph is unexpectedly limited because of this.
 
 However, if WebAudio rendered 192 frames at a time, the CPU usage would
 remain constant, and more complex graphs could be rendered because the peak CPU
-would be same as the average.  This does increase latency a bit, but since
+would be same as the average.  This does increase latency compared to a native
+size of 128, but since
 Android is already using a size of 192, there is no actual additional latency.
 
 Finally, some applications do not need these low latency requirements, and may
@@ -150,7 +151,7 @@ inclusive.
 
 It is highly recommended that other sizes that are not a power of two be
 supported.  This is particularly important on Android where sizes of 96, 144,
-192, and 240 are quite common.  The the problem isn't limited to Android.
+192, and 240 are quite common.  The problem isn't limited to Android.
 Windows generally wants 10 ms buffers so sizes of 440 or 480 for 44.1
 kHz and 48 kHz, respectively, should be supported.
 

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -184,7 +184,7 @@ Then, for
 
 * "interactive", the latency will be `192*n` where `n` is 1, 2, 3,..., and is
   chosen by the UA
-* "playback", the latency will be 20 ms.  This means the graph is rendered 5
+* "balanced", the latency will be 20 ms.  This means the graph is rendered 5
   times (`5*192` = `20 ms * 48 kHz`) per callback.
 * "playback", the latency will be 200 ms.  The graph is rendered 50 times per
   callback.
@@ -193,10 +193,20 @@ If, however, a render size of 1024 is selected, we have:
 
 * "interactive", the latency will be `1024*n` where `n` is 1, 2, 3,..., and is
   chosen by the UA
-* "playback", a latency of 20 ms is 960 frames, which is smaller than 1024.  The
-  resulting latency will be 1024 frames (21.33 sec).
+* "balanced", a latency of 20 ms is 960 frames, which is smaller than 1024.  The
+  resulting latency will be 1024 frames (21.33 msec).
 * "playback", the latency will be 200 ms since 200 ms is 9600 frames which is
   larger than 1024.
+  
+Finally, if the render size is 2048, we have:
+* "interactive", the latency will be `2048*n` where `n` is 1, 2, 3,..., and is
+  chosen by the UA
+* "balanced", a latency of 20 ms is 960 frames, which is greater than 2048.  The
+  resulting latency will be 2048 frames (42.67 msec).
+* "playback", the latency will be 200 ms since 200 ms is 9600 frames which is
+  larger than 2048.
+  
+
 
 
 # Security and Privacy Issues

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -78,7 +78,8 @@ partial interface BaseAudioContext {
 ```
 
 ### Enumeration description
-|||
+|Value|Description|
+|--|--|
 |"default"  | Default rendering size of 128 frames |
 |"hardware" | Use the appropriate value for the hardware |
 
@@ -140,38 +141,6 @@ supported.  This is particularly important on Android where sizes of 96, 144,
 Windows generally wants 10 ms buffers so sizes of 440 or 480 for 44.1
 kHz and 48 kHz, respectively, should be supported.
 
-### ScriptProcessorNode
-The [construction of a `ScriptProcessorNode`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor)
-requires a
-[`bufferSize`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize)
-argument that must be a power of two.  This is fine with appropriate buffering,
-but perhaps it would be better if the buffer sizes are defined to be a power of
-two times the render size.  So, while the current allowed sizes are 0, `128*2`,
-`128*2^2`, `128*2^3`, `128*2^4`, `128*2^5`, `128*2^6`, and `128*2^7`, we may
-want to specify the sizes as 0, `r*2`, `r*2^2`, `r*2^3`, `r*2^4`, `r*2^5`,
-`r*2^6`, and `r*2^7`, where `r` is the `renderSize`.
-
-
-# Implementation Issues
-Conceptually this change is relatively simple, but some nodes may have
-additional complexities.  It is up to the UA to handle these appropriately.
-
-## AnalyserNode Implementation
-The `AnalyserNode` currently specifies powers of two both for the size of the
-returned time-domain data and for the size of the frequency domain data.  This
-is probably ok.
-
-## ConvolverNode Implementation
-For efficiency, the `ConvolverNode` is often implemented using FFTs.  Typically,
-only power-of-two FFTs have been used because the render size was 128.  To
-support user-selectable sizes, either more complex algorithms are needed to
-buffer the data appropriately, or more general FFTs are required to support
-sizes that are not a power of two.  It is up to the discretion of the UA to
-implement this appropriately for all the supported render sizes.
-
-## ScriptProcessorNode Implementation
-We've already proposed a change for the `ScriptProcessorNode`.
-
 ## Interaction with `latencyHint`
 The
 [`latencyHint`](https://www.w3.org/TR/webaudio/#dom-audiocontextoptions-latencyhint)
@@ -209,5 +178,34 @@ If, however, a render size of 1024 is selected, we have:
   resulting latency will be 1024 frames (21.33 sec).
 * "playback", the latency will be 200 ms since 200 ms is 9600 frames which is
   larger than 1024.
+
+
+# Implementation Issues
+Conceptually this change is relatively simple, but some nodes may have
+additional complexities.  It is up to the UA to handle these appropriately.
+
+## AnalyserNode Implementation
+The `AnalyserNode` currently specifies powers of two both for the size of the
+returned time-domain data and for the size of the frequency domain data.  This
+is probably ok.
+
+## ConvolverNode Implementation
+For efficiency, the `ConvolverNode` is often implemented using FFTs.  Typically,
+only power-of-two FFTs have been used because the render size was 128.  To
+support user-selectable sizes, either more complex algorithms are needed to
+buffer the data appropriately, or more general FFTs are required to support
+sizes that are not a power of two.  It is up to the discretion of the UA to
+implement this appropriately for all the supported render sizes.
+
+### ScriptProcessorNode
+The [construction of a
+`ScriptProcessorNode`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor)
+requires a
+[`bufferSize`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize)
+argument that must be a power of two.  This is fine with appropriate buffering,
+but perhaps it would be better if the buffer sizes are defined to be a power of
+two times the render size.  So, while the current allowed sizes are 0, and
+`128*2^n`, for `n` = 1, 2, ..., 7., we may want to specify the sizes as 0,
+`r*2^n`, where `r` is the `renderSize`.
 
 

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -137,12 +137,14 @@ For an OfflineAudioContext, there's no concept of "hardware", so using
   <dt> renderSize, of type <code>unsigned long</code>, readonly
   </dt>
   <dd>
+    <p>
     This is the actual number of frames used to render the graph.  This may be
     different from the value requested by <code>renderSizeHint</code>.
-
+    </p>
+    <p>
     We explicitly do <bold>NOT</bold> support selecting a render size when using the
     <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">3-arg constructor</a> for the <code>OfflineAudioContext</code>.
-
+    </p>
   </dd>
 </dl>
 
@@ -229,5 +231,5 @@ two times the render size.  So, while the current allowed sizes are 0, and
 When the user requests "hardware" for the render size, the user's hardware
 capability can be exposed and can be used to finger print the user.  While no UA
 is required to return exactly the hardware value, it is most beneficial if it
-actually did, as explained #issues.  But for privacy reasons, a UA can return a
+actually did, as explained <a href="#issues">issues</a>.  But for privacy reasons, a UA can return a
 different value.

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -119,14 +119,9 @@ For an OfflineAudioContext, there's no concept of "hardware", so using
   </dt>
 
   <dd>
-  Identifies the render size for the context.  The preferred value of the
-  <code>renderSizeHint</code> is one of the values from the
-  <code>AudioContextRenderSizeCategory</code>.  However, an unsigned long value may be
-  given to request an exact number of frames to use for rendering.  Powers of
-  two between 64 and 2048, inclusive MUST be supported.  It is recommended that
-  UA's support values that are not a power of two.
-
-  For an OfflineContext, the value of "hardware" is the same as "default".
+  This has exactly the same meaning, behavior, and constraints as for an
+  `AudioContext`.  However, for an OfflineContext, the value of "hardware" is
+  the same as "default".
   </dd>
 </dl>
 
@@ -162,9 +157,14 @@ kHz and 48 kHz, respectively, should be supported.
 ## Interaction with `latencyHint`
 The
 [`latencyHint`](https://www.w3.org/TR/webaudio/#dom-audiocontextoptions-latencyhint)
-for an AudioContext interacts with the `renderSize` in the following way.
-Roughly, the `renderSize` choose the minimum possible latency, and the
-`latencyHint` can increase this appropriately when possible.
+for an AudioContext can interact with the `renderSize`.  The
+exact interaction between these is up to the UA to implement in a meaningful
+way.  In particular, UAs that don't double buffer WebAudio's output, the
+`latencyHint` value can be 0, independent of the `renderSize`.
+
+However, for UAs that do double buffer, then, roughly, the `renderSize` chooses
+the minimum possible latency, and the `latencyHint` can increase this
+appropriately when possible.
 
 * If `renderSize` is "default", then 128 frames is used to render the graph and
   `latencyHint` behaves as before.
@@ -175,6 +175,7 @@ Roughly, the `renderSize` choose the minimum possible latency, and the
   UA-supported value.  The `latencyHint` cannot produce latencies less than
   this.
 
+#### Non-normative Note:
 For example, suppose the "hardware" render size is 192 frames with a context
 whose sample rate is 48 kHz.  Also assume that a "balanced" latency implies a
 latency of 20 ms, and "playback" implies a latency of 200 ms.

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -100,8 +100,8 @@ For an OfflineAudioContext, there's no concept of "hardware", so using
 
   <dd>
   Identifies the render size for the context.  The preferred value of the
-  `renderSizeHint` is one of the values from the
-  `AudioContextRenderSizeCategory`.  However, an unsigned long value may be
+  <code>renderSizeHint</code> is one of the values from the
+  <code>AudioContextRenderSizeCategory</code>.  However, an unsigned long value may be
   given to request an exact number of frames to use for rendering.  Powers of
   two between 64 and 2048, inclusive MUST be supported.  It is recommended that
   UA's support values that are not a power of two.
@@ -120,8 +120,8 @@ For an OfflineAudioContext, there's no concept of "hardware", so using
 
   <dd>
   Identifies the render size for the context.  The preferred value of the
-  `renderSizeHint` is one of the values from the
-  `AudioContextRenderSizeCategory`.  However, an unsigned long value may be
+  <code>renderSizeHint</code> is one of the values from the
+  <code>AudioContextRenderSizeCategory</code>.  However, an unsigned long value may be
   given to request an exact number of frames to use for rendering.  Powers of
   two between 64 and 2048, inclusive MUST be supported.  It is recommended that
   UA's support values that are not a power of two.
@@ -133,16 +133,18 @@ For an OfflineAudioContext, there's no concept of "hardware", so using
 
 ### BaseAudioContext New Attributes
 
-```
-renderSize, of type `unsigned long`, readonly
-```
-This is the actual number of frames used to render the graph.  This may be
-different from the value requested by `renderSizeHint`.
+<dl>
+  <dt> renderSize, of type <code>unsigned long</code>, readonly
+  </dt>
+  <dd>
+    This is the actual number of frames used to render the graph.  This may be
+    different from the value requested by <code>renderSizeHint</code>.
 
-We explicitly do **NOT** support selecting a render size when using the 
-[3-arg constructor](https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate) for the `OfflineAudioContext`.
+    We explicitly do <bold>NOT</bold> support selecting a render size when using the
+    <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">3-arg constructor</a> for the <code>OfflineAudioContext</code>.
 
-
+  </dd>
+</dl>
 
 ## Requirements
 ### Supported Sizes
@@ -223,3 +225,9 @@ two times the render size.  So, while the current allowed sizes are 0, and
 `r*2^n`, where `r` is the `renderSize`.
 
 
+# Security and Privacy Issues
+When the user requests "hardware" for the render size, the user's hardware
+capability can be exposed and can be used to finger print the user.  While no UA
+is required to return exactly the hardware value, it is most beneficial if it
+actually did, as explained #issues.  But for privacy reasons, a UA can return a
+different value.

--- a/index.bs
+++ b/index.bs
@@ -678,6 +678,11 @@ initially empty ordered list of promises.
 Each {{BaseAudioContext}} has a unique
 <a href="https://html.spec.whatwg.org/multipage/media.html#media-element-event-task-source">
 media element event task source</a>.
+Additionally, a {{BaseAudioContext}} has two private slots <dfn attribute
+for="BaseAudioContext">[[rendering thread state]]</dfn> and <dfn attribute
+for="BaseAudioContext">[[control thread state]]</dfn> that take values from
+{{AudioContextState}}, and that are both initialy set to
+<code>"suspended"</code>.
 
 <pre class="idl">
 enum AudioContextState {
@@ -851,8 +856,8 @@ Attributes</h4>
 
 	: <dfn>state</dfn>
 	::
-		Describes the current state of the {{AudioContext}}. Its value is identical
-		to <a>control thread state</a>.
+		Describes the current state of the {{BaseAudioContext}}.  Getting this
+		attribute returns the contents of the {{[[control thread state]]}} slot.
 </dl>
 
 <h4 id="BaseAudioContent-methods">
@@ -1206,7 +1211,7 @@ Methods</h4>
 			5. Otherwise:
 				1. Take the result, representing the decoded [=linear PCM=]
 					audio data, and resample it to the sample-rate of the
-					{{AudioContext}} if it is different from
+					{{BaseAudioContext}} if it is different from
 					the sample-rate of {{BaseAudioContext/decodeAudioData(audioData,
 					successCallback, errorCallback)/audioData!!argument}}.
 
@@ -1412,9 +1417,9 @@ Constructors</h4>
 			<span class="synchronous">When creating an {{AudioContext}},
 			execute these steps:</span>
 
-			1. Set a <a>control thread state</a> to <code>suspended</code> on the {{AudioContext}}.
+			1. Set a {{[[control thread state]]}} to <code>suspended</code> on the {{AudioContext}}.
 
-			2. Set a <a>rendering thread state</a> to <code>suspended</code> on the {{AudioContext}}.
+			2. Set a {{[[rendering thread state]]}} to <code>suspended</code> on the {{AudioContext}}.
 
 			3. Let <dfn attribute for="AudioContext">[[pending resume promises]]</dfn> be a
 				slot on this {{AudioContext}}, that is an initially empty ordered list of
@@ -1451,7 +1456,7 @@ Constructors</h4>
 			1. Attempt to <a href="#acquiring">acquire system resources</a>.
 				In case of failure, abort the following steps.
 
-			3. Set the <a>rendering thread state</a> to <code>running</code> on the {{AudioContext}}.
+			3. Set the {{[[rendering thread state]]}} to <code>running</code> on the {{AudioContext}}.
 
 			1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
 				queue a media element task</a> to execute the following steps:
@@ -1534,12 +1539,13 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			1. If the <a>control thread state</a> flag on the
+			1. If the {{[[control thread state]]}} flag on the
 				{{AudioContext}} is <code>closed</code> reject the promise
 				with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
 
-			1. Set the <a>control thread state</a> flag on the {{AudioContext}} to <code>closed</code>.
+			1. Set the {{[[control thread state]]}} flag on the {{AudioContext}} to
+				<code>closed</code>.
 
 			1. <a>Queue a control message</a> to close the {{AudioContext}}.
 
@@ -1553,7 +1559,7 @@ Methods</h4>
 
 			1. Attempt to <a>release system resources</a>.
 
-			2. Set the <a>rendering thread state</a> to <code>suspended</code>.
+			2. Set the {{[[rendering thread state]]}} to <code>suspended</code>.
 				<div class="note">
 					This will stop rendering.
 				</div>
@@ -1724,7 +1730,7 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			2. If the <a>control thread state</a> on the
+			2. If the {{[[control thread state]]}} on the
 				{{AudioContext}} is <code>closed</code> reject the
 				promise with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
@@ -1736,7 +1742,7 @@ Methods</h4>
 				{{AudioContext/[[pending resume promises]]}} and abort these steps, returning
 				<var>promise</var>.
 
-			5. Set the <a>control thread state</a> on the
+			5. Set the {{[[control thread state]]}} on the
 				{{AudioContext}} to <code>running</code>.
 
 			6. <a>Queue a control message</a> to resume the {{AudioContext}}.
@@ -1751,7 +1757,7 @@ Methods</h4>
 
 			1. Attempt to <a href="#acquiring">acquire system resources</a>.
 
-			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>running</code>.
+			2. Set the {{[[rendering thread state]]}} on the {{AudioContext}} to <code>running</code>.
 
 			3. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
@@ -1814,7 +1820,7 @@ Methods</h4>
 
 			1. Let <var>promise</var> be a new Promise.
 
-			2. If the <a>control thread state</a> on the
+			2. If the {{[[control thread state]]}} on the
 				{{AudioContext}} is <code>closed</code> reject the promise
 				with {{InvalidStateError}}, abort these steps,
 				returning <var>promise</var>.
@@ -1823,7 +1829,7 @@ Methods</h4>
 
 			4. Set {{[[suspended by user]]}} to <code>true</code>.
 
-			5. Set the <a>control thread state</a> on the {{AudioContext}} to <code>suspended</code>.
+			5. Set the {{[[control thread state]]}} on the {{AudioContext}} to <code>suspended</code>.
 
 			6. <a>Queue a control message</a> to suspend the {{AudioContext}}.
 
@@ -1837,7 +1843,7 @@ Methods</h4>
 
 			1. Attempt to <a>release system resources</a>.
 
-			2. Set the <a>rendering thread state</a> on the {{AudioContext}} to <code>suspended</code>.
+			2. Set the {{[[rendering thread state]]}} on the {{AudioContext}} to <code>suspended</code>.
 
 			3. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
 				queue a media element task</a> to execute the following steps:
@@ -2002,10 +2008,10 @@ Constructors</h4>
 			Let <var>c</var> be a new {{OfflineAudioContext}} object.
 			Initialize <var>c</var> as follows:
 
-			1. Set the <a>control thread state</a> for <var>c</var>
+			1. Set the {{[[control thread state]]}} for <var>c</var>
 				to <code>"suspended"</code>.
 
-			2. Set the <a>rendering thread state</a> for
+			2. Set the {{[[rendering thread state]]}} for
 				<var>c</var> to <code>"suspended"</code>.
 
 			3. Construct an {{AudioDestinationNode}} with its
@@ -2174,12 +2180,12 @@ Methods</h4>
 
 			1. Abort these steps and reject <var>promise</var> with
 				{{InvalidStateError}} when any of following conditions is true:
-				- The <a>control thread state</a> on the {{OfflineAudioContext}}
+				- The {{[[control thread state]]}} on the {{OfflineAudioContext}}
 					is <code>closed</code>.
 				- The {{[[rendering started]]}} slot on the {{OfflineAudioContext}}
 					is <em>false</em>.
 
-			1. Set the <a>control thread state</a> flag on the
+			1. Set the {{[[control thread state]]}} flag on the
 				{{OfflineAudioContext}} to <code>running</code>.
 
 			1. <a>Queue a control message</a> to resume the {{OfflineAudioContext}}.
@@ -2192,7 +2198,7 @@ Methods</h4>
 			{{OfflineAudioContext}} means running these steps on the
 			<a>rendering thread</a>:
 
-			1. Set the <a>rendering thread state</a> on the {{OfflineAudioContext}} to <code>running</code>.
+			1. Set the {{[[rendering thread state]]}} on the {{OfflineAudioContext}} to <code>running</code>.
 
 			2. Start <a href="#rendering-loop">rendering the audio graph</a>.
 
@@ -4166,7 +4172,7 @@ Methods</h4>
 			5. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">start running its rendering thread</a> only when
 				all the following conditions are met:
-				1. The context's <a>control thread state</a> is
+				1. The context's {{[[control thread state]]}} is
 					"{{AudioContextState/suspended}}".
 				1. The context is <a>allowed to start</a>.
 				1. {{[[suspended by user]]}} flag is <code>false</code>.
@@ -4880,7 +4886,7 @@ Methods</h4>
 			1. Send a <a>control message</a> to the associated {{AudioContext}} to
 				<a href="#context-resume">start running its rendering thread</a> only when
 				all the following conditions are met:
-				1. The context's <a>control thread state</a> is
+				1. The context's {{[[control thread state]]}} is
 					{{AudioContextState/suspended}}.
 				1. The context is <a>allowed to start</a>.
 				1. {{[[suspended by user]]}} flag is <code>false</code>.
@@ -11036,11 +11042,6 @@ reaction to the calls from the <a>control thread</a>. It can be a
 real-time, callback-based audio thread, if computing audio for an
 {{AudioContext}}, or a normal thread if computing audio for an {{OfflineAudioContext}}.
 
-Each thread has an internal slot that indicates its current state.
-<dfn>control thread state</dfn> is the equivalent of {{BaseAudioContext/state}}
-and <dfn>rendering thread state</dfn> in the counterpart from the rendering
-thread. These slots have a value of {{AudioContextState}}.
-
 The <a>control thread</a> uses a traditional event loop, as described
 in [[HTML]].
 
@@ -11207,7 +11208,7 @@ task queue=] of its associated {{BaseAudioContext}}.
 
 	4. Process a render quantum.
 
-		1. If the <a>rendering thread state</a> of the {{BaseAudioContext}} is not
+		1. If the {{[[rendering thread state]]}} of the {{BaseAudioContext}} is not
 			<code>running</code>, return false.
 
 		2. Order the {{AudioNode}}s of the {{BaseAudioContext}} to be processed.


### PR DESCRIPTION
Addresses WebAudio/web-audio-api-v2#13 by adding an explainer for the user-selectable render size.