### PR TITLE
Adjust del part of AudioWorklet to avoid duplication in IDL index

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -10331,7 +10331,7 @@ Add a MessagePort to the AudioWorkletGlobalScope
 <div class="amendment-buttons">
 </div>
 <del cite=#2456>
-	<pre class="idl">
+	<pre class="idl extract" data-no-idl>
 [Exposed=Window, SecureContext]
 interface AudioWorklet : Worklet {
 };


### PR DESCRIPTION
Editing tools are still not very good at handling proposed changes constructs in specifications. The `<del>` part of the `AudioWorklet` definition is incorrectly linkified and duplicated in the final IDL index.

This update adds the `extract` class and the `data-no-idl` attributes to this definition as a workaround, as was done for `AudioContext` and `AudioWorkletProcessorConstructor`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 20, 2022, 8:19 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWebAudio%2Fweb-audio-api%2Fd19b57012bb5b9c9d6050e9a76a3e3e08c42f3a5%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232511.)._
</details>
