### PR TITLE
Feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to fix the specification.  New feature?  See https://github.com/WebAudio/web-audio-api-v2/issues
-title: ''
+about: Create a report to fix the specification.
 labels: Needs WG review, Untriaged
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest additions for WebAudio
+title: ''
+labels: feature,Needs WG Review
+assignees: ''
+
+---
+
+**Describe the feature**
+Briefly describe the feature you would like WebAudio to have.
+
+**Is there a prototype?**
+If you have a prototype (possibly using an AudioWorkletNode), provide links to illustrate this addition.  This is the best way to propose a new feature.
+
+**Describe the feature in more detail**
+Provide more information how it does and how it works.


### PR DESCRIPTION
Hi! The web-audio-v2 repo is archived and says to file new issues on the v1 repo, but the existing templates on this repo suggest that new feature issues are filed on that repo.

I guess that that repo was archived and this one just hasn't had issue templates updated yet? If so, this PR removes that suggestion, and adds the existing Feature Request template from that repo here.

Let me know if my guess was incorrect, or if you want me to make any changes in this PR. Thanks!