### PR TITLE
Adding WebIDL validation to auto-publish workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out the main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setting up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: Installing and updating Bikeshed
@@ -23,6 +23,8 @@ jobs:
       - name: Building index.html from index.bs
         run: bash ./compile.sh
         shell: bash
+      - name: Running WebIDL validation
+        uses: w3c/spec-prod@v2
       - name: Deploying to gh-pages branch
         if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
This PR adds a new step in the auto-publish workflow to use the WebIDL validation. It also updates some old version of GitHub actions to the latest ones.

Context: https://github.com/WebAudio/web-audio-api/issues/2514#issuecomment-1275016809