### PR TITLE
Minor editorial changes in output device selection (sinkId)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1722,8 +1722,14 @@ Constructors</h4>
 							<code>contextOptions.{{AudioContextOptions/sinkId}}</code> and
 							run the following substeps:
 
-							1. If |sinkId| is equal to {{AudioContext/[[sink ID]]}}, abort
-								these substeps.
+							1. If both |sinkId| and {{AudioContext/[[sink ID]]}} are a type of
+								{{DOMString}}, and they are equal to each other, abort these
+								substeps.
+
+							1. If |sinkId| is a type of {{AudioSinkOptions}} and
+								{{AudioContext/[[sink ID]]}} is a type of {{AudioSinkInfo}}, and
+								{{AudioSinkOptions/type}} in |sinkId| and {{AudioSinkInfo/type}}
+								in {{AudioContext/[[sink ID]]}} are equal, abort these substeps.
 
 							1. Let |validationResult| be the return value of
 								<a href="#validating-sink-identifier">sink identifier validation
@@ -2455,11 +2461,6 @@ This algorithm is used to validate the information provided to modify
 	1. If |document| is not allowed to use the feature identified by
 		<code>"speaker-selection"</code>, return a new {{DOMException}} whose name
 		is "{{NotAllowedError}}".
-
-	1. If |sinkIdArg| is a type of {{AudioSinkOptions}} and its
-		{{AudioSinkOptions/type}} property is not equal to
-		<code>"{{AudioSinkType/none}}"</code>, return a new {{DOMException}} whose
-		name is "{{NotSupportedError}}".
 
 	1. If |sinkIdArg| is a type of {{DOMString}} but it is not equal to the empty
 		string or it does not match any audio output device identified by the


### PR DESCRIPTION
PTAL - this PR has no functional changes.

The summary:

Expand the equality clause into two specific cases in the AudioContext constructor algorithm: now it has the exact same language with the AudioContext.setSinkId() method.
Remove redundant validation step: the WebIDL is thorough enough to throw a TypeError when an invalid enum is given as an argument. We don't need to check the type value within the Web Audio API implementation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 2, 2022, 5:47 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWebAudio%2Fweb-audio-api%2F527abc391ee256872be6564d3b5425a11635ed35%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232523.)._
</details>
