### PR TITLE
Fix WebIDL validation errors from PR2498

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2350,7 +2350,7 @@ Methods</h4>
 
 				1. If |sinkId| is a type of {{AudioSinkOptions}} and
 					{{AudioContext/[[sink ID]]}} is a type of {{AudioSinkInfo}}, and
-					{{AudioSinkOption/type}} in |sinkId| and {{AudioSinkInfo/type}} in
+					{{AudioSinkOptions/type}} in |sinkId| and {{AudioSinkInfo/type}} in
 					{{AudioContext/[[sink ID]]}} are equal,
 					<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
 					queue a media element task</a> to resolve |p| and abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -1576,13 +1576,14 @@ enum AudioSinkType {
 			constructor (optional AudioContextOptions contextOptions = {});
 			readonly attribute double baseLatency;
 			readonly attribute double outputLatency;
-			readonly attribute (DOMString or AudioSinkOptions) sinkId;
+			[SecureContext] readonly attribute (DOMString or AudioSinkInfo) sinkId;
 			[SecureContext] readonly attribute AudioRenderCapacity renderCapacity;
 			attribute EventHandler onsinkchange;
 			AudioTimestamp getOutputTimestamp ();
 			Promise<undefined> resume ();
 			Promise<undefined> suspend ();
 			Promise<undefined> close ();
+			[SecureContext] Promise<undefined> setSinkId ((DOMString or AudioSinkOptions) sinkId);
 			MediaElementAudioSourceNode createMediaElementSource (HTMLMediaElement mediaElement);
 			MediaStreamAudioSourceNode createMediaStreamSource (MediaStream mediaStream);
 			MediaStreamTrackAudioSourceNode createMediaStreamTrackSource (
@@ -1614,7 +1615,7 @@ and to allow it only when the {{AudioContext}}'s [=relevant global object=] has
 	<ins cite=#2400>
 	: <dfn>[[sink ID]]</dfn>
 	::
-		A {{DOMString}} or an {{AudioSinkOptions}} representing the identifier
+		A {{DOMString}} or an {{AudioSinkInfo}} representing the identifier
 		or the information of the current audio output device respectively. The
 		initial value is <code>""</code>, which means the default audio output
 		device.
@@ -1730,7 +1731,13 @@ Constructors</h4>
 							1. If |validationResult| is a type of {{DOMException}}, throw an
 								exception with |validationResult| and abort these steps.
 		
-							1. Set {{AudioContext/[[sink ID]]}} to |sinkId|.
+							1. If |sinkId| is a type of {{DOMString}}, set
+								{{AudioContext/[[sink ID]]}} to |sinkId|. Abort these steps.
+
+							1. If |sinkId| is a type of {{AudioSinkOptions}}, set
+								{{AudioContext/[[sink ID]]}} to a new instance of
+								{{AudioSinkInfo}} created with the value of
+								{{AudioSinkOptions/type}} of |sinkId|.
 		
 						1. Set the internal latency of |context| according to
 							<code>contextOptions.{{AudioContextOptions/latencyHint}}</code>,
@@ -1915,7 +1922,9 @@ Attributes</h4>
 	<ins cite=#2400>
 	: <dfn>sinkId</dfn>
 	::
-		Returns the value of {{AudioContext/[[sink ID]]}} internal slot.
+		Returns the value of {{AudioContext/[[sink ID]]}} internal slot. This
+		attribute is cached upon update, and it returns the same object after
+		caching.
 
 	: <dfn>onsinkchange</dfn>
 	::
@@ -2532,7 +2541,7 @@ The {{AudioSinkOptions}} dictionary is used to specify options for
 
 <pre class="idl">
 dictionary AudioSinkOptions {
-	AudioSinkType type;
+	required AudioSinkType type;
 };
 </pre>
 
@@ -2544,6 +2553,28 @@ Dictionary {{AudioSinkOptions}} Members</h5>
 	::
 		A value of {{AudioSinkType}} to specify the type of the device.
 </dl>
+
+<h4 interface id="AudioSinkInfo">
+{{AudioSinkInfo}}</h4>
+
+The {{AudioSinkInfo}} interface is used to get information on the current
+audio output device via {{AudioContext/sinkId}}.
+
+<pre class="idl">
+interface AudioSinkInfo {
+	readonly attribute AudioSinkType type;
+};
+</pre>
+
+<h5 id="audiosinkinfo-attributes">
+Attributes</h5>
+
+<dl dfn-type=attribute dfn-for="AudioSinkInfo">
+	: <dfn>type</dfn>
+	::
+		A value of {{AudioSinkType}} that represents the type of the device.
+</dl>
+
 </ins>
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1729,10 +1729,11 @@ Constructors</h4>
 								</a> of |sinkId|.
 			
 							1. If |validationResult| is a type of {{DOMException}}, throw an
-								exception with |validationResult| and abort these steps.
+								exception with |validationResult| and abort these substeps.
 		
 							1. If |sinkId| is a type of {{DOMString}}, set
-								{{AudioContext/[[sink ID]]}} to |sinkId|. Abort these steps.
+								{{AudioContext/[[sink ID]]}} to |sinkId| and abort these
+								substeps.
 
 							1. If |sinkId| is a type of {{AudioSinkOptions}}, set
 								{{AudioContext/[[sink ID]]}} to a new instance of
@@ -2342,9 +2343,17 @@ Methods</h4>
 
 				1. Let |sinkId| be the sink identifier passed into this algorithm.
 
-				1. If |sinkId| is equal to {{AudioContext/[[sink ID]]}},
+				1. If both |sinkId| and {{AudioContext/[[sink ID]]}} are a type of
+					{{DOMString}}, and they are equal to each other,
 					<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-					queue a media element task</a> to resolve |p|. Then abort these steps.
+					queue a media element task</a> to resolve |p| and abort these steps.
+
+				1. If |sinkId| is a type of {{AudioSinkOptions}} and
+					{{AudioContext/[[sink ID]]}} is a type of {{AudioSinkInfo}}, and
+					{{AudioSinkOption/type}} in |sinkId| and {{AudioSinkInfo/type}} in
+					{{AudioContext/[[sink ID]]}} are equal,
+					<a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+					queue a media element task</a> to resolve |p| and abort these steps.
 
 				1. Let |wasRunning| be true.
 
@@ -2386,7 +2395,19 @@ Methods</h4>
 				1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
 					Queue a media element task</a> to execute the following steps:
 
-					1. Set {{AudioContext/[[sink ID]]}} to |sinkId|.
+					1. If |sinkId| is a type of {{DOMString}}, set
+						{{AudioContext/[[sink ID]]}} to |sinkId|. Abort these steps.
+
+					1. If |sinkId| is a type of {{AudioSinkOptions}} and
+						{{AudioContext/[[sink ID]]}} is a type of {{DOMString}},
+						set {{AudioContext/[[sink ID]]}} to a new instance of
+						{{AudioSinkInfo}} created with the value of
+						{{AudioSinkOptions/type}} of |sinkId|.
+
+					1. If |sinkId| is a type of {{AudioSinkOptions}} and
+						{{AudioContext/[[sink ID]]}} is a type of {{AudioSinkInfo}},
+						set {{AudioSinkInfo/type}} of {{AudioContext/[[sink ID]]}} to
+						the {{AudioSinkOptions/type}} value of |sinkId|.
 
 					1. Resolve |p|.
 					


### PR DESCRIPTION
This is an addendum to https://github.com/WebAudio/web-audio-api/pull/2498.

I don't think we need another markup for this PR because the goal of the change is the same.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2517.html" title="Last updated on Oct 11, 2022, 5:18 PM UTC (990f91d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2517/b0ef960...990f91d.html" title="Last updated on Oct 11, 2022, 5:18 PM UTC (990f91d)">Diff</a>