### PR TITLE
Add "extract" class to deleted AudioContextOptions IDL block

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2455,7 +2455,7 @@ specify user-specified options for an {{AudioContext}}.
 			2400</a> Access to a different output device
 	<div class="amendment-buttons"></div>
 	<del cite=#2400>
-<pre class="idl" data-no-idl>
+<pre class="idl extract" data-no-idl>
 	dictionary AudioContextOptions {
 		(AudioContextLatencyCategory or double) latencyHint = "interactive";
 		float sampleRate;


### PR DESCRIPTION
The `data-no-idl` attribute tells Bikeshed not to process the IDL block, but it's still included in the IDL index. This update adds the necessary `class=extract` attribute to make Bikeshed skip the IDL block when it builds the IDL index.

FWIW, I note a related past discussion on Bikeshed's issue tracker: [Exclude data-no-idl blocks from IDL Index?](https://github.com/tabatkins/bikeshed/issues/598). In your case, ideally, Bikeshed would skip and avoid processing the IDL block simply because it appears in a `<del>`.