### PR TITLE
Fix Change log links.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13747,10 +13747,10 @@ Change Log</h2>
 <h3 id="recommendation-changes-1">
   Changes since Recommendation of 17 Jun 2021
 </h3>
-  * <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2456</a>: Add a MessagePort to the AudioWorkletGlobalScope
+  * <a href="https://github.com/WebAudio/web-audio-api/issues/2456">Issue 2456</a>: Add a MessagePort to the AudioWorkletGlobalScope
     <div id="change-list-2456">
     </div>
-  * <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2444</a>: Add AudioRenderCapacity interface and related classes
+  * <a href="https://github.com/WebAudio/web-audio-api/issues/2444">Issue 2444</a>: Add AudioRenderCapacity interface and related classes
     <div id="change-list-2444">
     </div>
   * <a href="https://github.com/WebAudio/web-audio-api/issues/2361">Issue 2361</a>: Use new Web IDL buffer primitives


### PR DESCRIPTION
The last two entries in the change log appear to be linking to the wrong issues, this fixes that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mkruisselbrink/web-audio-api/pull/2545.html" title="Last updated on Mar 29, 2023, 10:25 PM UTC (3937a5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2545/4eaca1a...mkruisselbrink:3937a5a.html" title="Last updated on Mar 29, 2023, 10:25 PM UTC (3937a5a)">Diff</a>