### PR TITLE
Specify `start()` and `stop()` in AudioRenderCapacity

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2852,6 +2852,20 @@ Dictionary {{AudioTimestamp}} Members</h5>
         {{AudioContext}}. In order to calculate them, the renderer collects a
         <a>load value</a> per <a>system-level audio callback</a>.
 
+        This interface has two internal slots:
+
+        <dl dfn-type=attribute dft-for="AudioRenderCapacity">
+            : <dfn>[[is running]]</dfn>
+            :: 
+                A boolean flag indicating whether the metric reporting loop is 
+                running. The initial value is <code>false</code>.
+
+            : <dfn>[[update interval]]</dfn>
+            ::
+                A double number that represents the interval of the metric
+                reporting loop in seconds. The initial value is 1.
+        </dl>
+
         <h5 id="AudioRenderCapacity-attributes">
         Attributes</h5>
 
@@ -2874,12 +2888,43 @@ Dictionary {{AudioTimestamp}} Members</h5>
                 {{AudioRenderCapacity/update}} at {{AudioRenderCapacity}}, using
                 {{AudioRenderCapacityEvent}}, with the given update interval in
                 {{AudioRenderCapacityOptions}}.
+
+                <div algorithm="audiorendercapacity-start">
+                    When invoked, perform the following steps:
+
+                    1. Set {{[[update interval]]}} to the value of
+                        <code>options.{{AudioRenderCapacityOptions/updateInterval}}
+                        </code>.
+                    1. Set {{[[is running]]}} to <code>true</code>.
+                    1. Queue a task to run the metric reporting loop.
+                </div>
             
             : <dfn>stop()</dfn>
             ::
                 Stops metric collection and analysis. It also stops dispatching
                 {{AudioRenderCapacity/update}} events.
+
+                <div algorithm="audiorendercapacity-stop">
+                    When invoked, perform the following steps:
+
+                    1. Set {{[[is running]]}} to <code>false<code>.
+                </div>
         </dl>
+
+        <h6 id="AudioRenderCapacity-metric-reporting-loop">
+        Metric Reporting Loop</h6>
+
+        This algorithm can be invoked by {{AudioRenderCapacity/start}} method
+        to report the performance metric repreatedly.
+
+        1. If {{[[is running]]}} is <code>false</code>, abort this algorithm.
+        2. Create |E|, which is a new instance of {{AudioRenderCapacityEvent}},
+            with computed performance metrics.
+        3. Dispatch |E| to the associated {{AudioRenderCapacity/onupdate}} event
+            handler.
+        4. Queue a task to run the metric reporting loop with the delay of
+            {{[[update interval]]}}.
+
 
         <h4 dictionary lt="audiorenderCapacityoptions" id="AudioRenderCapacityOptions">
         {{AudioRenderCapacityOptions}}</h4>

--- a/index.bs
+++ b/index.bs
@@ -2854,7 +2854,7 @@ Dictionary {{AudioTimestamp}} Members</h5>
 
         This interface has two internal slots:
 
-        <dl dfn-type=attribute dft-for="AudioRenderCapacity">
+        <dl dfn-type=attribute dfn-for="AudioRenderCapacity">
             : <dfn>[[is running]]</dfn>
             :: 
                 A boolean flag indicating whether the metric reporting loop is 

--- a/index.bs
+++ b/index.bs
@@ -2896,7 +2896,9 @@ Dictionary {{AudioTimestamp}} Members</h5>
                         <code>options.{{AudioRenderCapacityOptions/updateInterval}}
                         </code>.
                     1. Set {{[[is running]]}} to <code>true</code>.
-                    1. Queue a task to run the metric reporting loop.
+                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                        Queue a media element task</a> to run the metric 
+                        reporting loop.
                 </div>
             
             : <dfn>stop()</dfn>
@@ -2920,10 +2922,11 @@ Dictionary {{AudioTimestamp}} Members</h5>
         1. If {{[[is running]]}} is <code>false</code>, abort this algorithm.
         2. Create |E|, which is a new instance of {{AudioRenderCapacityEvent}},
             with computed performance metrics.
-        3. Dispatch |E| to the associated {{AudioRenderCapacity/onupdate}} event
-            handler.
-        4. Queue a task to run the metric reporting loop with the delay of
-            {{[[update interval]]}}.
+        3. <a spec="dom" lt="fire an event">Fire an event</a> named
+            {{AudioRenderCapacity/update}} using |E|.
+        4. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+            Queue a media element task</a> to run the metric reporting loop
+            with the delay of {{[[update interval]]}}.
 
 
         <h4 dictionary lt="audiorenderCapacityoptions" id="AudioRenderCapacityOptions">


### PR DESCRIPTION
Fixes #2526.

FYI @padenot - the current draft is without the proposed addition markup. I'll add markups once the PR is reviewed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2558.html" title="Last updated on Oct 12, 2023, 8:00 PM UTC (2931820)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2558/0c5f2df...2931820.html" title="Last updated on Oct 12, 2023, 8:00 PM UTC (2931820)">Diff</a>