### PR TITLE
Fix hardcoded links to WebIDL spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11296,7 +11296,7 @@ Methods</h5>
 
                 1. Let <var>parameterDescriptorSequence</var>
                     be the result of
-                    <a href="https://heycam.github.io/webidl/#es-to-sequence">
+                    <a href="https://webidl.spec.whatwg.org/#es-to-sequence">
                     the conversion</a> from
                     <var>parameterDescriptorsValue</var>
                     to an IDL value of type
@@ -11532,7 +11532,7 @@ Constructors</h5>
                 [$StructuredSerializeWithTransfer$](<var>processorPortOnThisSide</var>,
                 « <var>processorPortOnThisSide</var> »).
 
-            1. <a href="https://heycam.github.io/webidl/#dictionary-to-es">Convert</a>
+            1. <a href="https://webidl.spec.whatwg.org/#dictionary-to-es">Convert</a>
                 <var>options</var> dictionary to <var>optionsObject</var>.
 
             1. Let <var>serializedOptions</var> be the result of
@@ -12728,14 +12728,14 @@ task queue=] of its associated {{BaseAudioContext}}.
                 1. Perform the following substeps:
 
                     1. Let |args| be a
-                        <a href="https://heycam.github.io/webidl/#web-idl-arguments-list">
+                        <a href="https://webidl.spec.whatwg.org/#web-idl-arguments-list">
                         Web IDL arguments list</a> consisting of
                         {{AudioWorkletProcessCallback/inputs}},
                         {{AudioWorkletProcessCallback/outputs}}, and
                         {{AudioWorkletProcessCallback/parameters}}.
 
                     1. Let |esArgs| be the result of
-                        <a href="https://heycam.github.io/webidl/#web-idl-arguments-list-converting">
+                        <a href="https://webidl.spec.whatwg.org/#web-idl-arguments-list-converting">
                         converting</a> |args| to an ECMAScript arguments list.
 
                     1. Let |callResult| be the <a href="https://tc39.github.io/ecma262/#sec-call">


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/web-audio-api/pull/2575.html" title="Last updated on Mar 11, 2024, 5:06 PM UTC (736e7c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2575/8b7e3f1...dontcallmedom:736e7c3.html" title="Last updated on Mar 11, 2024, 5:06 PM UTC (736e7c3)">Diff</a>