### PR TITLE
AudioContext.onerror

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1997,7 +1997,7 @@ Constructors</h4>
         </ins>
     </div>
 
-        <div class="correction proposed" id="c2567-2">
+        <div class="correction proposed" id="c2567-3">
             <span class="marker">Proposed Correction</span>
             <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
                 Issue 2567</a> Device-related error reporting via AudioContext

--- a/index.bs
+++ b/index.bs
@@ -12931,7 +12931,7 @@ audio system resource error.
         1. <a spec="dom" lt="fire an event">Fire an event</a> named
             {{AudioContext/error}} at the {{AudioContext}}.
 
-    1. Abort these substeps.
+    1. Abort these steps.
 
 1. If the {{[[rendering thread state]]}} of the {{AudioContext}} is
     <code>suspended</code>.
@@ -12941,9 +12941,6 @@ audio system resource error.
 
         1. <a spec="dom" lt="fire an event">Fire an event</a> named
             {{AudioContext/error}} at the {{AudioContext}}.
-    
-    1. Abort these substeps.
-
 
 Note: An example of system audio resource errors would be when an external or wireless audio
     device becomes disconnected during the active rendering of the AudioContext.

--- a/index.bs
+++ b/index.bs
@@ -2189,13 +2189,14 @@ Attributes</h4>
     <ins cite=#2567>
     : <dfn>onerror</dfn>
     ::
-        An [=event handler=] for any <dfn event>error</dfn> {{Event}} dispatched
-        from an {{AudioContext}}. The user agent can dispatch this event in the following cases:
+        An [=event handler=] for the {{ErrorEvent}} dispatched from an {{AudioContext}}. The event
+            type of this handler is <dfn event for=AudioContext>error</dfn> and the user agent can
+            dispatch this event in the following cases:
 
-            * The process of initializing and activiating the selected audio device encounters an
-                issue.
-            * The audio output from a {{AudioContextState/running}} {{AudioContext}} unexpectedly
-                interrupted or the device is disconnected.
+            * When initializing and activating a selected audio device encounters failures.
+            * When the audio output device associated with an {{AudioContext}} is disconnected while
+                the context is {{AudioContextState/running}}.
+            * When the operating system reports an audio device malfunction.
 
     </ins>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -182,6 +182,7 @@ window.addEventListener('load', (event) => {
   ListAmendments("c2400", "Proposed Addition", "change-list-2400");
   ListAmendments("c2512", "Proposed Addition", "change-list-2512");
   ListAmendments("c2450", "Proposed Addition", "change-list-2450");
+  ListAmendments("c2567", "Proposed Addition", "change-list-2567");
 });
 </script>
 <style>
@@ -1694,8 +1695,8 @@ enum AudioSinkType {
         </a> Add AudioRenderCapacity Interface <br>
         <a href="https://github.com/WebAudio/web-audio-api/issues/2400" id="c2400-2">
             Issue 2400</a> Access to a different output device <br>
-        <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-2">
-            Issue 2567</a> Device-related error reporting via AudioContext
+        <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-1">
+            Issue 2567</a>. Device-related error reporting via AudioContext
     <div class="amendment-buttons"></div>
     <del cite="#c2444 #c2400 #c2567">
         <xmp class="idl extract" data-no-idl>
@@ -1946,61 +1947,73 @@ Constructors</h4>
         Sending a <a>control message</a> to start processing means
         executing the following steps:
     
-        <div class="addition proposed" id="c2400-5">
-        <span class="marker">Proposed Addition</span><br>
-            <a href="https://github.com/WebAudio/web-audio-api/issues/2400">Issue
-                2400</a> Access to a different output device <br>
-            <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-1">
-                Issue 2567</a> Device-related error reporting via AudioContext
-        <div class="amendment-buttons"></div>
-        <del cite="#2400 #2567">
-            1. Attempt to <a href="#acquiring">acquire system resources</a>.
-                In case of failure, abort the following steps.
+        <div class="addition proposed">
+            <div class="addition proposed" id="c2400-5" style="border:0; margin:0; padding:0">
+                <span class="marker">Proposed Addition
+                    <a href="https://github.com/WebAudio/web-audio-api/issues/2400">Issue 2400</a>.
+                </span>
+                Access to a different output device
+                <div class="amendment-buttons"></div>
+            </div>
+            <div class="addition proposed" id="c2567-2" style="border:0; margin:0; padding:0">
+                <span class="marker">Proposed Addition
+                    <a href="https://github.com/WebAudio/web-audio-api/issues/2567">Issue 2567</a>.
+                </span>
+                Device-related error reporting via AudioContext
+                <div class="amendment-buttons"></div>
+            </div>
 
-            3. Set the {{[[rendering thread state]]}} to <code>running</code> on the {{AudioContext}}.
+            <del cite="#2400 #2567">
+                1. Attempt to <a href="#acquiring">acquire system resources</a>.
+                    In case of failure, abort the following steps.
 
-            1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                queue a media element task</a> to execute the following steps:
-
-                1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
+                3. Set the {{[[rendering thread state]]}} to <code>running</code> on the {{AudioContext}}.
 
                 1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                    queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
-                    </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
-        </del>
-        <ins cite="#2400 #2567">
-            1. Attempt to <a href="#acquiring">acquire system resources</a> to use a
-                following audio output device based on {{AudioContext/[[sink ID]]}} for
-                rendering:
+                    queue a media element task</a> to execute the following steps:
 
-                * The default audio output device for the empty string.
-                * A audio output device identified by {{AudioContext/[[sink ID]]}}.
-            
-                Upon failure of resource acquisition,
-                    <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                    queue a media element task</a> to
-                    <a spec="dom" lt="fire an event">fire an event</a> named
-                    {{AudioContext/error}} at the {{AudioContext}}, and abort
-                    the following steps.
+                    1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
-            1. Set the {{[[rendering thread state]]}} to <code>running</code> on the
-                {{AudioContext}}.
+                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
+                        </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+            </del>
+            <ins cite="#2400 #2567">
+                1. Attempt to <a href="#acquiring">acquire system resources</a> to use a
+                    following audio output device based on {{AudioContext/[[sink ID]]}} for
+                    rendering:
 
-            1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                Queue a media element task</a> to execute the following steps:
+                    * The default audio output device for the empty string.
+                    * A audio output device identified by {{AudioContext/[[sink ID]]}}.
+                
+                    Upon failure of resource acquisition,
+                        <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                        queue a media element task</a> to
+                        <a spec="dom" lt="fire an event">fire an event</a> named
+                        {{AudioContext/error}} at the {{AudioContext}}, and abort
+                        the following steps.
 
-                1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
-                    to "{{AudioContextState/running}}".
+                1. Set the {{[[rendering thread state]]}} to <code>running</code> on the
+                    {{AudioContext}}.
 
-                1. <a spec="dom" lt="fire an event">Fire an event</a> named
-                    {{BaseAudioContext/statechange}} at the {{AudioContext}}.
-        </ins>
+                1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                    Queue a media element task</a> to execute the following steps:
+
+                    1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
+                        to "{{AudioContextState/running}}".
+
+                    1. <a spec="dom" lt="fire an event">Fire an event</a> named
+                        {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+            </ins>
+
+        </div>
     </div>
 
-        <div class="correction proposed" id="c2567-3">
-            <span class="marker">Proposed Correction</span>
-            <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
-                Issue 2567</a> Device-related error reporting via AudioContext
+        <div class="proposed addition" id="c2567-3">
+            <span class="marker">Proposed Addition
+                <a href="https://github.com/WebAudio/web-audio-api/issues/2567">Issue 2567</a>.
+            </span>
+            Device-related error reporting via AudioContext
             <div class="amendment-buttons"></div>
             <del>
             Note: It is unfortunately not possible to programatically notify authors
@@ -2150,10 +2163,9 @@ Attributes</h4>
     </ins>
 </div>
 
-<div class="addition proposed" id="c2567-4">
+<div class="proposed addition" id="c2567-4">
     <span class="marker">Proposed Addition
-        <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
-            Issue 2567</a>.
+        <a href="https://github.com/WebAudio/web-audio-api/issues/2567">Issue 2567</a>.
     </span>
     Device-related error reporting via AudioContext
     <div class="amendment-buttons"></div>

--- a/index.bs
+++ b/index.bs
@@ -2004,16 +2004,23 @@ Constructors</h4>
 
             </del>
             <ins cite="#2400 #2567">
+                1. Let |document| be the [=current settings object=]'s [=relevant global object=]'s
+                        [=associated Document=].
+
                 1. Attempt to [=acquire system resources=] to use a following audio output device
                     based on {{AudioContext/[[sink ID]]}} for rendering:
 
                     * The default audio output device for the empty string.
                     * A audio output device identified by {{AudioContext/[[sink ID]]}}.
                 
-                    Upon failure of resource acquisition,
-                        [=queue a media element task=] to [=fire an event=] using {{ErrorEvent}}
-                        at the {{AudioContext/error}} of the {{AudioContext}}, and abort the
-                        following steps.
+                    1. If resource acquisition fails, execute the following steps:
+                        
+                        1. If |document| is not allowed to use the feature identified by
+                            <code>"speaker-selection"</code>, abort these substeps.
+
+                        1. [=queue a media element task=] to [=fire an event=] using {{ErrorEvent}}
+                            at the {{AudioContext/error}} of the {{AudioContext}}, and abort the
+                            following steps.
 
                 1. Set [=this=] {{[[rendering thread state]]}} to <code>running</code> on the
                     {{AudioContext}}.

--- a/index.bs
+++ b/index.bs
@@ -2145,7 +2145,7 @@ Attributes</h4>
         following cases:
 
             * The process of initializing and activiating the selected audio
-                devie encounters an issue.
+                device encounters an issue.
             * The audio output from a {{AudioContextState/running}}
                 {{AudioContext}} unexpectedly interrupted or the device is
                 disconnected.
@@ -12870,6 +12870,34 @@ running the algorithm for this {{AudioNode}} to produce
 running the algorithm for an {{AudioNode}}, using an <a>input
 buffer</a> and the value(s) of the {{AudioParam}}(s) of this
 {{AudioNode}} as the input for this algorithm.
+
+
+<h3 id="error-handling-on-a-running-audio-context">
+    Error Handling for System Audio Resources on a running AudioContext</h3>
+
+In the event of an audio system resource error, the <a>rendering thread</a>
+performs the following steps upon receiving the error:
+
+1. Set {{[[rendering thread state]]}} of the {{AudioContext}} to
+    "{{AudioContextState/suspended}}".
+
+1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+    Queue a media element task</a> to execute the following steps:
+
+    1. <a spec="dom" lt="fire an event">fire an event</a> named
+        {{AudioContext/error}} at the associated {{AudioContext}}.
+    
+    1. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is
+        not already "{{AudioContextState/suspended}}":
+
+        1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
+            to "{{AudioContextState/suspended}}".
+
+        1. <a spec="dom" lt="fire an event">Fire an event</a> named
+            {{BaseAudioContext/statechange}} at the associated {{AudioContext}}.
+
+Note: An example of such a case would be when an external or wireless audio
+    device becomes disconnected during the active rendering of the AudioContext.
 
 <h3 id="unloading-a-document">Unloading a document</h3>
     Additional <a href=

--- a/index.bs
+++ b/index.bs
@@ -1967,37 +1967,33 @@ Constructors</h4>
                 1. Attempt to <a href="#acquiring">acquire system resources</a>.
                     In case of failure, abort the following steps.
 
-                3. Set the {{[[rendering thread state]]}} to <code>running</code> on the {{AudioContext}}.
+                1. Set the {{[[rendering thread state]]}} to <code>running</code> on the {{AudioContext}}.
 
                 1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
                     queue a media element task</a> to execute the following steps:
 
                     1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
-                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
-                        </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+                    1. [=Queue a media element task=] to [=fire an event=] named
+                        {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+
             </del>
             <ins cite="#2400 #2567">
-                1. Attempt to <a href="#acquiring">acquire system resources</a> to use a
-                    following audio output device based on {{AudioContext/[[sink ID]]}} for
-                    rendering:
+                1. Attempt to [=acquire system resources=] to use a following audio output device
+                    based on {{AudioContext/[[sink ID]]}} for rendering:
 
                     * The default audio output device for the empty string.
                     * A audio output device identified by {{AudioContext/[[sink ID]]}}.
                 
                     Upon failure of resource acquisition,
-                        <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                        queue a media element task</a> to
-                        <a spec="dom" lt="fire an event">fire an event</a> named
-                        {{AudioContext/error}} at the {{AudioContext}}, and abort
-                        the following steps.
+                        [=queue a media element task=] to [=fire an event=] named
+                        {{AudioContext/error}} at the {{AudioContext}}, and abort the following
+                        steps.
 
-                1. Set the {{[[rendering thread state]]}} to <code>running</code> on the
+                1. Set [=this=] {{[[rendering thread state]]}} to <code>running</code> on the
                     {{AudioContext}}.
 
-                1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                    Queue a media element task</a> to execute the following steps:
+                1. [=Queue a media element task=] to execute the following steps:
 
                     1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
                         to "{{AudioContextState/running}}".
@@ -2022,10 +2018,9 @@ Constructors</h4>
             mechanism, such as a developer tools console.
             </del>
             <ins>
-            NOTE: In cases where an AudioContext is constructed with no
-            arguments and resource acquisition fails, the User-Agent must 
-            attempt to silently render the audio graph using a mechanism that
-            emulates an audio output device.
+            NOTE: In cases where an {{AudioContext}} is constructed with no arguments and resource
+            acquisition fails, the User-Agent will attempt to silently render the audio graph using
+            a mechanism that emulates an audio output device.
             </ins>
         </div>
 
@@ -2169,9 +2164,8 @@ Attributes</h4>
     <ins cite=#2567>
     : <dfn>onerror</dfn>
     ::
-        An [=event handler=] for any <dfn event>error</dfn> {{Event}} dispatched from an
-        {{AudioContext}}. The user agent can dispatch this event in the
-        following cases:
+        An [=event handler=] for any <a event for="AudioContext">error</a> {{Event}} dispatched
+        from an {{AudioContext}}. The user agent can dispatch this event in the following cases:
 
             * The process of initializing and activiating the selected audio
                 device encounters an issue.
@@ -12915,43 +12909,35 @@ buffer</a> and the value(s) of the {{AudioParam}}(s) of this
 The <a>rendering thread</a> performs the following steps in the event of an
 audio system resource error.
 
-1. If the {{[[rendering thread state]]}} of the {{AudioContext}} is
-    <code>running</code>.
+1. If the |audioContext|'s {{[[rendering thread state]]}} is <code>running</code>:
 
     1. Attempt to <a>release system resources</a>.
 
-    1. Set {{[[rendering thread state]]}} of the {{AudioContext}} to
-        <code>suspended</code>.
+    1. Set the |audioContext|'s {{[[rendering thread state]]}} to <code>suspended</code>.
 
-    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-        Queue a media element task</a> to execute the following steps:
+    1. [=Queue a media element task=] to execute the following steps:
 
-        1. <a spec="dom" lt="fire an event">Fire an event</a> named {{AudioContext/error}} at the
-            {{AudioContext}}.
+        1. [=Fire an event=] at the |audioContext|'s {{AudioContext/error}}.
 
-        1. Set {{[[suspended by user]]}} of the {{AudioContext}} to <code>false</code>.
+        1. Set the |audioContext|'s {{[[suspended by user]]}} to <code>false</code>.
 
-        1. Set {{[[control thread state]]}} of the {{AudioContext}} to <code>suspended</code>.
+        1. Set the |audioContext|'s {{[[control thread state]]}} to <code>suspended</code>.
 
-        1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to 
+        1. Set the |audioContext|'s {{BaseAudioContext/state}} attribute to 
             "{{AudioContextState/suspended}}".
 
-        1. <a spec="dom" lt="fire an event">Fire an event</a> named
-            {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+        1. [=Fire an event=] at the |audioContext|'s {{BaseAudioContext/statechange}}.
 
     1. Abort these steps.
 
-1. If the {{[[rendering thread state]]}} of the {{AudioContext}} is
-    <code>suspended</code>.
+1. If the |audioContext|'s {{[[rendering thread state]]}} is <code>suspended</code>:
 
-    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-        Queue a media element task</a> to execute the following steps:
+    1. [=Queue a media element task=]to execute the following steps:
 
-        1. <a spec="dom" lt="fire an event">Fire an event</a> named {{AudioContext/error}} at the
-            {{AudioContext}}.
+        1. [=Fire an event=] at the |audioContext|'s {{AudioContext/error}}.
 
-Note: An example of system audio resource errors would be when an external or wireless audio
-    device becomes disconnected during the active rendering of the AudioContext.
+Note: An example of system audio resource errors would be when an external or wireless audio device
+    becoming disconnected during the active rendering of the {{AudioContext}}.
 
     </ins>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1996,6 +1996,26 @@ Constructors</h4>
                     {{BaseAudioContext/statechange}} at the {{AudioContext}}.
         </ins>
     </div>
+
+        <div class="correction proposed" id="c2567-2">
+            <span class="marker">Proposed Correction</span>
+            <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
+                Issue 2567</a> Device-related error reporting via AudioContext
+            <div class="amendment-buttons"></div>
+            <del>
+            Note: It is unfortunately not possible to programatically notify authors
+            that the creation of the {{AudioContext}} failed. User-Agents are
+            encouraged to log an informative message if they have access to a logging
+            mechanism, such as a developer tools console.
+            </del>
+            <ins>
+            NOTE: In cases where an AudioContext is constructed with no
+            arguments and resource acquisition fails, the User-Agent must 
+            attempt to silently render the audio graph using a mechanism that
+            emulates an audio output device.
+            </ins>
+        </div>
+
         </div>
 
         <div class="addition proposed" id="c2456-2">
@@ -2135,7 +2155,7 @@ Attributes</h4>
         <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
             Issue 2567</a>.
     </span>
-     Device-related error reporting via AudioContext
+    Device-related error reporting via AudioContext
     <div class="amendment-buttons"></div>
     <ins cite=#2567>
     : <dfn>onerror</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1694,8 +1694,10 @@ enum AudioSinkType {
         </a> Add AudioRenderCapacity Interface <br>
         <a href="https://github.com/WebAudio/web-audio-api/issues/2400" id="c2400-2">
             Issue 2400</a> Access to a different output device
+        <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-2">
+            Issue 2567</a> Device-related error reporting via AudioContext
     <div class="amendment-buttons"></div>
-    <del cite="#c2444 #c2400">
+    <del cite="#c2444 #c2400 #c2567">
         <xmp class="idl extract" data-no-idl>
         [Exposed=Window]
         interface AudioContext : BaseAudioContext {
@@ -1714,7 +1716,7 @@ enum AudioSinkType {
         };
         </xmp>
     </del>
-    <ins cite="#c2444 #2400">
+    <ins cite="#c2444 #2400 #2567">
         <xmp class="idl">
         [Exposed=Window]
         interface AudioContext : BaseAudioContext {
@@ -1724,6 +1726,7 @@ enum AudioSinkType {
             [SecureContext] readonly attribute (DOMString or AudioSinkInfo) sinkId;
             [SecureContext] readonly attribute AudioRenderCapacity renderCapacity;
             attribute EventHandler onsinkchange;
+            attribute EventHandler onerror;
             AudioTimestamp getOutputTimestamp ();
             Promise<undefined> resume ();
             Promise<undefined> suspend ();
@@ -1947,8 +1950,10 @@ Constructors</h4>
         <span class="marker">Proposed Addition</span><br>
             <a href="https://github.com/WebAudio/web-audio-api/issues/2400">Issue
                 2400</a> Access to a different output device
+            <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-1">
+                Issue 2567</a> Device-related error reporting via AudioContext
         <div class="amendment-buttons"></div>
-        <del cite=#2400>
+        <del cite=#2400 #c2567>
             1. Attempt to <a href="#acquiring">acquire system resources</a>.
                 In case of failure, abort the following steps.
 
@@ -1963,7 +1968,7 @@ Constructors</h4>
                     queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
                     </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
         </del>
-        <ins cite=#2400>
+        <ins cite=#2400 #2567>
             1. Attempt to <a href="#acquiring">acquire system resources</a> to use a
                 following audio output device based on {{AudioContext/[[sink ID]]}} for
                 rendering:
@@ -1971,7 +1976,12 @@ Constructors</h4>
                 * The default audio output device for the empty string.
                 * A audio output device identified by {{AudioContext/[[sink ID]]}}.
             
-                In case of failure, abort the following steps.
+                Upon failure of resource acquisition,
+                    <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                    queue a media element task</a> to
+                    <a spec="dom" lt="fire an event">fire an event</a> named
+                    {{AudioContext/error}} at the {{AudioContext}}, and abort
+                    the following steps.
 
             1. Set the {{[[rendering thread state]]}} to <code>running</code> on the
                 {{AudioContext}}.
@@ -1986,10 +1996,6 @@ Constructors</h4>
                     {{BaseAudioContext/statechange}} at the {{AudioContext}}.
         </ins>
     </div>
-            Note: It is unfortunately not possible to programatically notify authors
-            that the creation of the {{AudioContext}} failed. User-Agents are
-            encouraged to log an informative message if they have access to a logging
-            mechanism, such as a developer tools console.
         </div>
 
         <div class="addition proposed" id="c2456-2">
@@ -2042,7 +2048,7 @@ Attributes</h4>
 
 <div class="correction proposed" id="c2450-6">
   <span class="marker">Proposed addition
-    <a href="https://github.com/WebAudio/web-audio-api/issues/2450">Issue 2450</a>-1.
+    <a href="https://github.com/WebAudio/web-audio-api/issues/2450">Issue 2450</a>.
   </span>
   Allow specifying a different render quantum size
   <div class="amendment-buttons">
@@ -2080,16 +2086,15 @@ Attributes</h4>
         is running or the associated audio output device changes. It is
         useful to query this value frequently when accurate
         synchronization is required.
+
 <div class="correction proposed" id="c2444-2">
     <span class="marker">Proposed Addition
         <a href="https://github.com/WebAudio/web-audio-api/issues/2444">Issue
             2444</a>.
     </span>
     Add AudioRenderCapacity Interface
-    <div class="amendment-buttons">
-        Buttons here
-    </div>
-    <ins cite=#c2444>       
+    <div class="amendment-buttons"></div>
+    <ins cite=#c2444>
     : <dfn>renderCapacity</dfn>
     ::
         Returns an {{AudioRenderCapacity}} instance associated with
@@ -2099,9 +2104,11 @@ Attributes</h4>
 </div>
 
 <div class="addition proposed" id="c2400-6">
-    <span class="marker">Proposed Addition</span><br>
+    <span class="marker">Proposed Addition
         <a href="https://github.com/WebAudio/web-audio-api/issues/2400">Issue
-            2400</a> Access to a different output device
+            2400</a>.
+    </span>
+    Access to a different output device
     <div class="amendment-buttons"></div>
     <ins cite=#2400>
     : <dfn>sinkId</dfn>
@@ -2121,7 +2128,32 @@ Attributes</h4>
         is available to check the readiness of the initial output device.
 
     </ins>
-    </dl>
+</div>
+
+<div class="addition proposed" id="c2567-3">
+    <span class="marker">Proposed Addition
+        <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
+            Issue 2567</a>.
+    </span>
+     Device-related error reporting via AudioContext
+    <div class="amendment-buttons"></div>
+    <ins cite=#2567>
+    : <dfn>onerror</dfn>
+    ::
+        An [=event handler=] for any <dfn event>error</dfn> {{Event}} dispatched from an
+        {{AudioContext}}. The user agent can dispatch this event in the
+        following cases:
+
+            * The process of initializing and activiating the selected audio
+                devie encounters an issue.
+            * The audio output from a {{AudioContextState/running}}
+                {{AudioContext}} unexpectedly interrupted or the device is
+                disconnected.
+
+    </ins>
+</div>
+
+</dl>
 
 <h4 id="AudioContext-methods">
 Methods</h4>

--- a/index.bs
+++ b/index.bs
@@ -12905,30 +12905,47 @@ buffer</a> and the value(s) of the {{AudioParam}}(s) of this
 
 
 <h3 id="error-handling-on-a-running-audio-context">
-    Error Handling for System Audio Resources on a running AudioContext</h3>
+    Handling an error from System Audio Resources on the {{AudioContext}}</h3>
 
-In the event of an audio system resource error, the <a>rendering thread</a>
-performs the following steps upon receiving the error:
+The <a>rendering thread</a> performs the following steps in the event of an
+audio system resource error.
 
-1. Set {{[[rendering thread state]]}} of the {{AudioContext}} to
-    "{{AudioContextState/suspended}}".
+1. If the {{[[rendering thread state]]}} of the {{AudioContext}} is
+    <code>running</code>.
 
-1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-    Queue a media element task</a> to execute the following steps:
+    1. Attempt to <a>release system resources</a>.
 
-    1. <a spec="dom" lt="fire an event">fire an event</a> named
-        {{AudioContext/error}} at the associated {{AudioContext}}.
-    
-    1. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is
-        not already "{{AudioContextState/suspended}}":
+    1. Set {{[[rendering thread state]]}} of the {{AudioContext}} to
+        <code>suspended</code>.
 
-        1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
-            to "{{AudioContextState/suspended}}".
+    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+        Queue a media element task</a> to execute the following steps:
+
+        1. Set {{[[suspended by user]]}} of the {{AudioContext}} to <code>false</code>.
+
+        1. Set {{[[control thread state]]}} of the {{AudioContext}} to <code>suspended</code>.
+
+        1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to 
+            "{{AudioContextState/suspended}}".
 
         1. <a spec="dom" lt="fire an event">Fire an event</a> named
-            {{BaseAudioContext/statechange}} at the associated {{AudioContext}}.
+            {{AudioContext/error}} at the {{AudioContext}}.
 
-Note: An example of such a case would be when an external or wireless audio
+    1. Abort these substeps.
+
+1. If the {{[[rendering thread state]]}} of the {{AudioContext}} is
+    <code>suspended</code>.
+
+    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+        Queue a media element task</a> to execute the following steps:
+
+        1. <a spec="dom" lt="fire an event">Fire an event</a> named
+            {{AudioContext/error}} at the {{AudioContext}}.
+    
+    1. Abort these substeps.
+
+
+Note: An example of system audio resource errors would be when an external or wireless audio
     device becomes disconnected during the active rendering of the AudioContext.
 
 <h3 id="unloading-a-document">Unloading a document</h3>

--- a/index.bs
+++ b/index.bs
@@ -1693,7 +1693,7 @@ enum AudioSinkType {
         <a href="https://github.com/WebAudio/web-audio-api/issues/2444">Issue 2444
         </a> Add AudioRenderCapacity Interface <br>
         <a href="https://github.com/WebAudio/web-audio-api/issues/2400" id="c2400-2">
-            Issue 2400</a> Access to a different output device
+            Issue 2400</a> Access to a different output device <br>
         <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-2">
             Issue 2567</a> Device-related error reporting via AudioContext
     <div class="amendment-buttons"></div>
@@ -1949,7 +1949,7 @@ Constructors</h4>
         <div class="addition proposed" id="c2400-5">
         <span class="marker">Proposed Addition</span><br>
             <a href="https://github.com/WebAudio/web-audio-api/issues/2400">Issue
-                2400</a> Access to a different output device
+                2400</a> Access to a different output device <br>
             <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-1">
                 Issue 2567</a> Device-related error reporting via AudioContext
         <div class="amendment-buttons"></div>

--- a/index.bs
+++ b/index.bs
@@ -12930,8 +12930,8 @@ buffer</a> and the value(s) of the {{AudioParam}}(s) of this
 <h3 id="error-handling-on-a-running-audio-context">
     Handling an error from System Audio Resources on the {{AudioContext}}</h3>
 
-The <a>rendering thread</a> performs the following steps in the event of an
-audio system resource error.
+The {{AudioContext}} |audioContext| performs the following steps on <a>rendering thread</a> in the
+    event of an udio system resource error.
 
 1. If the |audioContext|'s {{[[rendering thread state]]}} is <code>running</code>:
 

--- a/index.bs
+++ b/index.bs
@@ -2081,7 +2081,7 @@ Attributes</h4>
 
 <div class="correction proposed" id="c2450-6">
   <span class="marker">Proposed addition
-    <a href="https://github.com/WebAudio/web-audio-api/issues/2450">Issue 2450</a>.
+    <a href="https://github.com/WebAudio/web-audio-api/issues/2450">Issue 2450</a>-1.
   </span>
   Allow specifying a different render quantum size
   <div class="amendment-buttons">
@@ -2119,7 +2119,6 @@ Attributes</h4>
         is running or the associated audio output device changes. It is
         useful to query this value frequently when accurate
         synchronization is required.
-
 <div class="correction proposed" id="c2444-2">
     <span class="marker">Proposed Addition
         <a href="https://github.com/WebAudio/web-audio-api/issues/2444">Issue
@@ -2137,11 +2136,9 @@ Attributes</h4>
 </div>
 
 <div class="addition proposed" id="c2400-6">
-    <span class="marker">Proposed Addition
+    <span class="marker">Proposed Addition</span><br>
         <a href="https://github.com/WebAudio/web-audio-api/issues/2400">Issue
-            2400</a>.
-    </span>
-    Access to a different output device
+            2400</a> Access to a different output device
     <div class="amendment-buttons"></div>
     <ins cite=#2400>
     : <dfn>sinkId</dfn>
@@ -12904,6 +12901,14 @@ buffer</a> and the value(s) of the {{AudioParam}}(s) of this
 {{AudioNode}} as the input for this algorithm.
 
 
+<div class="addition proposed" id="c2567-5">
+    <span class="marker">Proposed addition
+        <a href="https://github.com/WebAudio/web-audio-api/issues/2567">Issue 2567</a>.
+    </span>
+    Device-related error reporting via AudioContext
+    <div class="amendment-buttons"></div>
+    <ins>
+
 <h3 id="error-handling-on-a-running-audio-context">
     Handling an error from System Audio Resources on the {{AudioContext}}</h3>
 
@@ -12921,6 +12926,9 @@ audio system resource error.
     1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
         Queue a media element task</a> to execute the following steps:
 
+        1. <a spec="dom" lt="fire an event">Fire an event</a> named {{AudioContext/error}} at the
+            {{AudioContext}}.
+
         1. Set {{[[suspended by user]]}} of the {{AudioContext}} to <code>false</code>.
 
         1. Set {{[[control thread state]]}} of the {{AudioContext}} to <code>suspended</code>.
@@ -12929,7 +12937,7 @@ audio system resource error.
             "{{AudioContextState/suspended}}".
 
         1. <a spec="dom" lt="fire an event">Fire an event</a> named
-            {{AudioContext/error}} at the {{AudioContext}}.
+            {{BaseAudioContext/statechange}} at the {{AudioContext}}.
 
     1. Abort these steps.
 
@@ -12939,11 +12947,14 @@ audio system resource error.
     1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
         Queue a media element task</a> to execute the following steps:
 
-        1. <a spec="dom" lt="fire an event">Fire an event</a> named
-            {{AudioContext/error}} at the {{AudioContext}}.
+        1. <a spec="dom" lt="fire an event">Fire an event</a> named {{AudioContext/error}} at the
+            {{AudioContext}}.
 
 Note: An example of system audio resource errors would be when an external or wireless audio
     device becomes disconnected during the active rendering of the AudioContext.
+
+    </ins>
+</div>
 
 <h3 id="unloading-a-document">Unloading a document</h3>
     Additional <a href=

--- a/index.bs
+++ b/index.bs
@@ -2011,9 +2011,9 @@ Constructors</h4>
                     * A audio output device identified by {{AudioContext/[[sink ID]]}}.
                 
                     Upon failure of resource acquisition,
-                        [=queue a media element task=] to [=fire an event=] named
-                        {{AudioContext/error}} at the {{AudioContext}}, and abort the following
-                        steps.
+                        [=queue a media element task=] to [=fire an event=] using {{ErrorEvent}}
+                        at the {{AudioContext/error}} of the {{AudioContext}}, and abort the
+                        following steps.
 
                 1. Set [=this=] {{[[rendering thread state]]}} to <code>running</code> on the
                     {{AudioContext}}.
@@ -2023,8 +2023,8 @@ Constructors</h4>
                     1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
                         to "{{AudioContextState/running}}".
 
-                    1. <a spec="dom" lt="fire an event">Fire an event</a> named
-                        {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+                    1. [=fire an event=] named {{BaseAudioContext/statechange}} at the
+                        {{AudioContext}}.
             </ins>
 
         </div>
@@ -12941,7 +12941,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
 
     1. [=Queue a media element task=] to execute the following steps:
 
-        1. [=Fire an event=] at the |audioContext|'s {{AudioContext/error}}.
+        1. [=Fire an event=] using {{ErrorEvent}} at the |audioContext|'s {{AudioContext/error}}.
 
         1. Set the |audioContext|'s {{[[suspended by user]]}} to <code>false</code>.
 
@@ -12958,7 +12958,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
 
     1. [=Queue a media element task=]to execute the following steps:
 
-        1. [=Fire an event=] at the |audioContext|'s {{AudioContext/error}}.
+        1. [=Fire an event=] using {{ErrorEvent}} at the |audioContext|'s {{AudioContext/error}}.
 
 Note: An example of system audio resource errors would be when an external or wireless audio device
     becoming disconnected during the active rendering of the {{AudioContext}}.

--- a/index.bs
+++ b/index.bs
@@ -2164,14 +2164,13 @@ Attributes</h4>
     <ins cite=#2567>
     : <dfn>onerror</dfn>
     ::
-        An [=event handler=] for any <a event for="AudioContext">error</a> {{Event}} dispatched
+        An [=event handler=] for any <dfn event>error</dfn> {{Event}} dispatched
         from an {{AudioContext}}. The user agent can dispatch this event in the following cases:
 
-            * The process of initializing and activiating the selected audio
-                device encounters an issue.
-            * The audio output from a {{AudioContextState/running}}
-                {{AudioContext}} unexpectedly interrupted or the device is
-                disconnected.
+            * The process of initializing and activiating the selected audio device encounters an
+                issue.
+            * The audio output from a {{AudioContextState/running}} {{AudioContext}} unexpectedly
+                interrupted or the device is disconnected.
 
     </ins>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2150,7 +2150,7 @@ Attributes</h4>
     </ins>
 </div>
 
-<div class="addition proposed" id="c2567-3">
+<div class="addition proposed" id="c2567-4">
     <span class="marker">Proposed Addition
         <a href="https://github.com/WebAudio/web-audio-api/issues/2567">
             Issue 2567</a>.

--- a/index.bs
+++ b/index.bs
@@ -1953,7 +1953,7 @@ Constructors</h4>
             <a href="https://github.com/WebAudio/web-audio-api/issues/2567" id="c2567-1">
                 Issue 2567</a> Device-related error reporting via AudioContext
         <div class="amendment-buttons"></div>
-        <del cite=#2400 #c2567>
+        <del cite="#2400 #2567">
             1. Attempt to <a href="#acquiring">acquire system resources</a>.
                 In case of failure, abort the following steps.
 
@@ -1968,7 +1968,7 @@ Constructors</h4>
                     queue a media element task</a> to <a spec="dom" lt="fire an event">fire an event
                     </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
         </del>
-        <ins cite=#2400 #2567>
+        <ins cite="#2400 #2567">
             1. Attempt to <a href="#acquiring">acquire system resources</a> to use a
                 following audio output device based on {{AudioContext/[[sink ID]]}} for
                 rendering:


### PR DESCRIPTION
This PR resolves #2567.

- Add the `onerror` event handler under the `AudioContext` interface.
- Add a step to fire `onerror` event in the AudioContext constructor steps on the render thread.
- Remove the non-normative notes on the notification being impossible.
- Add a prose to specify the `onerror` case on a running AudioContext.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2580.html" title="Last updated on Jul 9, 2024, 6:42 PM UTC (8776c75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2580/22d71ec...8776c75.html" title="Last updated on Jul 9, 2024, 6:42 PM UTC (8776c75)">Diff</a>