### PR TITLE
Revise the description for AudioContext.outputLatency

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1658,11 +1658,10 @@ Attributes</h4>
 
 		The {{outputLatency}} attribute value depends
 		on the platform and the connected hardware audio output device.
-		The {{outputLatency}} attribute value does not
-		change for the context's lifetime as long as the connected
-		audio output device remains the same. If the audio output
-		device is changed the {{outputLatency}}
-		attribute value will be updated accordingly.
+		The {{outputLatency}} attribute value changes while the context
+		is running or the associated audio output device changes. It is
+		useful to query this value frequently when the accurate
+		synchronization is required.
 </dl>
 
 <h4 id="AudioContext-methods">

--- a/index.bs
+++ b/index.bs
@@ -1656,11 +1656,11 @@ Attributes</h4>
 		signal, this latter time refers to the time when a sample's
 		sound is produced.
 
-		The {{outputLatency}} attribute value depends
-		on the platform and the connected hardware audio output device.
-		The {{outputLatency}} attribute value changes while the context
+		An {{outputLatency}} attribute value depends on the platform and
+		the connected audio output device hardware. The
+		{{outputLatency}} attribute value may change while the context
 		is running or the associated audio output device changes. It is
-		useful to query this value frequently when the accurate
+		useful to query this value frequently when accurate
 		synchronization is required.
 </dl>
 


### PR DESCRIPTION
As we agreed on the teleconf 2/10/2022:
- The output latency value changes at run time.
- Adding informative notes to clarify how this attribute can be useful.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hoch/web-audio-api/pull/2470.html" title="Last updated on Feb 14, 2022, 4:19 PM UTC (a6dd0df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2470/95992b4...hoch:a6dd0df.html" title="Last updated on Feb 14, 2022, 4:19 PM UTC (a6dd0df)">Diff</a>