### PR TITLE
Fix the typing error identified in AudioWorklet Examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12171,7 +12171,7 @@ class Bitcrusher extends AudioWorkletProcessor {
         // No need to return a value; this node's lifetime is dependent only on its
         // input connections.
     }
-});
+};
 
 registerProcessor('bitcrusher', Bitcrusher);
 </xmp>


### PR DESCRIPTION
Describe the issue

The Bitcrusher class is ending with braces and parentheses, like this: }), instead of just braces }.


Fixes
Remove the extra parentheses

#2472


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MeenuyD/web-audio-api/pull/2576.html" title="Last updated on Mar 18, 2024, 11:08 AM UTC (f8b8ea9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2576/e37458b...MeenuyD:f8b8ea9.html" title="Last updated on Mar 18, 2024, 11:08 AM UTC (f8b8ea9)">Diff</a>