### PR TITLE
Update the dict operation 'present' to a valid operation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11429,8 +11429,8 @@ used to configure various channel configurations.
         {{AudioWorkletNodeOptions/numberOfOutputs}} are zero,
         throw a {{NotSupportedError}} and abort the remaining steps.
 
-    1. If {{AudioWorkletNodeOptions/outputChannelCount}} is
-        [[WEBIDL-1#dfn-present|present]],
+    1. If {{AudioWorkletNodeOptions/outputChannelCount}}
+         [=map/exists=],
 
         1. If any value in
             {{AudioWorkletNodeOptions/outputChannelCount}} is zero
@@ -11455,8 +11455,8 @@ used to configure various channel configurations.
             of {{AudioWorkletNodeOptions/outputChannelCount}}
             sequence and return.
 
-    1. If {{AudioWorkletNodeOptions/outputChannelCount}} is
-        [[WEBIDL-1#dfn-present|not present]],
+    1. If {{AudioWorkletNodeOptions/outputChannelCount}}
+         [=map/exists=],
 
         1. If both {{AudioWorkletNodeOptions/numberOfInputs}} and
             {{AudioWorkletNodeOptions/numberOfOutputs}} are 1,


### PR DESCRIPTION
This fixes #2535.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 17, 2023, 7:39 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWebAudio%2Fweb-audio-api%2Ffa11275fdfddf32c179945555f098fb6bae08568%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebAudio/web-audio-api%232552.)._
</details>
