### PR TITLE
Remove the repeated  word in the PannerNode equalpower Panning

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -13365,7 +13365,7 @@ connections to the input are mono. Otherwise
 PannerNode "equalpower" Panning</h4>
 
 This is a simple and relatively inexpensive algorithm which
-provides basic, but reasonable results. It is used for the for the
+provides basic, but reasonable results. It is used for the
 {{PannerNode}} when the {{PannerNode/panningModel}} attribute is set to
 "{{PanningModelType/equalpower}}", in which case the <em>elevation</em>
 value is ignored. This algorithm MUST be implemented using


### PR DESCRIPTION
Describe the issue

It is used for the for the PannerNode when the panningModel attribute is set to "equalpower", in which case the elevation value is ignored.

Fixed
Remove the repeated words "for the"

#2477


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/MeenuyD/web-audio-api/pull/2577.html" title="Last updated on Mar 18, 2024, 11:19 AM UTC (8f2f70d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2577/e37458b...MeenuyD:8f2f70d.html" title="Last updated on Mar 18, 2024, 11:19 AM UTC (8f2f70d)">Diff</a>