### PR TITLE
Fix #2361: Use new Web IDL buffer primitives

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1145,17 +1145,14 @@ Methods</h4>
 
 			2. Let <var>promise</var> be a new Promise.
 
-			3. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
-				(described in [[!ECMASCRIPT]]) on {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} is
-				<code>false</code>, execute the following steps:
+			3. If {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
+				is [=BufferSource/detached=], execute the following steps:
 
 				1. Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
-				2. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">
-					Detach</a> the {{BaseAudioContext/decodeAudioData(audioData,
+				2. [=ArrayBuffer/Detach=] the {{BaseAudioContext/decodeAudioData(audioData,
 					successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
-					This operation is described in [[!ECMASCRIPT]]. If this operations
-					throws, jump to the step 3.
+					If this operations throws, jump to the step 3.
 
 				3. Queue a decoding operation to be performed on another thread.
 
@@ -2513,7 +2510,7 @@ Methods</h4>
 	: <dfn>getChannelData(channel)</dfn>
 	::
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
-		either [=get a reference to the buffer source|get a reference to=]
+		either [=ArrayBufferView/write=] into
 		or [=get a copy of the buffer source|get a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}
@@ -2550,14 +2547,12 @@ invoker.
 	When an <dfn lt="acquire the content|acquire the contents of an AudioBuffer">acquire the content</dfn>
 	operation occurs on an {{AudioBuffer}}, run the following steps:
 
-	1. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
-		on any of the {{AudioBuffer}}'s {{ArrayBuffer}}s return
-		`true`, abort these steps, and return a zero-length
-		channel data buffer to the invoker.
+	1. If any of the {{AudioBuffer}}'s {{ArrayBuffer}}s are
+		[=BufferSource/detached=], return `true`, abort these steps, and
+		return a zero-length channel data buffer to the invoker.
 
-	2. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
-		all {{ArrayBuffer}}s for arrays previously returned by
-		{{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
+	2. [=ArrayBuffer/Detach=] all {{ArrayBuffer}}s for arrays previously returned
+		by {{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
 
 		Note: Because {{AudioBuffer}} can only be created via
 		{{BaseAudioContext/createBuffer()}} or via the {{AudioBuffer}} constructor, this
@@ -3692,7 +3687,7 @@ Methods</h4>
 		are also removed if the hold time occurs after
 		{{AudioParam/cancelScheduledValues()/cancelTime!!argument}}.
 
-		For a {{AudioParam/setValueCurveAtTime()}}, let \(T_0\) and \(T_D\) be the corresponding 
+		For a {{AudioParam/setValueCurveAtTime()}}, let \(T_0\) and \(T_D\) be the corresponding
 		{{AudioParam/setValueCurveAtTime()/startTime!!argument}} and {{AudioParam/setValueCurveAtTime()/duration!!argument}}, respectively of this event.
 		Then if {{AudioParam/cancelScheduledValues()/cancelTime!!argument}}
 		is in the range \([T_0, T_0 + T_D]\), the event is
@@ -4364,15 +4359,12 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AnalyserNode">
 	: <dfn>getByteFrequencyData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the {{Uint8Array}}
-		passed as an argument.  Copies the <a>current frequency data</a> to those
-		bytes. If the array has fewer elements than the {{frequencyBinCount}}, the
-		excess elements will be dropped. If the array has more elements than the
-		{{frequencyBinCount}}, the excess elements will be ignored. The most
-		recent {{AnalyserNode/fftSize}} frames are used in computing the frequency
-		data.
+		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
+		|array|'s [=BufferSource/byte length=] is less than {{frequencyBinCount}},
+		the excess elements will be dropped. If |array|'s
+		[=BufferSource/byte length=] is greater than the {{frequencyBinCount}}, the
+		excess elements will be ignored. The most recent {{AnalyserNode/fftSize}}
+		frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getByteFrequencyData()}} or
 		{{AnalyserNode/getFloatFrequencyData()}} occurs within the same
@@ -4409,15 +4401,12 @@ Methods</h4>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the {{Uint8Array}}
-		passed as an argument.  Copies the <a>current time-domain data</a>
-		(waveform data) into those bytes. If the array has fewer elements than the
-		value of {{AnalyserNode/fftSize}}, the excess elements will be dropped. If
-		the array has more elements than {{AnalyserNode/fftSize}}, the excess
-		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
-		are used in computing the byte data.
+		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		into |array|. If |array|'s [=BufferSource/byte length=] is less than
+		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|'s
+		[=BufferSource/byte length=] is greater than the {{AnalyserNode/fftSize}},
+		the excess elements will be ignored. The most recent
+		{{AnalyserNode/fftSize}} frames are used in computing the byte data.
 
 		The values stored in the unsigned byte array are computed in
 		the following way. Let \(x[k]\) be the time-domain data. Then
@@ -4442,14 +4431,10 @@ Methods</h4>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the
-		{{Float32Array}} passed as an argument.  Copies
-		the <a>current frequency data</a> into those bytes.  If the array has
-		fewer elements than the {{frequencyBinCount}}, the excess elements will be
-		dropped. If the array has more elements than the {{frequencyBinCount}},
-		the excess elements will be ignored. The most recent
+		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
+		|array| has fewer elements than the {{frequencyBinCount}}, the excess
+		elements will be dropped. If |array| has more elements than the
+		{{frequencyBinCount}}, the excess elements will be ignored. The most recent
 		{{AnalyserNode/fftSize}} frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getFloatFrequencyData()}} or
@@ -4470,15 +4455,12 @@ Methods</h4>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the
-		{{Float32Array}} passed as an argument.  Copies the
-		<a>current time-domain data</a> (waveform data) into those bytes. If the
-		array has fewer elements than the value of {{AnalyserNode/fftSize}}, the
-		excess elements will be dropped. If the array has more elements than
-		{{AnalyserNode/fftSize}}, the excess elements will be ignored. The most
-		recent {{AnalyserNode/fftSize}} frames are returned (after downmixing).
+		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		into |array|. If |array| has fewer elements than the value of
+		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|
+		has more elements than the value of {{AnalyserNode/fftSize}}, the excess
+		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
+		are written (after downmixing).
 
 		<pre class=argumentdef for="AnalyserNode/getFloatTimeDomainData()">
 			array: This parameter is where the time-domain sample data will be copied.

--- a/index.bs
+++ b/index.bs
@@ -1136,6 +1136,13 @@ Methods</h4>
 		is via its promise return value, the callback parameters are
 		provided for legacy reasons.
 
+		<div class="correction" id="c2361-1">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-1.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+
 		<div algorithm="decodeAudioData()">
 			<span class="synchronous">When <code>decodeAudioData</code> is
 			called, the following steps MUST be performed on the control
@@ -1145,14 +1152,17 @@ Methods</h4>
 
 			2. Let <var>promise</var> be a new Promise.
 
-			3. If {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
-				is [=BufferSource/detached=], execute the following steps:
+			3. If <del cite=#c2361-1>
+				the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a> (described in [[!ECMASCRIPT]]) on
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
+				is <code>false</code>,</del><ins cite=#c2361-1> {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} is [=BufferSource/detached=],</ins> execute the following steps:
 
 				1. Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
-				2. [=ArrayBuffer/Detach=] the {{BaseAudioContext/decodeAudioData(audioData,
-					successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
-					If this operations throws, jump to the step 3.
+				2. <del cite=#c2361-1><a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a></del><ins cite=#c2361-1>[=ArrayBuffer/Detach=]</ins>
+					the {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
+					<del cite=#c2361-1>This operation is described in [[!ECMASCRIPT]].</del>
+					 If this operations throws, jump to the step 3.
 
 				3. Queue a decoding operation to be performed on another thread.
 
@@ -2509,8 +2519,14 @@ Methods</h4>
 
 	: <dfn>getChannelData(channel)</dfn>
 	::
+		<div class="correction" id="c2361-2">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-2.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
-		either [=ArrayBufferView/write=] into
+		either <del cite=#c2361-2>[=get a reference to the buffer source|get a reference to=]</del><ins cite=#c2361-2>[=ArrayBufferView/write=]</ins> into
 		or [=get a copy of the buffer source|get a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}
@@ -2547,11 +2563,19 @@ invoker.
 	When an <dfn lt="acquire the content|acquire the contents of an AudioBuffer">acquire the content</dfn>
 	operation occurs on an {{AudioBuffer}}, run the following steps:
 
-	1. If any of the {{AudioBuffer}}'s {{ArrayBuffer}}s are
-		[=BufferSource/detached=], return `true`, abort these steps, and
+	<div class="correction" id="c2361-3">
+	  <span class="marker">Candidate Correction
+	  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-3.</a>
+	  </span>
+	  Use new Web IDL buffer primitives
+	</div>
+	
+	1. If <del cite=#c2361-3>the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
+		on any of the {{AudioBuffer}}'s {{ArrayBuffer}}s</del><ins cite=#c2361-3>any of the {{AudioBuffer}}'s {{ArrayBuffer}}s are
+		[=BufferSource/detached=]</ins>, return `true`, abort these steps, and
 		return a zero-length channel data buffer to the invoker.
 
-	2. [=ArrayBuffer/Detach=] all {{ArrayBuffer}}s for arrays previously returned
+	2. <del cite=#c2361-3><a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a></del><ins cite=#c2361-3>[=ArrayBuffer/Detach=]</ins> all {{ArrayBuffer}}s for arrays previously returned
 		by {{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
 
 		Note: Because {{AudioBuffer}} can only be created via
@@ -4359,10 +4383,23 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AnalyserNode">
 	: <dfn>getByteFrequencyData(array)</dfn>
 	::
+		<div class="correction" id="c2361-4">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-4.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-4>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the {{Uint8Array}}
+		passed as an argument.  Copies the <a>current frequency data</a> to those
+		bytes. If the array has fewer elements than the {{frequencyBinCount}}, the
+		excess elements will be dropped. If the array has more elements than the
+		{{frequencyBinCount}}</del><ins cite=#c2361-4>
 		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
 		|array|'s [=BufferSource/byte length=] is less than {{frequencyBinCount}},
 		the excess elements will be dropped. If |array|'s
-		[=BufferSource/byte length=] is greater than the {{frequencyBinCount}}, the
+		[=BufferSource/byte length=] is greater than the {{frequencyBinCount}}</ins>, the
 		excess elements will be ignored. The most recent {{AnalyserNode/fftSize}}
 		frames are used in computing the frequency data.
 
@@ -4401,10 +4438,22 @@ Methods</h4>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
 	::
-		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		<div class="correction" id="c2361-5">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-5.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-5>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the {{Uint8Array}}
+		passed as an argument.  Copies the <a>current time-domain data</a>
+		(waveform data) into those bytes. If the array has fewer elements than the
+		value of {{AnalyserNode/fftSize}}, the excess elements will be dropped. If
+		the array has more elements than {{AnalyserNode/fftSize}},</del><ins cite=#c2361-5>[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
 		into |array|. If |array|'s [=BufferSource/byte length=] is less than
 		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|'s
-		[=BufferSource/byte length=] is greater than the {{AnalyserNode/fftSize}},
+		[=BufferSource/byte length=] is greater than the {{AnalyserNode/fftSize}},</ins>
 		the excess elements will be ignored. The most recent
 		{{AnalyserNode/fftSize}} frames are used in computing the byte data.
 
@@ -4431,10 +4480,21 @@ Methods</h4>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
 	::
-		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
+		<div class="correction" id="c2361-6">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-6.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-6>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the
+		{{Float32Array}} passed as an argument.  Copies
+		the <a>current frequency data</a> into those bytes.  If the array has
+		fewer elements than the {{frequencyBinCount}},</del><ins cite=#c2361-6>[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
 		|array| has fewer elements than the {{frequencyBinCount}}, the excess
 		elements will be dropped. If |array| has more elements than the
-		{{frequencyBinCount}}, the excess elements will be ignored. The most recent
+		{{frequencyBinCount}},</ins> the excess elements will be ignored. The most recent
 		{{AnalyserNode/fftSize}} frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getFloatFrequencyData()}} or
@@ -4455,10 +4515,23 @@ Methods</h4>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
 	::
-		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		<div class="correction" id="c2361-7">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-7.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-7>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the
+		{{Float32Array}} passed as an argument.  Copies the
+		<a>current time-domain data</a> (waveform data) into those bytes. If the
+		array has fewer elements than the value of {{AnalyserNode/fftSize}}, the
+		excess elements will be dropped. If the array has more elements than
+		{{AnalyserNode/fftSize}},</del><ins cite=#c2361-7>[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
 		into |array|. If |array| has fewer elements than the value of
 		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|
-		has more elements than the value of {{AnalyserNode/fftSize}}, the excess
+		has more elements than the value of {{AnalyserNode/fftSize}},</ins> the excess
 		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
 		are written (after downmixing).
 


### PR DESCRIPTION
Updates spec to use new Web IDL buffer primitives.  The changes are
marked as candidate corrections, but we use several correction
amendments to make it easy to see what the new and old text will be.
Using just one makes it super-hard to figure out what controls the
text, and the text sometimes doesn't always clearly show what's
deleted and what's inserted because the links are colored correctly,
and struck-through text doesn't strike through links.  (A bikeshed
issue?)
