### PR TITLE
Specify AnalyserNode treatment of non-finite values.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -179,7 +179,8 @@ window.addEventListener('load', (event) => {
   ListAmendments("c2475", "Proposed Addition", "change-list-2475");
   ListAmendments("c2444", "Proposed Addition", "change-list-2444");
   ListAmendments("c2456", "Proposed Addition", "change-list-2456");
-    ListAmendments("c2400", "Proposed Addition", "change-list-2400");
+  ListAmendments("c2400", "Proposed Addition", "change-list-2400");
+  ListAmendments("c2512", "Proposed Addition", "change-list-2512");
 });
 </script>
 <style>
@@ -5557,6 +5558,17 @@ In the following, let \(N\) be the value of the
         \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, \left|X[k]\right|
     $$
     </pre>
+
+<div class="addition proposed" id="c2512-1">
+  <span class="marker">Proposed Addition
+    <a href="https://github.com/WebAudio/web-audio-api/issues/2512">Issue 2512</a>
+  </span>
+  Specify AnalyserNode treatment of non-fininte values.
+  <div class="amendment-buttons"></div>
+  <ins cite=#c2512>
+        * If \(\hat{X}[k]\) is <code>NaN</code>, positive infinity or negative infinity, set \(\hat{X}[k]\) = 0.
+  </ins>
+</div>
 
     for \(k = 0, \ldots, N - 1\).
 </div>
@@ -13747,6 +13759,9 @@ Change Log</h2>
 <h3 id="recommendation-changes-1">
   Changes since Recommendation of 17 Jun 2021
 </h3>
+  * <a href="https://github.com/WebAudio/web-audio-api/issues/2512">Issue 2512</a>: Specify AnalyserNode treatment of non-fininte values.
+    <div id="change-list-2512">
+    </div>
   * <a href="https://github.com/WebAudio/web-audio-api/issues/2456">Issue 2456</a>: Add a MessagePort to the AudioWorkletGlobalScope
     <div id="change-list-2456">
     </div>


### PR DESCRIPTION
This is intended to fix [#2512](https://github.com/WebAudio/web-audio-api/issues/2512) by specifying that non-finite values after the smoothing step in the AnalyserNode should be set to zero.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mjwilson-google/web-audio-api/pull/2555.html" title="Last updated on Sep 7, 2023, 10:28 PM UTC (a5382be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2555/3f09f52...mjwilson-google:a5382be.html" title="Last updated on Sep 7, 2023, 10:28 PM UTC (a5382be)">Diff</a>