### PR TITLE
`decodeAudioData` only returns the first track of a multi-track media file

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -175,6 +175,7 @@ window.addEventListener('load', (event) => {
   ListAmendments("c2359", "Proposed Correction", "change-list-2359");
   ListAmendments("c2373", "Proposed Correction", "change-list-2373");
   ListAmendments("c2321", "Proposed Correction", "change-list-2321");
+  ListAmendments("c2375", "Proposed Correction", "change-list-2375");
 });
 </script>
 <style>
@@ -1319,6 +1320,24 @@ Methods</h4>
 				{{BaseAudioContext/decodeAudioData(audioData, successCallback,
 				errorCallback)/audioData!!argument}} into [=linear PCM=]. In case of
 				failure, set <var>can decode</var> to <em>false</em>.
+
+				<div class="correction proposed" id="c2375-1">
+					<span class="marker">Proposed Correction
+						<a href="https://github.com/WebAudio/web-audio-api/issues/2375">Issue
+							2375</a>.
+					</span>
+					Only decode the first audio track of a multi-track media file.
+					<div class="amendment-buttons">
+						Buttons here
+					</div>
+					<ins cite=#c2375>
+						If the media byte-stream contains multiple audio tracks, only decode the
+						first track to [=linear pcm=].
+
+						Note: Authors who need more control over the decoding process can use
+						[[WEBCODECS]].
+					</ins>
+				</div>
 
 			4. If |can decode| is `false`,
 				<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
@@ -12913,6 +12932,9 @@ Change Log</h2>
     </div>
   * <a href="https://github.com/WebAudio/web-audio-api/issues/2321">Issue 2321</a>: Warn about corrupted fils in decodeAudioData.
     <div id="change-list-2321">
+    </div>
+  * <a href="https://github.com/WebAudio/web-audio-api/issues/2375">Issue 2375</a>: decodeAudioData only decodes the first track of a multi-track audio file.
+    <div id="change-list-2375">
     </div>
 
 <h3 id="changes-2021-05-06">


### PR DESCRIPTION
This fixes issue #2375.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2376.html" title="Last updated on Aug 31, 2021, 11:31 AM UTC (02481df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2376/8cf873c...02481df.html" title="Last updated on Aug 31, 2021, 11:31 AM UTC (02481df)">Diff</a>