### PR TITLE
Swap input and output in audioDestination description

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4380,7 +4380,7 @@ Methods</h4>
         destination {{AudioNode}}.
 
         <pre class=argumentdef for="AudioNode/disconnect(destinationNode, output, input)">
-            destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationNode</code> from the given input to the given output, an {{InvalidAccessError}} exception MUST be thrown.</span>
+            destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationNode</code> from the given output to the given input, an {{InvalidAccessError}} exception MUST be thrown.</span>
             output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to disconnect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
             input: The <code>input</code> parameter is an index describing which input of the destination {{AudioNode}} to disconnect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
         </pre>


### PR DESCRIPTION
Input and output were swapped in the description of the `audioDestination` parameter for the `AudioNode.disconnect(destinationNode, output, input)` function.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/KristofferStrube/web-audio-api/pull/2562.html" title="Last updated on Dec 6, 2023, 6:33 PM UTC (b31c2bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2562/0c5f2df...KristofferStrube:b31c2bb.html" title="Last updated on Dec 6, 2023, 6:33 PM UTC (b31c2bb)">Diff</a>