### PR TITLE
[Dynamic Lifetime] Fix typo: "releases"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12907,7 +12907,7 @@ Example</h3>
     <img alt="dynamic allocation" src="images/dynamic-allocation.png"
     width="671" height="221">
     <figcaption>
-        A graph featuring a subgraph that will be releases early.
+        A graph featuring a subgraph that will be released early.
     </figcaption>
 </figure>
 


### PR DESCRIPTION
A small fix for a typo in here: https://webaudio.github.io/web-audio-api/#dynamic-lifetime-example.

It's most probably meant to be `released` verb instead of `releases`.