### PR TITLE
Update README.md to remove any reference to a V2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,3 @@ and if appropriate [file an issue](https://github.com/web-platform-tests/wpt/iss
 up later. Add the `type:untestable` or `type:missing-coverage` label as appropriate.
 
 We also have an [implementation report](https://webaudio.github.io/web-audio-api/implementation-report.html).
-
-# v2.0
-
-See [Web Audio API v.2.0](https://github.com/WebAudio/web-audio-api-v2) .


### PR DESCRIPTION
It's just an historical artifact at this point. This removes any possible confusion.

See https://github.com/WebAudio/web-audio-api/discussions/2464.