### PR TITLE
Align dfn syntax for constructors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4976,7 +4976,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
 <h4 id="AudioBufferSourceNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="AudioBufferSourceNode">
+<dl dfn-type=constructor dfn-for="AudioBufferSourceNode" id="dom-audiobuffersourcenode-constructor-audiobuffersourcenode">
 	: <dfn>AudioBufferSourceNode(context, options)</dfn>
 	::
 
@@ -6686,7 +6686,7 @@ interface ChannelMergerNode : AudioNode {
 <h4 id="ChannelMergerNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ChannelMergerNode">
+<dl dfn-type=constructor dfn-for="ChannelMergerNode" id="dom-channelmergernode-constructor-channelmergernode">
 	: <dfn>ChannelMergerNode(context, options)</dfn>
 	::
 
@@ -6799,7 +6799,7 @@ interface ChannelSplitterNode : AudioNode {
 <h4 id="ChannelSplitterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ChannelSplitterNode">
+<dl dfn-type=constructor dfn-for="ChannelSplitterNode" id="dom-channelsplitternode-constructor-channelsplitternode">
 	: <dfn>ChannelSplitterNode(context, options)</dfn>
 	::
 
@@ -6882,7 +6882,7 @@ interface ConstantSourceNode : AudioScheduledSourceNode {
 <h4 id="ConstantSourceNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ConstantSourceNode">
+<dl dfn-type=constructor dfn-for="ConstantSourceNode" id="dom-constantsourcenode-constructor-constantsourcenode">
 	: <dfn>ConstantSourceNode(context, options)</dfn>
 	::
 
@@ -6989,7 +6989,7 @@ interface ConvolverNode : AudioNode {
 <h4 id="ConvolverNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ConvolverNode">
+<dl dfn-type=constructor dfn-for="ConvolverNode" id="dom-convolvernode-constructor-convolvernode">
 	: <dfn>ConvolverNode(context, options)</dfn>
 	::
 		When the constructor is called with a {{BaseAudioContext}} <var>context</var> and
@@ -7275,7 +7275,7 @@ interface DelayNode : AudioNode {
 <h4 id="DelayNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="DelayNode">
+<dl dfn-type=constructor dfn-for="DelayNode" id="dom-delaynode-constructor-delaynode">
 	: <dfn>DelayNode(context, options)</dfn>
 	::
 
@@ -7439,7 +7439,7 @@ interface DynamicsCompressorNode : AudioNode {
 <h4 id="DynamicsCompressorNode-constructors">
 Constructors</h4>
 
-<dl dfn-type="constructor" dfn-for="DynamicsCompressorNode">
+<dl dfn-type="constructor" dfn-for="DynamicsCompressorNode" id="dom-dynamicscompressornode-constructor-dynamicscompressornode">
 	: <dfn>DynamicsCompressorNode(context, options)</dfn>
 	::
 
@@ -7895,7 +7895,7 @@ interface GainNode : AudioNode {
 <h4 id="GainNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="GainNode">
+<dl dfn-type=constructor dfn-for="GainNode" id="dom-gainnode-constructor-gainnode">
 	: <dfn>GainNode(context, options)</dfn>
 	::
 
@@ -8009,7 +8009,7 @@ interface IIRFilterNode : AudioNode {
 <h4 id="IIRFilterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="IIRFilterNode">
+<dl dfn-type=constructor dfn-for="IIRFilterNode" id="dom-iirfilternode-constructor-iirfilternode">
 	: <dfn>IIRFilterNode(context, options)</dfn>
 	::
 

--- a/index.bs
+++ b/index.bs
@@ -4976,7 +4976,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
 <h4 id="AudioBufferSourceNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=method dfn-for="AudioBufferSourceNode/constructor">
+<dl dfn-type=constructor dfn-for="AudioBufferSourceNode">
 	: <dfn>AudioBufferSourceNode(context, options)</dfn>
 	::
 
@@ -6686,7 +6686,7 @@ interface ChannelMergerNode : AudioNode {
 <h4 id="ChannelMergerNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=method dfn-for="ChannelMergerNode/constructor">
+<dl dfn-type=constructor dfn-for="ChannelMergerNode">
 	: <dfn>ChannelMergerNode(context, options)</dfn>
 	::
 
@@ -6799,7 +6799,7 @@ interface ChannelSplitterNode : AudioNode {
 <h4 id="ChannelSplitterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ChannelSplitterNode/constructor()">
+<dl dfn-type=constructor dfn-for="ChannelSplitterNode">
 	: <dfn>ChannelSplitterNode(context, options)</dfn>
 	::
 
@@ -6882,7 +6882,7 @@ interface ConstantSourceNode : AudioScheduledSourceNode {
 <h4 id="ConstantSourceNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=method dfn-for="ConstantSourceNode/constructor()">
+<dl dfn-type=constructor dfn-for="ConstantSourceNode">
 	: <dfn>ConstantSourceNode(context, options)</dfn>
 	::
 
@@ -6989,7 +6989,7 @@ interface ConvolverNode : AudioNode {
 <h4 id="ConvolverNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="ConvolverNode/constructor()">
+<dl dfn-type=constructor dfn-for="ConvolverNode">
 	: <dfn>ConvolverNode(context, options)</dfn>
 	::
 		When the constructor is called with a {{BaseAudioContext}} <var>context</var> and
@@ -7275,7 +7275,7 @@ interface DelayNode : AudioNode {
 <h4 id="DelayNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="DelayNode/constructor()">
+<dl dfn-type=constructor dfn-for="DelayNode">
 	: <dfn>DelayNode(context, options)</dfn>
 	::
 
@@ -7439,7 +7439,7 @@ interface DynamicsCompressorNode : AudioNode {
 <h4 id="DynamicsCompressorNode-constructors">
 Constructors</h4>
 
-<dl dfn-type="method" dfn-for="DynamicsCompressorNode/constructor()">
+<dl dfn-type="constructor" dfn-for="DynamicsCompressorNode">
 	: <dfn>DynamicsCompressorNode(context, options)</dfn>
 	::
 
@@ -7895,7 +7895,7 @@ interface GainNode : AudioNode {
 <h4 id="GainNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=method dfn-for="GainNode/constructor()">
+<dl dfn-type=constructor dfn-for="GainNode">
 	: <dfn>GainNode(context, options)</dfn>
 	::
 
@@ -8009,7 +8009,7 @@ interface IIRFilterNode : AudioNode {
 <h4 id="IIRFilterNode-constructors">
 Constructors</h4>
 
-<dl dfn-type=constructor dfn-for="IIRFilterNode/constructor()">
+<dl dfn-type=constructor dfn-for="IIRFilterNode">
 	: <dfn>IIRFilterNode(context, options)</dfn>
 	::
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/web-audio-api/pull/2473.html" title="Last updated on Feb 23, 2022, 10:34 AM UTC (a64c6af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2473/7a2ca43...dontcallmedom:a64c6af.html" title="Last updated on Feb 23, 2022, 10:34 AM UTC (a64c6af)">Diff</a>