### PR TITLE
AudioContext.setSinkId()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1574,7 +1574,7 @@ enum AudioContextSinkCategory {
 			Promise<undefined> resume ();
 			Promise<undefined> suspend ();
 			Promise<undefined> close ();
-			[SecureContext] Promise<undefined> setSinkId((DOMString or AudioContextSinkCategory)) sinkId);
+			[SecureContext] Promise<undefined> setSinkId((DOMString or AudioContextSinkCategory) sinkId);
 			MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
 			MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
 			MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (
@@ -1598,6 +1598,10 @@ and to allow it only when the {{AudioContext}}'s [=relevant global object=] has
 	::
 		A boolean flag representing whether the context is suspended by user code.
 		The initial value is <code>false</code>.
+
+	: <dfn>[[sink ID]]</dfn>
+	::
+		sinkid. Initialize it to <code>""</code>.
 </dl>
 
 <h4 id="AudioContext-constructors">
@@ -1618,6 +1622,9 @@ Constructors</h4>
 
 			1. Let |context| be a new {{AudioContext}} object.
 
+			1. Let |document| be the current settings object's
+				[=associated Document=].
+
 			1. Set a {{[[control thread state]]}} to <code>suspended</code> on
 				|context|.
 
@@ -1629,13 +1636,10 @@ Constructors</h4>
 				a slot on |context|, that is an initially empty ordered list of
 				promises.
 			
-			1. Let |context| have a [[SinkId]] internal slot, initialize to "".
-
 			1. If <code>contextOptions</code> is given, perform the following
 				substeps:
 
-				1. If <code>contextOptions.{{AudioContextOptions/sinkId}}</code> is
-					specified, set |sinkId| to
+				1. If {{AudioContextOptions/sinkId}} is specified, set |sinkId| to
 					<code>contextOptions.{{AudioContextOptions/sinkId}}</code> and run
 					the following substeps:
 
@@ -1645,7 +1649,7 @@ Constructors</h4>
 						the result that would be provided by
 						{{MediaDevices/enumerateDevices()}}, abort these substeps.
 
-					1. Set [[SinkId]] to |sinkId|.
+					1. Set {{AudioContext/[[sink ID]]}} to |sinkId|.
 
 				1. Set the internal latency of |context| according to
 					<code>contextOptions.{{AudioContextOptions/latencyHint}}</code>, as
@@ -1664,20 +1668,20 @@ Constructors</h4>
 			1. Run the following substeps to prepare an audio output device for
 				rendering:
 
-				1. If [[SinkId]] is <code>"none"</code>, acquire system resources to
+				1. If {{[[SinkId]]}} is <code>"none"</code>, acquire system resources to
 					render the audio graph without an actual audio output device. Abort
 					these substeps.
 
-				1. If [[SinkId]] is the empty string, acquire system resources to
+				1. If {{[[SinkId]]}} is the empty string, acquire system resources to
 					render the audio graph with a default audio output device. Abort
 					these substeps.
 
-				1. If [[SinkId]] is not the empty string, acquire system resources to
-					render the audio graph with the underlying audio output device
-					identified by [[SinkId]].
+				1. If {{[[SinkId]]}} is not the empty string, acquire system resources
+					to render the audio graph with the underlying audio output device
+					identified by {{[[SinkId]]}}.
 			
-			1. If the context is <a>allowed to start</a>, send a <a>control message
-				</a> to start processing.
+			1. If the context is <a>allowed to start</a>, send a
+				<a>control message</a> to start processing.
 
 			1. Return |context| object.
 		</div>
@@ -1769,7 +1773,7 @@ Attributes</h4>
 	::
 		This attribute contains the ID of the current audio output device, or the
 		empty string for the user-agent default device. The attribute MUST return
-		the value of [[sinkId]] internal slot upon getting.
+		the value of {{AudioContext/[[SinkId]]}} internal slot upon getting.
 </dl>
 
 <h4 id="AudioContext-methods">
@@ -2142,61 +2146,61 @@ Methods</h4>
 			this method is invoked, the user agent MUST run the following steps:
 
 			<div algorithm="AudioContext.setSinkId()">
-			1. Let |document| be the current settings object's
-				[=associated Document=].
+				1. Let |document| be the current settings object's
+					[=associated Document=].
 
-			1. If |document| is not allowed to use the feature identified by
-				<code>"speaker-selection"</code>, return [=a promise rejected with=] a
-				new {{DOMException}} whose name is "{{NotAllowedError}}".
+				1. If |document| is not allowed to use the feature identified by
+					<code>"speaker-selection"</code>, return [=a promise rejected with=] a
+					new {{DOMException}} whose name is "{{NotAllowedError}}".
 
-			1. Let |context| be the {{AudioContext}} object on which this method was
-				invoked.
+				1. Let |context| be the {{AudioContext}} object on which this method was
+					invoked.
 
-			1. Let |sinkId| be the method's first argument.
+				1. Let |sinkId| be the method's first argument.
 
-			1. If |sinkId| is equal to context's [[SinkId]] internal slot, return a
-				promise resolved with {{undefined}}.
+				1. If |sinkId| is equal to |context|'s {{[[SinkId]]}} internal slot,
+					return a promise resolved with {{undefined}}.
 
-			1. Let |p| be a new promise.
+				1. Let |p| be a new promise.
 
-			1. Run the following substeps:
+				1. Run the following substeps:
 
-				1. If |sinkId| is the empty string, reject |p| with a new
-					{{DOMException}} whose name is "{{NotFoundError}}" and abort these
-					substeps.
+					1. If |sinkId| is the empty string, reject |p| with a new
+						{{DOMException}} whose name is "{{NotFoundError}}" and abort these
+						substeps.
 
-				1. If |sinkId| does not match any audio output device identified by
-					the result that would be provided by
-					{{MediaDevices/enumerateDevices()}}, reject |p| with a new
-					{{DOMException}} whose name is "{{NotFoundError}}" and abort these
-					substeps.
+					1. If |sinkId| does not match any audio output device identified by
+						the result that would be provided by
+						{{MediaDevices/enumerateDevices()}}, reject |p| with a new
+						{{DOMException}} whose name is "{{NotFoundError}}" and abort these
+						substeps.
 
-				1. If the device specified by |sinkId| is not the user agent’s
-					default device or is not permitted to play audio through, reject |p|
-					with a new {{DOMException}} whose name is {{NotAllowedError}} and
-					abort these substeps.
+					1. If the device specified by |sinkId| is not the user agent’s
+						default device or is not permitted to play audio through, reject |p|
+						with a new {{DOMException}} whose name is {{NotAllowedError}} and
+						abort these substeps.
 
-				1. Stop playing audio out of the current output device.
+					1. Stop playing audio out of the current output device.
 
-				1. Run the following substeps to prepare an audio output device for
-					rendering:
+					1. Run the following substeps to prepare an audio output device for
+						rendering:
 
-					1. Set context’s [[SinkId]] internal slot to |sinkId|.
+						1. Set context’s {{[[SinkId]]}} internal slot to |sinkId|.
 
-					1. If [[SinkId]] is <code>"none"</code>, acquire system resources to
-						render the audio graph without an actual audio output device. Abort
-						these substeps.
+						1. If {{[[SinkId]]}} is <code>"none"</code>, acquire system
+							resources to render the audio graph without an actual audio
+							output device. Abort these substeps.
 
-					1. If [[SinkId]] is not the empty string, acquire system resources to
-						render the audio graph with the underlying audio output device
-						identified by [[SinkId]].
+						1. If {{[[SinkId]]}} is not the empty string, acquire system
+							resources to render the audio graph with the underlying audio
+							output device identified by {{[[SinkId]]}}.
 
-				1. Queue a task to perform the following steps:
+					1. Queue a task to perform the following steps:
 
-					1. Resolve |p|.
-			
-			1. Return |p|.
-		</div>
+						1. Resolve |p|.
+				
+				1. Return |p|.
+			</div>
 </dl>
 
 <h4 dictionary id="AudioContextOptions">

--- a/index.bs
+++ b/index.bs
@@ -1511,6 +1511,28 @@ enum AudioContextLatencyCategory {
 </table>
 </div>
 
+<pre class="idl">
+enum AudioContextSinkCategory {
+		"none"
+};
+</pre>
+
+<div class="enum-description">
+<table class="simple" dfn-type=enum-value dfn-for="AudioContextSinkCategory">
+	<thead>
+		<tr>
+			<th scope="col" colspan="2">
+				Enumeration description
+	<tbody>
+		<tr>
+			<td>
+				"<dfn>none</dfn>"
+			<td>
+				The audio graph will be rendered by a worker thread without using an
+				audio output device.
+</table>
+</div>
+
 <div class="correction proposed" id="c2444-1">
 	<span class="marker">Proposed Addition
 		<a href="https://github.com/WebAudio/web-audio-api/issues/2444">Issue
@@ -1592,36 +1614,70 @@ Constructors</h4>
 			<span class="synchronous">When creating an {{AudioContext}},
 			execute these steps:</span>
 
-			1. Set a {{[[control thread state]]}} to <code>suspended</code> on the {{AudioContext}}.
+			1. Let |context| be a new {{AudioContext}} object.
 
-			2. Set a {{[[rendering thread state]]}} to <code>suspended</code> on the {{AudioContext}}.
+			1. Set a {{[[control thread state]]}} to <code>suspended</code> on
+				|context|.
 
-			3. Let <dfn attribute for="AudioContext">[[pending resume promises]]</dfn> be a
-				slot on this {{AudioContext}}, that is an initially empty ordered list of
+			1. Set a {{[[rendering thread state]]}} to <code>suspended</code> on
+				|context|.
+
+			1. Let 
+				<dfn attribute for="AudioContext">[[pending resume promises]]</dfn> be
+				a slot on |context|, that is an initially empty ordered list of
 				promises.
+			
+			1. Let |context| have a [[SinkId]] internal slot, initialize to "".
 
-			4. If <code>contextOptions</code> is given, apply the options:
+			1. If <code>contextOptions</code> is given, perform the following
+				substeps:
 
-				1. Set the internal latency of this {{AudioContext}}
-					according to <code>contextOptions.{{AudioContextOptions/latencyHint}}</code>, as described
-					in {{AudioContextOptions/latencyHint}}.
+				1. If <code>contextOptions.{{AudioContextOptions/sinkId}}</code> is
+					specified, set |sinkId| to
+					<code>contextOptions.{{AudioContextOptions/sinkId}}</code> and run
+					the following substeps:
 
-				2. If <code>contextOptions.{{AudioContextOptions/sampleRate}}</code> is specified,
-					set the {{BaseAudioContext/sampleRate}}
-					of this {{AudioContext}} to this value. Otherwise, use
-					the sample rate of the default output device. If the
-					selected sample rate differs from the sample rate of the
-					output device, this {{AudioContext}} MUST resample the
-					audio output to match the sample rate of the output device.
+					1. If |document| is not allowed to use the feature identified by
+						<code>“speaker-selection”</code>, |sinkId| is the empty string,
+						or |sinkId| does not match any audio output device identified by
+						the result that would be provided by
+						{{MediaDevices/enumerateDevices()}}, abort these substeps.
 
-					Note: If resampling is required, the latency of the
-					AudioContext may be affected, possibly by a large
-					amount.
+					1. Set [[SinkId]] to |sinkId|.
 
-			5. If the context is <a>allowed to start</a>, send a
-				<a>control message</a> to start processing.
+				1. Set the internal latency of |context| according to
+					<code>contextOptions.{{AudioContextOptions/latencyHint}}</code>, as
+					described in {{AudioContextOptions/latencyHint}}.
 
-			6. Return this {{AudioContext}} object.
+				1. If <code>contextOptions.{{AudioContextOptions/sampleRate}}</code> is
+					specified, set the {{BaseAudioContext/sampleRate}} of |context| to
+					this value. Otherwise, use the sample rate of the default output
+					device. If the selected sample rate differs from the sample rate of
+					the output device, the user agent MUST resample the audio output to
+					match the sample rate of the output device.
+
+					Note: If resampling is required, the latency of |context|	may be
+					affected, possibly by a large amount.
+
+			1. Run the following substeps to prepare an audio output device for
+				rendering:
+
+				1. If [[SinkId]] is <code>"none"</code>, acquire system resources to
+					render the audio graph without an actual audio output device. Abort
+					these substeps.
+
+				1. If [[SinkId]] is the empty string, acquire system resources to
+					render the audio graph with a default audio output device. Abort
+					these substeps.
+
+				1. If [[SinkId]] is not the empty string, acquire system resources to
+					render the audio graph with the underlying audio output device
+					identified by [[SinkId]].
+			
+			1. If the context is <a>allowed to start</a>, send a <a>control message
+				</a> to start processing.
+
+			1. Return |context| object.
 		</div>
 
 		<div algorithm="sending a control message to start processing">

--- a/index.bs
+++ b/index.bs
@@ -1763,7 +1763,7 @@ Attributes</h4>
 	::
 		Returns an {{AudioRenderCapacity}} instance associated with
 		an {{AudioContext}}.
-	</ins>
+		</ins>
 </div>
 	: <dfn>sinkId</dfn>
 	::
@@ -2188,15 +2188,15 @@ Methods</h4>
 						these substeps.
 
 					1. If [[SinkId]] is not the empty string, acquire system resources to
-					render the audio graph with the underlying audio output device
-					identified by [[SinkId]].
+						render the audio graph with the underlying audio output device
+						identified by [[SinkId]].
 
 				1. Queue a task to perform the following steps:
 
 					1. Resolve |p|.
 			
 			1. Return |p|.
-			</div>
+		</div>
 </dl>
 
 <h4 dictionary id="AudioContextOptions">

--- a/index.bs
+++ b/index.bs
@@ -1569,10 +1569,12 @@ enum AudioContextSinkCategory {
 			readonly attribute double baseLatency;
 			readonly attribute double outputLatency;
 			[SecureContext] readonly attribute AudioRenderCapacity renderCapacity;
+			readonly attribute DOMString sinkId;
 			AudioTimestamp getOutputTimestamp ();
 			Promise<undefined> resume ();
 			Promise<undefined> suspend ();
 			Promise<undefined> close ();
+			[SecureContext] Promise<undefined> setSinkId((DOMString or AudioContextSinkCategory)) sinkId);
 			MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
 			MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
 			MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (
@@ -1761,9 +1763,13 @@ Attributes</h4>
 	::
 		Returns an {{AudioRenderCapacity}} instance associated with
 		an {{AudioContext}}.
-
 	</ins>
 </div>
+	: <dfn>sinkId</dfn>
+	::
+		This attribute contains the ID of the current audio output device, or the
+		empty string for the user-agent default device. The attribute MUST return
+		the value of [[sinkId]] internal slot upon getting.
 </dl>
 
 <h4 id="AudioContext-methods">
@@ -2129,6 +2135,68 @@ Methods</h4>
 		<div>
 			<em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
 		</div>
+
+		: <dfn>setSinkId((DOMString or AudioContextSinkCategory) sinkId)</dfn>
+		::
+			Sets the ID of the output device if it is permitted to play audio. When
+			this method is invoked, the user agent MUST run the following steps:
+
+			<div algorithm="AudioContext.setSinkId()">
+			1. Let |document| be the current settings object's
+				[=associated Document=].
+
+			1. If |document| is not allowed to use the feature identified by
+				<code>"speaker-selection"</code>, return [=a promise rejected with=] a
+				new {{DOMException}} whose name is "{{NotAllowedError}}".
+
+			1. Let |context| be the {{AudioContext}} object on which this method was
+				invoked.
+
+			1. Let |sinkId| be the method's first argument.
+
+			1. If |sinkId| is equal to context's [[SinkId]] internal slot, return a
+				promise resolved with {{undefined}}.
+
+			1. Let |p| be a new promise.
+
+			1. Run the following substeps:
+
+				1. If |sinkId| is the empty string, reject |p| with a new
+					{{DOMException}} whose name is "{{NotFoundError}}" and abort these
+					substeps.
+
+				1. If |sinkId| does not match any audio output device identified by
+					the result that would be provided by
+					{{MediaDevices/enumerateDevices()}}, reject |p| with a new
+					{{DOMException}} whose name is "{{NotFoundError}}" and abort these
+					substeps.
+
+				1. If the device specified by |sinkId| is not the user agent’s
+					default device or is not permitted to play audio through, reject |p|
+					with a new {{DOMException}} whose name is {{NotAllowedError}} and
+					abort these substeps.
+
+				1. Stop playing audio out of the current output device.
+
+				1. Run the following substeps to prepare an audio output device for
+					rendering:
+
+					1. Set context’s [[SinkId]] internal slot to |sinkId|.
+
+					1. If [[SinkId]] is <code>"none"</code>, acquire system resources to
+						render the audio graph without an actual audio output device. Abort
+						these substeps.
+
+					1. If [[SinkId]] is not the empty string, acquire system resources to
+					render the audio graph with the underlying audio output device
+					identified by [[SinkId]].
+
+				1. Queue a task to perform the following steps:
+
+					1. Resolve |p|.
+			
+			1. Return |p|.
+			</div>
 </dl>
 
 <h4 dictionary id="AudioContextOptions">
@@ -2173,6 +2241,11 @@ Dictionary {{AudioContextOptions}} Members</h5>
 		If {{AudioContextOptions/sampleRate}} is not
 		specified, the preferred sample rate of the output device for
 		this {{AudioContext}} is used.
+
+	: <dfn>sinkId</dfn>
+	::
+		Set the ID of the output device if the {{AudioContext}} is permitted to
+		play audio.
 </dl>
 
 <h4 dictionary id="AudioTimestamp">


### PR DESCRIPTION
[work-in-progress] Uploading this PR to have further discussion.

TODO:
- [ ] Add `onsinkchange` event handler
- [ ] Confirm defaulting behavior (with no valid output device)
- [ ] Confirm the process of "acquiring system resource"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2497.html" title="Last updated on Jul 20, 2022, 12:44 AM UTC (4b3ebfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2497/dd2a12d...4b3ebfe.html" title="Last updated on Jul 20, 2022, 12:44 AM UTC (4b3ebfe)">Diff</a>