### PR TITLE
Fix #2359: Fix typo in VUMeterNode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -58,6 +58,7 @@ spec:webidl; type:interface; text:Promise
 <link rel="preload" href="https://www.w3.org/scripts/MathJax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js?rev=2.7.5" as="script">
 <link rel="preload" href="https://www.w3.org/scripts/MathJax/2.7.5/jax/element/mml/optable/BasicLatin.js?rev=2.7.5" as="script">
 <link rel="preload" href="https://www.w3.org/scripts/MathJax/2.7.5/jax/output/HTML-CSS/autoload/mtable.js?rev=2.7.5" as="script">
+<script src="//www.w3.org/scripts/TR/2016/fixup.js" type="application/javascript"></script>
 <script>
 window.addEventListener("DOMContentLoaded", function () {
 	"use strict";
@@ -10891,7 +10892,13 @@ communication (asynchronous) between
 {{AudioWorkletNode}} and
 {{AudioWorkletProcessor}}. This node does not use any output.
 
-<xmp line-numbers class="example" highlight="js" title="VUMeterNode - Global Scope (vumeternode.js)">
+<div class="correction" id="c2359">
+  <span class="marker">Candidate Correction
+    <a href="https://github.com/WebAudio/web-audio-api/issues/2359">Issue 2359.</a>
+  </span>
+  Fix typo in code; semi-colon is incorrect.
+</div>
+<pre line-numbers class="example" highlight="js" title="VUMeterNode - Global Scope (vumeternode.js)">
 /* vumeter-node.js: Main global scope */
 
 export default class VUMeterNode extends AudioWorkletNode {
@@ -10901,7 +10908,7 @@ export default class VUMeterNode extends AudioWorkletNode {
 			numberOfOutputs: 0,
 			channelCount: 1,
 			processorOptions: {
-				updateIntervalInMS: updateIntervalInMS || 16.67;
+				updateIntervalInMS: updateIntervalInMS || 16.67<del cite=#c2359>;</del>
 			}
 		});
 
@@ -10931,7 +10938,7 @@ export default class VUMeterNode extends AudioWorkletNode {
 		// every |this._updateIntervalInMS| milliseconds.
 	}
 };
-</xmp>
+</pre>
 
 <xmp line-numbers class="example" highlight="js" title="VUMeterNode - AudioWorkletGlobalScope (vumeterprocessor.js)">
 /* vumeter-processor.js: AudioWorkletGlobalScope */
@@ -12969,3 +12976,4 @@ Wei, James (Intel Corporation);
 Weitnauer, Michael (IRT);
 Wilson, Chris (Google,Inc);
 Zergaoui, Mohamed (INNOVIMAX)
+


### PR DESCRIPTION
The typo is marked as a candidate correction, and linked to #2359 for
easy tracking.  The id is "c2359" where "c" stands for "correction",
and "2359" is the corresponding V1 issue number.  This makes it easy
to create unique ids for the links necessary for the correction.