### PR TITLE
Fix IDL errors in AudioRenderCapacity interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2160,8 +2160,8 @@ Dictionary {{AudioTimestamp}} Members</h5>
 
 		<pre class="idl">
 		[Exposed=Window]
-		interface AudioRenderCapacity {
-			undefined start(AudioRenderCapacityOptions options);
+		interface AudioRenderCapacity : EventTarget {
+			undefined start(AudioRenderCapacityOptions options = {});
 				undefined stop();
 				attribute EventHandler onupdate;
 		};
@@ -2233,13 +2233,19 @@ Dictionary {{AudioTimestamp}} Members</h5>
 
 		<pre class="idl">
 		[Exposed=Window]
-		interface AudioRenderCapacityEvent {
-			constructor (DOMString type, double timestamp, double averageLoad,
-									double peakLoad, double underrunRatio);
+		interface AudioRenderCapacityEvent : Event {
+			constructor (DOMString type, optional AudioRenderCapacityEventInit eventInitDict = {});
 				readonly attribute double timestamp;
 				readonly attribute double averageLoad;
 				readonly attribute double peakLoad;
 				readonly attribute double underrunRatio;
+		};
+
+		dictionary AudioRenderCapacityEventInit : EventInit {
+			double timestamp = 0;
+			double averageLoad = 0;
+			double peakLoad = 0;
+			double underrunRatio = 0;
 		};
 		</pre>
 

--- a/index.bs
+++ b/index.bs
@@ -2161,7 +2161,7 @@ Dictionary {{AudioTimestamp}} Members</h5>
 		<pre class="idl">
 		[Exposed=Window]
 		interface AudioRenderCapacity : EventTarget {
-			undefined start(AudioRenderCapacityOptions options = {});
+			undefined start(optional AudioRenderCapacityOptions options = {});
 				undefined stop();
 				attribute EventHandler onupdate;
 		};


### PR DESCRIPTION
Fixes #2488 and closes #2485.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2489.html" title="Last updated on May 2, 2022, 2:35 PM UTC (fb6e740)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2489/6efc9f0...fb6e740.html" title="Last updated on May 2, 2022, 2:35 PM UTC (fb6e740)">Diff</a>