### PR TITLE
2361 use new idl buffer prim next buttons

### DIFF
--- a/amendments.js
+++ b/amendments.js
@@ -1,7 +1,21 @@
+// This replaces the contents of |divID| with an unordered list of all the
+// amendment boxes with a prefix of |prefix|.  Each item of the list will be of
+// the form "label n", where "label" is the specified label to use via |label|.
+// "n" is just a sequential number starting at 1.
+//
+// Example usage where we want a list of all the changes whose id begins with
+// "c2361".
+//
+// <div id="change-list-2361">
+//  <script>ListAmendments("c2361", "Correction", "change-list-2361")</script>
+// </div>
 function ListAmendments(prefix, label, divID) {
+  // Find all the nodes whose id starts with |prefix|.
   let nodes = document.querySelectorAll(`*[id^="${prefix}"]`);
+  // Find the div element which will be replaced by the unordered list.
   let div = document.getElementById(divID);
 
+  // Create the unordered list
   let text = '<ul>';
   let index = 1;
   nodes.forEach(x => {

--- a/amendments.js
+++ b/amendments.js
@@ -11,6 +11,8 @@
 // </div>
 function ListAmendments(prefix, label, divID) {
   // Find all the nodes whose id starts with |prefix|.
+
+  // TODO: Needs error checking!
   let nodes = document.querySelectorAll(`*[id^="${prefix}"]`);
   // Find the div element which will be replaced by the unordered list.
   let div = document.getElementById(divID);
@@ -19,10 +21,37 @@ function ListAmendments(prefix, label, divID) {
   let text = '<ul>';
   let index = 1;
   nodes.forEach(x => {
-      text += `<li><a href="#${x.id}">${label} ${index}</a></li>`;
-      ++index;
+    text += `<li><a href="#${x.id}">${label} ${index}</a></li>`;
+    ++index;
+    // Insert buttons for prev and next change
+    InsertButtons(x);
   });
   text += '</ul>';
 
   div.innerHTML = text;
+}
+
+// Search for the class "amendment-buttons", and replace the contents of the div
+// with a set of buttons which link to the previous and next related amendment.
+
+function InsertButtons(node) {
+  let list = node.getElementsByClassName("amendment-buttons");
+
+  // We only add buttons to the first class inside the node.
+  if (list && list.length > 0) {
+    let matches = node.id.match(/([ac]\d+)-(\d+)/);
+    let changeID = matches[1];
+    let changeNum = parseInt(matches[2]);
+    // Create buttons.
+    let text = "";
+    if (changeNum > 1) {
+      text += `<button onclick='location.href="#${changeID}-${changeNum-1}"'>Previous</button>`;
+    }
+
+    if (document.getElementById(changeID + "-" + (changeNum + 1))) {
+      text += `<button onclick='location.href="#${changeID}-${changeNum+1}"'>Next</button>`;
+    }
+
+    list[0].innerHTML = text;
+  }
 }

--- a/amendments.js
+++ b/amendments.js
@@ -1,0 +1,14 @@
+function ListAmendments(prefix, label, divID) {
+  let nodes = document.querySelectorAll(`*[id^="${prefix}"]`);
+  let div = document.getElementById(divID);
+
+  let text = '<ul>';
+  let index = 1;
+  nodes.forEach(x => {
+      text += `<li><a href="#${x.id}">${label} ${index}</a></li>`;
+      ++index;
+  });
+  text += '</ul>';
+
+  div.innerHTML = text;
+}

--- a/explainer/user-selectable-render-size.md
+++ b/explainer/user-selectable-render-size.md
@@ -1,0 +1,254 @@
+# User-Selectable Render Size
+Raymond Toy (rtoy@chromium.org)
+
+## Background
+Historically, WebAudio has always rendered the graph in chunks of 128 frames,
+called a [render
+quantum](https://webaudio.github.io/web-audio-api/#render-quantum) in the
+specification.  This was a trade-off between function-call overhead and
+latency.  A smaller number would reduce latency, but the function call overhead
+would increase.  With a larger value, the overhead is reduced, but the latency
+increases because any change takes more audio frames to reach the output.  In
+addition, Mac OS probably processed 128 frames at a time anyway.
+
+## Issues
+This has worked well over time, especially on desktop, but is particularly bad
+on Android where 128 may not fit in well with Android's audio processing.  The
+main problem is illustrated very well from the example from Paul Adenot in a
+[comment to issue #13](https://github.com/WebAudio/web-audio-api-v2/issues/13#issuecomment-572469654),
+reproduced below.
+
+The example is an Android phone that has a native processing buffer size
+of 192.  Since WebAudio processes 128 frames we have the following behavior:
+
+|iteration | #	number of frames to render |	number of buffers to render |	leftover frames|
+|---|---|---|---|
+|0|	192|	2|	64|
+|1|	192|	1|	0|
+|2|	192|	2|	64|
+|3|	192|	1|	0|
+|4|	192|	2|	64|
+|5|	192|	1|	0|
+
+At a sample rate of 48 kHz, 128 frames would require 2.666 ms.  The net result
+is that the **peak** CPU usage is twice has high as might be expected since,
+every other time, you need to render the graph twice in 2.666 ms instead of once.
+Then the max complexity of the graph is unexpectedly limited because of this.
+
+However, if WebAudio rendered 192 frames at a time, the CPU usage would
+remain constant, and more complex graphs could be rendered because the peak CPU
+would be same as the average.  This does increase latency compared to a native
+size of 128, but since
+Android is already using a size of 192, there is no actual additional latency.
+
+Finally, some applications do not need these low latency requirements, and may
+also want AudioWorklets to process larger blocks to reduce function call
+overhead.  In this case allowing render sizes of 1024 or 2048 could be
+appropriate.
+
+## The API
+To allow user-selectable render size, we propose the following API:
+
+```idl
+// New enum
+enum AudioContextRenderSizeCategory {
+  "default",
+  "hardware"
+};
+
+dictionary AudioContextOptions {
+  (AudioContextLatencyCategory or double) latencyHint = "interactive";
+  float sampleRate;
+
+  // New addition
+  (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
+};
+
+dictionary OfflineAudioContextOptions {
+  unsigned long numberOfChannels = 1;
+  required unsigned long length;
+  required float sampleRate;
+  
+  // New addition
+  (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
+};
+
+partial interface BaseAudioContext {
+  unsigned long renderSize;
+};
+```
+
+### Enumeration Description
+|Value|Description|
+|--|--|
+|"default"  | Default rendering size of 128 frames |
+|"hardware" | Use an appropriate value for the hardware for an AudioContext or the default for an OfflineAudioContext|
+
+#### AudioContext
+For an AudioContext, the "hardware" category means a size is chosen that is
+appropriate to the current output device.  For example, selecting "hardware" may
+result in a size of 192 frames for the Android phone used in the example.
+
+#### OfflineAudioContext
+For an OfflineAudioContext, there's no concept of "hardware", so using
+"hardware" is the same as "default".
+
+### New Dictionary Members
+#### AudioContextOptions
+<dl>
+  <dt> renderSizeHint, of type (AudioContextRenderSizeCategory or unsigned long), defaulting to "default"
+  </dt>
+
+  <dd>
+  Identifies the render size for the context.  The preferred value of the
+  <code>renderSizeHint</code> is one of the values from the
+  <code>AudioContextRenderSizeCategory</code>.  However, an unsigned long value may be
+  given to request an exact number of frames to use for rendering.  Powers of
+  two between 64 and 2048, inclusive MUST be supported.  It is recommended that
+  UA's support values that are not a power of two.
+
+  If the requested value is not supported by the UA, the UA MUST round the value
+  up to the next smallest value that is supported.  If this exceeds the maximum
+  supported value, it is clamped to the max.
+  </dd>
+</dl>
+
+
+#### OfflineAudioContextOptions
+<dl>
+  <dt> renderSizeHint, of type (AudioContextRenderSizeCategory or unsigned long), defaulting to "default"
+  </dt>
+
+  <dd>
+  This has exactly the same meaning, behavior, and constraints as for an
+  `AudioContext`.  However, for an OfflineContext, the value of "hardware" is
+  the same as "default".
+  </dd>
+</dl>
+
+
+### BaseAudioContext New Attributes
+
+<dl>
+  <dt> renderSize, of type <code>unsigned long</code>, readonly
+  </dt>
+  <dd>
+    <p>
+    This is the actual number of frames used to render the graph.  This may be
+    different from the value requested by <code>renderSizeHint</code>.
+    </p>
+    <p>
+    We explicitly do <bold>NOT</bold> support selecting a render size when using the
+    <a href="https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-offlineaudiocontext-numberofchannels-length-samplerate">3-arg constructor</a> for the <code>OfflineAudioContext</code>.
+    </p>
+  </dd>
+</dl>
+
+## Requirements
+### Supported Sizes
+All UA's must support a `renderSize` that is a power of two between 64 and 2048,
+inclusive.
+
+It is highly recommended that other sizes that are not a power of two be
+supported.  This is particularly important on Android where sizes of 96, 144,
+192, and 240 are quite common.  The problem isn't limited to Android.
+Windows generally wants 10 ms buffers so sizes of 440 or 480 for 44.1
+kHz and 48 kHz, respectively, should be supported.
+
+## Interaction with `latencyHint`
+The
+[`latencyHint`](https://www.w3.org/TR/webaudio/#dom-audiocontextoptions-latencyhint)
+for an AudioContext can interact with the `renderSize`.  The
+exact interaction between these is up to the UA to implement in a meaningful
+way.  In particular, UAs that don't double buffer WebAudio's output, the
+`latencyHint` value can be 0, independent of the `renderSize`.
+
+However, for UAs that do double buffer, then, roughly, the `renderSize` chooses
+the minimum possible latency, and the `latencyHint` can increase this
+appropriately if needed.
+
+* If `renderSize` is "default", then 128 frames is used to render the graph and
+  `latencyHint` behaves as before.
+* If `renderSize` is "hardware", then the graph is rendered using the hardware
+  size.  The latency value is chosen appropriately but the resulting latency
+  value cannot be smaller than the hardware size.
+* If `renderSize` is a number, the graph is rendered using the appropriate
+  UA-supported value.  The `latencyHint` cannot produce latencies less than
+  this.
+
+#### Non-normative Note:
+For example, suppose the "hardware" render size is 192 frames with a context
+whose sample rate is 48 kHz.  Also assume that a "balanced" latency implies a
+latency of 20 ms, and "playback" implies a latency of 200 ms.
+
+Then, for
+
+* "interactive", the latency will be `192*n` where `n` is 1, 2, 3,..., and is
+  chosen by the UA
+* "balanced", the latency will be 20 ms.  This means the graph is rendered 5
+  times (`5*192` = `20 ms * 48 kHz`) per callback.
+* "playback", the latency will be 200 ms.  The graph is rendered 50 times per
+  callback.
+  
+If, however, a render size of 1024 is selected, we have:
+
+* "interactive", the latency will be `1024*n` where `n` is 1, 2, 3,..., and is
+  chosen by the UA
+* "balanced", a latency of 20 ms is 960 frames, which is smaller than 1024.  The
+  resulting latency will be 1024 frames (21.33 msec).
+* "playback", the latency will be 200 ms since 200 ms is 9600 frames which is
+  larger than 1024.
+  
+Finally, if the render size is 2048, we have:
+* "interactive", the latency will be `2048*n` where `n` is 1, 2, 3,..., and is
+  chosen by the UA
+* "balanced", a latency of 20 ms is 960 frames, which is greater than 2048.  The
+  resulting latency will be 2048 frames (42.67 msec).
+* "playback", the latency will be 200 ms since 200 ms is 9600 frames which is
+  larger than 2048.
+  
+
+
+
+# Security and Privacy Issues
+When the user requests "hardware" for the render size, the user's hardware
+capability can be exposed and can be used to finger print the user.  While no UA
+is required to return exactly the hardware value, it is most beneficial if it
+actually did, as explained #issues.  But for privacy reasons, a UA can return a
+different value.
+
+# Implementation Issues
+Conceptually this change is relatively simple, but some nodes may have
+additional complexities.  It is up to the UA to handle these appropriately.
+
+## AnalyserNode Implementation
+The `AnalyserNode` currently specifies powers of two both for the size of the
+returned time-domain data and for the size of the frequency domain data.  This
+is probably ok.
+
+## ConvolverNode Implementation
+For efficiency, the `ConvolverNode` is often implemented using FFTs.  Typically,
+only power-of-two FFTs have been used because the render size was 128.  To
+support user-selectable sizes, either more complex algorithms are needed to
+buffer the data appropriately, or more general FFTs are required to support
+sizes that are not a power of two.  It is up to the discretion of the UA to
+implement this appropriately for all the supported render sizes.
+
+## DelayNode Implementation
+Since render size may be different from 128 frames, the minimum delay for a
+`DelayNode` in a loop is adjusted to match the selected render size.  Thus, if
+the render size is 256, loops containing a delay node must have a delay greater
+than or equal to this.  See step 4.2.6.1 in the processing algorithm in
+[Sec. 2.4. Rendering an Audio Graph](https://webaudio.github.io/web-audio-api/#rendering-loop). 
+
+### ScriptProcessorNode
+The [construction of a
+`ScriptProcessorNode`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor)
+requires a
+[`bufferSize`](https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createscriptprocessor-buffersize-numberofinputchannels-numberofoutputchannels-buffersize)
+argument that must be a power of two.  This is fine with appropriate buffering,
+but perhaps it would be better if the buffer sizes are defined to be a power of
+two times the render size.  So, while the current allowed sizes are 0, and
+`128*2^n`, for `n` = 1, 2, ..., 7., we may want to specify the sizes as 0,
+`r*2^n`, where `r` is the `renderSize`.
+

--- a/index.bs
+++ b/index.bs
@@ -1145,17 +1145,14 @@ Methods</h4>
 
 			2. Let <var>promise</var> be a new Promise.
 
-			3. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
-				(described in [[!ECMASCRIPT]]) on {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} is
-				<code>false</code>, execute the following steps:
+			3. If {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
+				is [=BufferSource/detached=], execute the following steps:
 
 				1. Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
-				2. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">
-					Detach</a> the {{BaseAudioContext/decodeAudioData(audioData,
+				2. [=ArrayBuffer/Detach=] the {{BaseAudioContext/decodeAudioData(audioData,
 					successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
-					This operation is described in [[!ECMASCRIPT]]. If this operations
-					throws, jump to the step 3.
+					If this operations throws, jump to the step 3.
 
 				3. Queue a decoding operation to be performed on another thread.
 
@@ -2513,7 +2510,7 @@ Methods</h4>
 	: <dfn>getChannelData(channel)</dfn>
 	::
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
-		either [=get a reference to the buffer source|get a reference to=]
+		either [=ArrayBufferView/write=] into
 		or [=get a copy of the buffer source|get a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}
@@ -2550,14 +2547,12 @@ invoker.
 	When an <dfn lt="acquire the content|acquire the contents of an AudioBuffer">acquire the content</dfn>
 	operation occurs on an {{AudioBuffer}}, run the following steps:
 
-	1. If the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
-		on any of the {{AudioBuffer}}'s {{ArrayBuffer}}s return
-		`true`, abort these steps, and return a zero-length
-		channel data buffer to the invoker.
+	1. If any of the {{AudioBuffer}}'s {{ArrayBuffer}}s are
+		[=BufferSource/detached=], return `true`, abort these steps, and
+		return a zero-length channel data buffer to the invoker.
 
-	2. <a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a>
-		all {{ArrayBuffer}}s for arrays previously returned by
-		{{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
+	2. [=ArrayBuffer/Detach=] all {{ArrayBuffer}}s for arrays previously returned
+		by {{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
 
 		Note: Because {{AudioBuffer}} can only be created via
 		{{BaseAudioContext/createBuffer()}} or via the {{AudioBuffer}} constructor, this
@@ -3692,7 +3687,7 @@ Methods</h4>
 		are also removed if the hold time occurs after
 		{{AudioParam/cancelScheduledValues()/cancelTime!!argument}}.
 
-		For a {{AudioParam/setValueCurveAtTime()}}, let \(T_0\) and \(T_D\) be the corresponding 
+		For a {{AudioParam/setValueCurveAtTime()}}, let \(T_0\) and \(T_D\) be the corresponding
 		{{AudioParam/setValueCurveAtTime()/startTime!!argument}} and {{AudioParam/setValueCurveAtTime()/duration!!argument}}, respectively of this event.
 		Then if {{AudioParam/cancelScheduledValues()/cancelTime!!argument}}
 		is in the range \([T_0, T_0 + T_D]\), the event is
@@ -4364,15 +4359,12 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AnalyserNode">
 	: <dfn>getByteFrequencyData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the {{Uint8Array}}
-		passed as an argument.  Copies the <a>current frequency data</a> to those
-		bytes. If the array has fewer elements than the {{frequencyBinCount}}, the
-		excess elements will be dropped. If the array has more elements than the
-		{{frequencyBinCount}}, the excess elements will be ignored. The most
-		recent {{AnalyserNode/fftSize}} frames are used in computing the frequency
-		data.
+		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
+		|array|'s [=BufferSource/byte length=] is less than {{frequencyBinCount}},
+		the excess elements will be dropped. If |array|'s
+		[=BufferSource/byte length=] is greater than the {{frequencyBinCount}}, the
+		excess elements will be ignored. The most recent {{AnalyserNode/fftSize}}
+		frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getByteFrequencyData()}} or
 		{{AnalyserNode/getFloatFrequencyData()}} occurs within the same
@@ -4409,15 +4401,12 @@ Methods</h4>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the {{Uint8Array}}
-		passed as an argument.  Copies the <a>current time-domain data</a>
-		(waveform data) into those bytes. If the array has fewer elements than the
-		value of {{AnalyserNode/fftSize}}, the excess elements will be dropped. If
-		the array has more elements than {{AnalyserNode/fftSize}}, the excess
-		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
-		are used in computing the byte data.
+		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		into |array|. If |array|'s [=BufferSource/byte length=] is less than
+		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|'s
+		[=BufferSource/byte length=] is greater than the {{AnalyserNode/fftSize}},
+		the excess elements will be ignored. The most recent
+		{{AnalyserNode/fftSize}} frames are used in computing the byte data.
 
 		The values stored in the unsigned byte array are computed in
 		the following way. Let \(x[k]\) be the time-domain data. Then
@@ -4442,14 +4431,10 @@ Methods</h4>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the
-		{{Float32Array}} passed as an argument.  Copies
-		the <a>current frequency data</a> into those bytes.  If the array has
-		fewer elements than the {{frequencyBinCount}}, the excess elements will be
-		dropped. If the array has more elements than the {{frequencyBinCount}},
-		the excess elements will be ignored. The most recent
+		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
+		|array| has fewer elements than the {{frequencyBinCount}}, the excess
+		elements will be dropped. If |array| has more elements than the
+		{{frequencyBinCount}}, the excess elements will be ignored. The most recent
 		{{AnalyserNode/fftSize}} frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getFloatFrequencyData()}} or
@@ -4470,15 +4455,12 @@ Methods</h4>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
 	::
-		Get a
-		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
-		reference to the bytes</a> held by the
-		{{Float32Array}} passed as an argument.  Copies the
-		<a>current time-domain data</a> (waveform data) into those bytes. If the
-		array has fewer elements than the value of {{AnalyserNode/fftSize}}, the
-		excess elements will be dropped. If the array has more elements than
-		{{AnalyserNode/fftSize}}, the excess elements will be ignored. The most
-		recent {{AnalyserNode/fftSize}} frames are returned (after downmixing).
+		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		into |array|. If |array| has fewer elements than the value of
+		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|
+		has more elements than the value of {{AnalyserNode/fftSize}}, the excess
+		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
+		are written (after downmixing).
 
 		<pre class=argumentdef for="AnalyserNode/getFloatTimeDomainData()">
 			array: This parameter is where the time-domain sample data will be copied.

--- a/index.bs
+++ b/index.bs
@@ -1143,6 +1143,9 @@ Methods</h4>
 		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-1.</a>
 		  </span>
 		  Use new Web IDL buffer primitives
+		  <div class="amendment-buttons">
+		    Buttons here
+		  </div>
 		</div>
 
 		<div algorithm="decodeAudioData()">
@@ -2526,6 +2529,9 @@ Methods</h4>
 		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-2.</a>
 		  </span>
 		  Use new Web IDL buffer primitives
+		  <div class="amendment-buttons">
+		    Buttons here
+		  </div>
 		</div>
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
 		either <del cite=#c2361-2>get a reference to</del><ins cite=#c2361-2>allow [=ArrayBufferView/write|writing=]</ins> into
@@ -2570,6 +2576,9 @@ invoker.
 	  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-3.</a>
 	  </span>
 	  Use new Web IDL buffer primitives
+	  <div class="amendment-buttons">
+	    Buttons here
+	  </div>
 	</div>
 	
 	1. If <del cite=#c2361-3>the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
@@ -4390,6 +4399,9 @@ Methods</h4>
 		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-4.</a>
 		  </span>
 		  Use new Web IDL buffer primitives
+		  <div class="amendment-buttons">
+		    Buttons here
+		  </div>
 		</div>
 		<del cite=#c2361-4>Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
@@ -4445,6 +4457,9 @@ Methods</h4>
 		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-5.</a>
 		  </span>
 		  Use new Web IDL buffer primitives
+		  <div class="amendment-buttons">
+		    Buttons here
+		  </div>
 		</div>
 		<del cite=#c2361-5>Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
@@ -4487,6 +4502,9 @@ Methods</h4>
 		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-6.</a>
 		  </span>
 		  Use new Web IDL buffer primitives
+		  <div class="amendment-buttons">
+		    Buttons here
+		  </div>
 		</div>
 		<del cite=#c2361-6>Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
@@ -4522,6 +4540,9 @@ Methods</h4>
 		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-7.</a>
 		  </span>
 		  Use new Web IDL buffer primitives
+		  <div class="amendment-buttons">
+		    Buttons here
+		  </div>
 		</div>
 		<del cite=#c2361-7>Get a
 		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
@@ -12742,7 +12763,6 @@ Change Log</h2>
 </h3>
   * <a href="https://github.com/WebAudio/web-audio-api/pull/2361">PR 2361</a>: Use new Web IDL buffer primitives
     <div id="change-list-2361">
-        <script>ListAmendments("c2361", "Correction", "change-list-2361")</script>
     </div>
 
 <h3 id="changes-2021-05-06">
@@ -13034,3 +13054,8 @@ Wei, James (Intel Corporation);
 Weitnauer, Michael (IRT);
 Wilson, Chris (Google,Inc);
 Zergaoui, Mohamed (INNOVIMAX)
+<script>
+window.addEventListener('load', (event) => {
+  ListAmendments("c2361", "Correction", "change-list-2361");
+  });
+</script>

--- a/index.bs
+++ b/index.bs
@@ -6769,8 +6769,8 @@ Constructors</h4>
 
 		1. Set the attributes {{ConvolverNode/normalize}} to the inverse of the
 			value of {{ConvolverOptions/disableNormalization}}.
-		2. If {{ConvolverNode/buffer}} is
-			<a href="https://heycam.github.io/webidl/#dfn-present">present</a>, set the
+		2. If {{ConvolverNode/buffer}}
+		        <a for=map>exists</a>, set the
 			{{ConvolverNode/buffer}} attribute to its value.
 
 			Note: This means that the buffer will be normalized according to the
@@ -6778,16 +6778,16 @@ Constructors</h4>
 			attribute.
 
 		3. Let <var>o</var> be new {{AudioNodeOptions}} dictionary.
-		4. If {{AudioNodeOptions/channelCount}} is
-			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+		4. If {{AudioNodeOptions/channelCount}}
+		        <a for=map>exists</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelCount}} on <var>o</var>
 			with the same value.
-		5. If {{AudioNodeOptions/channelCountMode}} is
-			<a href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+		5. If {{AudioNodeOptions/channelCountMode}} 
+			<a for=map>exists</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelCountMode}} on
 			<var>o</var> with the same value.
-		6. If {{AudioNodeOptions/channelInterpretation}} is <a
-			href="https://heycam.github.io/webidl/#dfn-present">present</a> in
+		6. If {{AudioNodeOptions/channelInterpretation}} 
+			<a for=map>exists</a> in
 			<var>options</var>, set {{AudioNodeOptions/channelInterpretation}} on
 			<var>o</var> with the same value.
 		7. <a href="#audionode-constructor-init">Initialize the AudioNode</a>

--- a/index.bs
+++ b/index.bs
@@ -128,13 +128,47 @@ function ListAmendments(prefix, label, divID) {
   let text = '<ul>';
   let index = 1;
   nodes.forEach(x => {
-      text += '<li><a href="#' + x.id + '">' + label + ' ' + index + '</a></li>';
-      ++index;
+    text += '<li><a href="#' + x.id + '">' + label + ' ' + index + '</a></li>';
+    ++index;
+    // Insert buttons for prev and next change
+    InsertButtons(x);
   });
   text += '</ul>';
 
   div.innerHTML = text;
 }
+
+// Search for the class "amendment-buttons", and replace the contents of the div
+// with a set of buttons which link to the previous and next related amendment.
+
+function InsertButtons(node) {
+  let list = node.getElementsByClassName("amendment-buttons");
+
+  // We only add buttons to the first class inside the node.
+  if (list && list.length > 0) {
+    let matches = node.id.match(/([ac]\d+)-(\d+)/);
+    let changeID = matches[1];
+    let changeNum = parseInt(matches[2]);
+    // Create buttons.
+    let text = "";
+    if (changeNum > 1) {
+      text += "<button onclick='location.href=";
+      text += '"#' + changeID + '-' + (changeNum-1) + '"';
+      text += "'>Previous</button>";
+    }
+
+    if (document.getElementById(changeID + "-" + (changeNum + 1))) {
+      text += "<button onclick='location.href=";
+      text += '"#' + changeID + '-' + (changeNum + 1) + '"';
+      text += "'>Next</button>";
+    }
+
+    list[0].innerHTML = text;
+  }
+}
+window.addEventListener('load', (event) => {
+  ListAmendments("c2361", "Correction", "change-list-2361");
+});
 </script>
 <style>
 @media (prefers-color-scheme: light) {
@@ -13091,8 +13125,3 @@ Wei, James (Intel Corporation);
 Weitnauer, Michael (IRT);
 Wilson, Chris (Google,Inc);
 Zergaoui, Mohamed (INNOVIMAX)
-<script>
-window.addEventListener('load', (event) => {
-  ListAmendments("c2361", "Correction", "change-list-2361");
-});
-</script>

--- a/index.bs
+++ b/index.bs
@@ -2528,8 +2528,8 @@ Methods</h4>
 		  Use new Web IDL buffer primitives
 		</div>
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
-		either <del cite=#c2361-2>get a reference to</del><ins cite=#c2361-2>[=ArrayBufferView/write=]</ins> into
-		or [=get a copy of the buffer source|get a copy of=]
+		either <del cite=#c2361-2>get a reference to</del><ins cite=#c2361-2>allow [=ArrayBufferView/write|writing=]</ins> into
+		or [=get a copy of the buffer source|getting a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}
 

--- a/index.bs
+++ b/index.bs
@@ -97,6 +97,8 @@ window.addEventListener("DOMContentLoaded", function () {
 	});
 });
 </script>
+<script src="amendments.js">
+</script>
 <style>
 @media (prefers-color-scheme: light) {
 :root {
@@ -12739,6 +12741,9 @@ Change Log</h2>
   Candidate Changes since Recommendation of 17 Jun 2021
 </h3>
   * <a href="https://github.com/WebAudio/web-audio-api/pull/2361">PR 2361</a>: Use new Web IDL buffer primitives
+    <div id="change-list-2361">
+        <script>ListAmendments("c2361", "Correction", "change-list-2361")</script>
+    </div>
 
 <h3 id="changes-2021-05-06">
   Since Proposed Recommendation of 6 May 2021

--- a/index.bs
+++ b/index.bs
@@ -2526,7 +2526,7 @@ Methods</h4>
 		  Use new Web IDL buffer primitives
 		</div>
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
-		either <del cite=#c2361-2>[=get a reference to the buffer source|get a reference to=]</del><ins cite=#c2361-2>[=ArrayBufferView/write=]</ins> into
+		either <del cite=#c2361-2>get a reference to</del><ins cite=#c2361-2>[=ArrayBufferView/write=]</ins> into
 		or [=get a copy of the buffer source|get a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}

--- a/index.bs
+++ b/index.bs
@@ -1136,6 +1136,13 @@ Methods</h4>
 		is via its promise return value, the callback parameters are
 		provided for legacy reasons.
 
+		<div class="correction" id="c2361-1">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-1.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+
 		<div algorithm="decodeAudioData()">
 			<span class="synchronous">When <code>decodeAudioData</code> is
 			called, the following steps MUST be performed on the control
@@ -1145,14 +1152,17 @@ Methods</h4>
 
 			2. Let <var>promise</var> be a new Promise.
 
-			3. If {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
-				is [=BufferSource/detached=], execute the following steps:
+			3. If <del cite=#c2361-1>
+				the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a> (described in [[!ECMASCRIPT]]) on
+				{{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
+				is <code>false</code>,</del><ins cite=#c2361-1> {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} is [=BufferSource/detached=],</ins> execute the following steps:
 
 				1. Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
-				2. [=ArrayBuffer/Detach=] the {{BaseAudioContext/decodeAudioData(audioData,
-					successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
-					If this operations throws, jump to the step 3.
+				2. <del cite=#c2361-1><a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a></del><ins cite=#c2361-1>[=ArrayBuffer/Detach=]</ins>
+					the {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
+					<del cite=#c2361-1>This operation is described in [[!ECMASCRIPT]].</del>
+					 If this operations throws, jump to the step 3.
 
 				3. Queue a decoding operation to be performed on another thread.
 
@@ -2509,8 +2519,14 @@ Methods</h4>
 
 	: <dfn>getChannelData(channel)</dfn>
 	::
+		<div class="correction" id="c2361-2">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-2.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
 		According to the rules described in <a href="#acquire-the-content">acquire the content</a>
-		either [=ArrayBufferView/write=] into
+		either <del cite=#c2361-2>[=get a reference to the buffer source|get a reference to=]</del><ins cite=#c2361-2>[=ArrayBufferView/write=]</ins> into
 		or [=get a copy of the buffer source|get a copy of=]
 		the bytes stored in {{[[internal data]]}} in a new
 		{{Float32Array}}
@@ -2547,11 +2563,19 @@ invoker.
 	When an <dfn lt="acquire the content|acquire the contents of an AudioBuffer">acquire the content</dfn>
 	operation occurs on an {{AudioBuffer}}, run the following steps:
 
-	1. If any of the {{AudioBuffer}}'s {{ArrayBuffer}}s are
-		[=BufferSource/detached=], return `true`, abort these steps, and
+	<div class="correction" id="c2361-3">
+	  <span class="marker">Candidate Correction
+	  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-3.</a>
+	  </span>
+	  Use new Web IDL buffer primitives
+	</div>
+	
+	1. If <del cite=#c2361-3>the operation <a href="https://tc39.github.io/ecma262/#sec-isdetachedbuffer"><code>IsDetachedBuffer</code></a>
+		on any of the {{AudioBuffer}}'s {{ArrayBuffer}}s</del><ins cite=#c2361-3>any of the {{AudioBuffer}}'s {{ArrayBuffer}}s are
+		[=BufferSource/detached=]</ins>, return `true`, abort these steps, and
 		return a zero-length channel data buffer to the invoker.
 
-	2. [=ArrayBuffer/Detach=] all {{ArrayBuffer}}s for arrays previously returned
+	2. <del cite=#c2361-3><a href="https://tc39.github.io/ecma262/#sec-detacharraybuffer">Detach</a></del><ins cite=#c2361-3>[=ArrayBuffer/Detach=]</ins> all {{ArrayBuffer}}s for arrays previously returned
 		by {{AudioBuffer/getChannelData()}} on this {{AudioBuffer}}.
 
 		Note: Because {{AudioBuffer}} can only be created via
@@ -4359,10 +4383,23 @@ Methods</h4>
 <dl dfn-type=method dfn-for="AnalyserNode">
 	: <dfn>getByteFrequencyData(array)</dfn>
 	::
+		<div class="correction" id="c2361-4">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-4.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-4>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the {{Uint8Array}}
+		passed as an argument.  Copies the <a>current frequency data</a> to those
+		bytes. If the array has fewer elements than the {{frequencyBinCount}}, the
+		excess elements will be dropped. If the array has more elements than the
+		{{frequencyBinCount}}</del><ins cite=#c2361-4>
 		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
 		|array|'s [=BufferSource/byte length=] is less than {{frequencyBinCount}},
 		the excess elements will be dropped. If |array|'s
-		[=BufferSource/byte length=] is greater than the {{frequencyBinCount}}, the
+		[=BufferSource/byte length=] is greater than the {{frequencyBinCount}}</ins>, the
 		excess elements will be ignored. The most recent {{AnalyserNode/fftSize}}
 		frames are used in computing the frequency data.
 
@@ -4401,10 +4438,22 @@ Methods</h4>
 
 	: <dfn>getByteTimeDomainData(array)</dfn>
 	::
-		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		<div class="correction" id="c2361-5">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-5.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-5>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the {{Uint8Array}}
+		passed as an argument.  Copies the <a>current time-domain data</a>
+		(waveform data) into those bytes. If the array has fewer elements than the
+		value of {{AnalyserNode/fftSize}}, the excess elements will be dropped. If
+		the array has more elements than {{AnalyserNode/fftSize}},</del><ins cite=#c2361-5>[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
 		into |array|. If |array|'s [=BufferSource/byte length=] is less than
 		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|'s
-		[=BufferSource/byte length=] is greater than the {{AnalyserNode/fftSize}},
+		[=BufferSource/byte length=] is greater than the {{AnalyserNode/fftSize}},</ins>
 		the excess elements will be ignored. The most recent
 		{{AnalyserNode/fftSize}} frames are used in computing the byte data.
 
@@ -4431,10 +4480,21 @@ Methods</h4>
 
 	: <dfn>getFloatFrequencyData(array)</dfn>
 	::
-		[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
+		<div class="correction" id="c2361-6">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-6.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-6>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the
+		{{Float32Array}} passed as an argument.  Copies
+		the <a>current frequency data</a> into those bytes.  If the array has
+		fewer elements than the {{frequencyBinCount}},</del><ins cite=#c2361-6>[=ArrayBufferView/Write=] the [=current frequency data=] into |array|. If
 		|array| has fewer elements than the {{frequencyBinCount}}, the excess
 		elements will be dropped. If |array| has more elements than the
-		{{frequencyBinCount}}, the excess elements will be ignored. The most recent
+		{{frequencyBinCount}},</ins> the excess elements will be ignored. The most recent
 		{{AnalyserNode/fftSize}} frames are used in computing the frequency data.
 
 		If another call to {{AnalyserNode/getFloatFrequencyData()}} or
@@ -4455,10 +4515,23 @@ Methods</h4>
 
 	: <dfn>getFloatTimeDomainData(array)</dfn>
 	::
-		[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
+		<div class="correction" id="c2361-7">
+		  <span class="marker">Candidate Correction
+		  <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361-7.</a>
+		  </span>
+		  Use new Web IDL buffer primitives
+		</div>
+		<del cite=#c2361-7>Get a
+		<a href="https://heycam.github.io/webidl/#dfn-get-buffer-source-reference">
+		reference to the bytes</a> held by the
+		{{Float32Array}} passed as an argument.  Copies the
+		<a>current time-domain data</a> (waveform data) into those bytes. If the
+		array has fewer elements than the value of {{AnalyserNode/fftSize}}, the
+		excess elements will be dropped. If the array has more elements than
+		{{AnalyserNode/fftSize}},</del><ins cite=#c2361-7>[=ArrayBufferView/Write=] the [=current time-domain data=] (waveform data)
 		into |array|. If |array| has fewer elements than the value of
 		{{AnalyserNode/fftSize}}, the excess elements will be dropped. If |array|
-		has more elements than the value of {{AnalyserNode/fftSize}}, the excess
+		has more elements than the value of {{AnalyserNode/fftSize}},</ins> the excess
 		elements will be ignored. The most recent {{AnalyserNode/fftSize}} frames
 		are written (after downmixing).
 

--- a/index.bs
+++ b/index.bs
@@ -12680,6 +12680,13 @@ class Vec3 {
 
 <h2 id="changes">
 Change Log</h2>
+<h3 id="changes-2021-05-06">
+  Since Proposed Recommendation of 6 May 2021
+</h3>
+  * Styling, status and boilerplate updates for Recommendation
+  * Updated links to RFC2119, High-Resolution Time, and Audio EQ Cookbook
+  * A spelling error was corrected
+
 <h3 id="changes-2021-01-14">
   Since Candidate Recommendation of 14 January 2021
 </h3>

--- a/index.bs
+++ b/index.bs
@@ -12735,6 +12735,11 @@ class Vec3 {
 
 <h2 id="changes">
 Change Log</h2>
+<h3 id="candidate-changes-1">
+  Candidate Changes since Recommendation of 17 Jun 2021
+</h3>
+  * <a href="https://github.com/WebAudio/web-audio-api/pull/2361">PR 2361</a>: Use new Web IDL buffer primitives
+
 <h3 id="changes-2021-05-06">
   Since Proposed Recommendation of 6 May 2021
 </h3>


### PR DESCRIPTION
Example for adding previous and next buttons to help navigate through related changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rtoy/web-audio-api/pull/2366.html" title="Last updated on Jul 9, 2021, 10:58 PM UTC (59bbd4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2366/dd494a8...rtoy:59bbd4d.html" title="Last updated on Jul 9, 2021, 10:58 PM UTC (59bbd4d)">Diff</a>