### PR TITLE
Add "extract" class to old AudioContext IDL definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1521,7 +1521,7 @@ enum AudioContextLatencyCategory {
 		Buttons here
 	</div>
 	<del cite=#c2444>
-		<xmp class="idl" data-no-idl>
+		<xmp class="idl extract" data-no-idl>
 		[Exposed=Window]
 		interface AudioContext : BaseAudioContext {
 			constructor (optional AudioContextOptions contextOptions = {});


### PR DESCRIPTION
The `data-no-idl` attribute that was added in #2462 tells Bikeshed not to process the current `AudioContext` IDL block. This is enough to work around duplicate definition errors that would otherwise occur.

However, even though it is not processed, Bikeshed still adds the IDL block to the [final IDL index](https://webaudio.github.io/web-audio-api/#idl-index), which thus contains both the current and future `AudioContext` interface definitions.

The `extract` class tells Bikeshed not to include the current IDL block in the final IDL index.

Note: I'm taking for granted that the working group would like the "future" IDL block to be the one that becomes authoritative, and in particular the one that shows up in Web Platform Tests. If the group rather wanted the "current" IDL block to remain the authoritative one for now, the `extract` class should rather be added to the future IDL block.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/web-audio-api/pull/2486.html" title="Last updated on Apr 26, 2022, 8:27 AM UTC (0cccc72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2486/6efc9f0...tidoust:0cccc72.html" title="Last updated on Apr 26, 2022, 8:27 AM UTC (0cccc72)">Diff</a>