### PR TITLE
RangeError is thrown only for negative cancelTime

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -97,6 +97,8 @@ window.addEventListener("DOMContentLoaded", function () {
 	});
 });
 </script>
+<!-- Handles candidate corrections and additions -->
+<script src="fixup.js"></script>
 <style>
 @media (prefers-color-scheme: light) {
 :root {
@@ -3671,8 +3673,14 @@ Methods</h4>
 			the original timeline would have had at time \(t_c\).
 		</div>
 
+		<div class="correction" id="c127">
+			<span class="marker">Candidate Correction Issue 127:</span>
+			A {{RangeError}} is only thrown for negative cancelTime values for
+			cancelAndHoldAtTime and cancelScheduledValues.  See <a
+			href="https://github.com/WebAudio/web-audio-api-v2/issues/127">Issue 127</a>
+		</div>
 		<pre class=argumentdef for="AudioParam/cancelAndHoldAtTime()">
-			cancelTime: The time after which any previously scheduled parameter changes will be cancelled. It is a time in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>cancelTime</code> is negative or is not a finite number.</span> If {{AudioParam/cancelAndHoldAtTime()/cancelTime}} is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
+			cancelTime: The time after which any previously scheduled parameter changes will be cancelled. It is a time in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>cancelTime</code> is negative<del cite=#c127> or is not a finite number</del>. If {{AudioParam/cancelAndHoldAtTime()/cancelTime}} is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
 		</pre>
 
 		<div>
@@ -3699,7 +3707,7 @@ Methods</h4>
 		removed from the timeline.
 
 		<pre class=argumentdef for="AudioParam/cancelScheduledValues()">
-			cancelTime: The time after which any previously scheduled parameter changes will be cancelled. It is a time in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>cancelTime</code> is negative or is not a finite number.</span> If <code>cancelTime</code> is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
+			cancelTime: The time after which any previously scheduled parameter changes will be cancelled. It is a time in the same time coordinate system as the {{AudioContext}}'s {{BaseAudioContext/currentTime}} attribute. <span class="synchronous">A {{RangeError}} exception MUST be thrown if <code>cancelTime</code> is negative<del cite=#c127> or is not a finite number</del>.</span> If <code>cancelTime</code> is less than {{BaseAudioContext/currentTime}}, it is clamped to {{BaseAudioContext/currentTime}}.
 		</pre>
 
 		<div>


### PR DESCRIPTION
Fixes WebAudio/web-audio-api-v2#127 by removing the text that says a
`RangeError` is also thrown for non-finite values.  That's not
possible because the type of `cancelTime` is `double`, not
`unrestricted double`.  Non-finite values are handled at a higher
level before these methods even see the number.