### PR TITLE
Add a caption and split the colum header on each enumeration description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -790,10 +790,10 @@ enum AudioContextState {
 
 <div class="enum-description">
 <table class="simple" dfn-for="AudioContextState" dfn-type="enum-value">
+    <caption>{{AudioContextState}} enumeration description</caption>
 	<thead>
 		<tr>
-			<th scope="col" colspan="2">
-				Enumeration description
+            <th>Enum value</th><th>Description</th>
 	<tbody>
 		<tr>
 			<td>
@@ -1486,10 +1486,10 @@ enum AudioContextLatencyCategory {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="AudioContextLatencyCategory">
+    <caption>{{AudioContextLatencyCategory}} enumeration description</caption>
 	<thead>
 		<tr>
-			<th scope="col" colspan="2">
-				Enumeration description
+            <th>Enum value</th><th>Description</th>
 	<tbody>
 		<tr>
 			<td>
@@ -3152,10 +3152,10 @@ mixing is to be done.
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="ChannelCountMode">
+    <caption>{{ChannelCountMode}} enumeration description</caption>
 	<thead>
 	<tr>
-		<th scope="col" colspan="2">
-			Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 	<tr>
 		<td>"<dfn>max</dfn>"
@@ -3186,10 +3186,10 @@ enum ChannelInterpretation {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="ChannelInterpretation">
+    <caption>{{ChannelInterpretation}} enumeration description</caption>
 	<thead>
 	<tr>
-		<th scope="col" colspan="2">
-			Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 	<tr>
 		<td>"<dfn>speakers</dfn>"
@@ -3807,10 +3807,10 @@ enum AutomationRate {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="AutomationRate">
+    <caption>{{AutomationRate}} enumeration description</caption>
 	<thead>
 		<tr>
-		<th scope="col" colspan="2">
-			Enumeration description
+			<th>Enum value</th><th>Description</th>
 		</th>
 		</tr>
 	<tbody>
@@ -6257,10 +6257,10 @@ enum BiquadFilterType {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="BiquadFilterType">
+    <caption>{{BiquadFilterType}} enumeration description</caption>
 	<thead>
 	<tr>
-		<th scope="col" colspan="2">
-			Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 	<tr>
 		<td>"<dfn>lowpass</dfn>"
@@ -8754,8 +8754,9 @@ enum OscillatorType {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="OscillatorType">
+    <caption>{{OscillatorType}} enumeration description</caption>
 	<thead>
-		<tr><th scope="col" colspan="2">Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 		<tr><td>"<dfn>sine</dfn>" <td>A sine wave
 		<tr><td>"<dfn>square</dfn>" <td>A square wave of duty period 0.5
@@ -9026,8 +9027,9 @@ enum PanningModelType {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="PanningModelType">
+    <caption>{{PanningModelType}} enumeration description</caption>
 	<thead>
-		<tr><th scope="col" colspan="2">Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 		<tr><td>"<dfn>equalpower</dfn>"
 		<td>
@@ -9077,8 +9079,9 @@ enum DistanceModelType {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="DistanceModelType">
+    <caption>{{DistanceModelType}} enumeration description</caption>
 	<thead>
-		<tr><th scope="col" colspan="2">Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 		<tr>
 			<td>"<dfn>linear</dfn>"
@@ -9969,8 +9972,9 @@ enum OverSampleType {
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="OverSampleType">
+    <caption>{{OverSampleType}} enumeration description</caption>
 	<thead>
-		<tr><th scope="col" colspan="2">Enumeration description
+		<th>Enum value</th><th>Description</th>
 	<tbody>
 		<tr><td>"<dfn>none</dfn>"
 			<td>Don't oversample


### PR DESCRIPTION
This fixes #2490.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2508.html" title="Last updated on Sep 14, 2022, 10:25 PM UTC (b3426d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2508/dd2a12d...b3426d2.html" title="Last updated on Sep 14, 2022, 10:25 PM UTC (b3426d2)">Diff</a>