### PR TITLE
Fix wrong syntax around firing events in the spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2018,7 +2018,7 @@ Constructors</h4>
                         1. If |document| is not allowed to use the feature identified by
                             <code>"speaker-selection"</code>, abort these substeps.
 
-                        1. [=queue a media element task=] to [=fire an event=] named
+                        1. [=Queue a media element task=] to [=fire an event=] named
                             {{AudioContext/error}} at the {{AudioContext}}, and abort the following
                             steps.
 
@@ -2647,7 +2647,7 @@ Methods</h4>
                             1. Set the {{BaseAudioContext/state}} attribute of the
                                 {{AudioContext}} to "{{AudioContextState/suspended}}".
 
-                            1. [=fire an event=] named {{BaseAudioContext/statechange}} at the
+                            1. [=Fire an event=] named {{BaseAudioContext/statechange}} at the
                                 associated {{AudioContext}}.
 
                 1. Attempt to <a href="#acquiring">acquire system resources</a> to use
@@ -2679,7 +2679,7 @@ Methods</h4>
 
                     1. Resolve |p|.
                     
-                    1. [=fire an event=] named {{AudioContext/sinkchange}} at the
+                    1. [=Fire an event=] named {{AudioContext/sinkchange}} at the
                         associated {{AudioContext}}.
 
                 1. If |wasRunning| is true:
@@ -2696,7 +2696,7 @@ Methods</h4>
                             1. Set the {{BaseAudioContext/state}} attribute of the
                                 {{AudioContext}} to "{{AudioContextState/running}}".
                             
-                            1. [=fire an event=] named {{BaseAudioContext/statechange}} at the
+                            1. [=Fire an event=] named {{BaseAudioContext/statechange}} at the
                                 associated {{AudioContext}}.
             </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2018,9 +2018,9 @@ Constructors</h4>
                         1. If |document| is not allowed to use the feature identified by
                             <code>"speaker-selection"</code>, abort these substeps.
 
-                        1. [=queue a media element task=] to [=fire an event=] using {{ErrorEvent}}
-                            at the {{AudioContext/error}} of the {{AudioContext}}, and abort the
-                            following steps.
+                        1. [=queue a media element task=] to [=fire an event=] named
+                            {{AudioContext/error}} at the {{AudioContext}}, and abort the following
+                            steps.
 
                 1. Set [=this=] {{[[rendering thread state]]}} to <code>running</code> on the
                     {{AudioContext}}.
@@ -2475,9 +2475,8 @@ Methods</h4>
 
                     1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
-                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire
-                        an event </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+                    1. [=Queue a media element task=] to [=fire an event=] named
+                        {{BaseAudioContext/statechange}} at the {{AudioContext}}.
         </div>
 
         <div>
@@ -2546,9 +2545,8 @@ Methods</h4>
 
                     1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/suspended}}".
 
-                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire
-                        an event </a> named {{BaseAudioContext/statechange}} at the {{AudioContext}}.
+                    1. [=Queue a media element task=] to [=fire an event=] named
+                        {{BaseAudioContext/statechange}} at the {{AudioContext}}.
         </div>
 
         While an {{AudioContext}} is suspended,
@@ -2648,9 +2646,9 @@ Methods</h4>
 
                             1. Set the {{BaseAudioContext/state}} attribute of the
                                 {{AudioContext}} to "{{AudioContextState/suspended}}".
-                            
-                            1. <a spec="dom" lt="fire an event">Fire an event</a> named
-                                {{BaseAudioContext/statechange}} at the associated {{AudioContext}}.
+
+                            1. [=fire an event=] named {{BaseAudioContext/statechange}} at the
+                                associated {{AudioContext}}.
 
                 1. Attempt to <a href="#acquiring">acquire system resources</a> to use
                     a following audio output device based on {{AudioContext/[[sink ID]]}}
@@ -2681,8 +2679,8 @@ Methods</h4>
 
                     1. Resolve |p|.
                     
-                    1. <a spec="dom" lt="fire an event">Fire an event</a> named
-                        {{AudioContext/sinkchange}} at the associated {{AudioContext}}.
+                    1. [=fire an event=] named {{AudioContext/sinkchange}} at the
+                        associated {{AudioContext}}.
 
                 1. If |wasRunning| is true:
 
@@ -2698,8 +2696,8 @@ Methods</h4>
                             1. Set the {{BaseAudioContext/state}} attribute of the
                                 {{AudioContext}} to "{{AudioContextState/running}}".
                             
-                            1. <a spec="dom" lt="fire an event">Fire an event</a> named
-                                {{BaseAudioContext/statechange}} at the associated {{AudioContext}}.
+                            1. [=fire an event=] named {{BaseAudioContext/statechange}} at the
+                                associated {{AudioContext}}.
             </div>
 
         </ins>
@@ -2956,9 +2954,8 @@ Dictionary {{AudioTimestamp}} Members</h5>
         <dl dfn-type=method dfn-for="AudioRenderCapacity">
             : <dfn>start(options)</dfn>
             ::
-                Starts metric collection and analysis. This will repeatedly
-                <a spec="dom" lt="fire an event">fire an event</a> named
-                {{AudioRenderCapacity/update}} at {{AudioRenderCapacity}}, using
+                Starts metric collection and analysis. This will repeatedly [=fire an event=] named
+                {{AudioRenderCapacity/update}} at the {{AudioRenderCapacity}}, using
                 {{AudioRenderCapacityEvent}}, with the given update interval in
                 {{AudioRenderCapacityOptions}}.
             
@@ -3297,14 +3294,13 @@ Methods</h4>
                     queue a media element task</a> to execute the following steps:
 
                     <ol>
-                        <li>Resolve the <var ignore>promise</var> created by {{startRendering()}} with {{[[rendered buffer]]}}.
+                        <li>Resolve the <var ignore>promise</var> created by {{startRendering()}}
+                        with {{[[rendered buffer]]}}.
 
-                        <li><a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                            queue a media element task</a> to
-                            <a spec="dom" lt="fire an event">fire an event</a> named
-                            {{OfflineAudioContext/complete}} using an instance of {{OfflineAudioCompletionEvent}}
-                            whose `renderedBuffer` property is set to
-                            {{[[rendered buffer]]}}.
+                        <li>[=Queue a media element task=] to [=fire an event=] named
+                        {{OfflineAudioContext/complete}} at the {{OfflineAudioContext}} using
+                        {{OfflineAudioCompletionEvent}} whose `renderedBuffer` property is set to
+                        {{[[rendered buffer]]}}.
 
                     </ol>
 
@@ -3373,9 +3369,8 @@ Methods</h4>
                     1. Set the {{BaseAudioContext/state}} attribute of the
                         {{OfflineAudioContext}} to "{{AudioContextState/running}}".
 
-                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire
-                        an event</a> named {{BaseAudioContext/statechange}} at the {{OfflineAudioContext}}.
+                    1. [=Queue a media element task=] to [=fire an event=] named
+                        {{BaseAudioContext/statechange}} at the {{OfflineAudioContext}}.
 
         </div>
 
@@ -11512,10 +11507,10 @@ the <a>rendering thread</a> will invoke the algorithm below:
             of this {{AudioWorkletGlobalScope}}'s
             [=pending processor construction data=] respectively.
 
-        1. <a spec=webidl lt=construct>Construct a callback function</a> from |processorCtor| with the argument
-            of |deserializedOptions|. If any exceptions are thrown in the callback, <a>queue a task</a> to
-            the <a>control thread</a> to <a spec="dom" lt="fire an event">fire an event</a> named
-            {{AudioWorkletNode/processorerror}} using {{ErrorEvent}} at |nodeReference|.
+        1. <a spec=webidl lt=construct>Construct a callback function</a> from |processorCtor| with
+            the argument of |deserializedOptions|. If any exceptions are thrown in the callback,
+            <a>queue a task</a> to the <a>control thread</a> to [=fire an event=] named
+            {{AudioWorkletNode/processorerror}} at |nodeReference| using {{ErrorEvent}}.
 
         1. Empty the [=pending processor construction data=] slot.
     </div>
@@ -11699,10 +11694,8 @@ Attributes</h5>
         When an unhandled exception is thrown from the processor's
         <code>constructor</code>, <code>process</code> method,
         or any user-defined class method, the processor will
-        <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task"> queue a media
-        element task</a> to <a spec="dom" lt="fire an event">fire an event</a> named <dfn event>processorerror</dfn> using
-        <a href="https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface">
-        ErrorEvent</a> at the associated {{AudioWorkletNode}}.
+        [=queue a media element task=] to [=fire an event=] named <dfn event>processorerror</dfn>
+        at the associated {{AudioWorkletNode}} using {{ErrorEvent}}.
 
         The <code>ErrorEvent</code> is created and initialized
         appropriately with its <code>message</code>,
@@ -12862,10 +12855,9 @@ task queue=] of its associated {{BaseAudioContext}}.
 
                         1. [=Making a buffer available for reading|Make a silent output buffer available for reading=].
 
-                        1. <a>Queue a task</a> to the <a>control thread</a>
-                            <a spec="dom" lt="fire an event">fire</a> an
-                            {{ErrorEvent}} named {{AudioWorkletNode/processorerror}} at the
-                            associated {{AudioWorkletNode}}.
+                        1. <a>Queue a task</a> to the <a>control thread</a> to [=fire an event=]
+                            named {{AudioWorkletNode/processorerror}} at the associated
+                            {{AudioWorkletNode}} using {{ErrorEvent}}.
 
             5. If this {{AudioNode}} is a <a>destination node</a>,
                 [=Recording the input|record the input=] of this {{AudioNode}}.
@@ -12949,7 +12941,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
 
     1. [=Queue a media element task=] to execute the following steps:
 
-        1. [=Fire an event=] using {{ErrorEvent}} at the |audioContext|'s {{AudioContext/error}}.
+        1. [=Fire an event=] named {{AudioContext/error}} at |audioContext| using {{ErrorEvent}}.
 
         1. Set the |audioContext|'s {{[[suspended by user]]}} to <code>false</code>.
 
@@ -12958,7 +12950,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
         1. Set the |audioContext|'s {{BaseAudioContext/state}} attribute to 
             "{{AudioContextState/suspended}}".
 
-        1. [=Fire an event=] at the |audioContext|'s {{BaseAudioContext/statechange}}.
+        1. [=Fire an event=] named {{BaseAudioContext/statechange}} at the |audioContext|.
 
     1. Abort these steps.
 
@@ -12966,7 +12958,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
 
     1. [=Queue a media element task=]to execute the following steps:
 
-        1. [=Fire an event=] using {{ErrorEvent}} at the |audioContext|'s {{AudioContext/error}}.
+        1. [=Fire an event=] named {{AudioContext/error}} at |audioContext| using {{ErrorEvent}}.
 
 Note: An example of system audio resource errors would be when an external or wireless audio device
     becoming disconnected during the active rendering of the {{AudioContext}}.


### PR DESCRIPTION
This PR fixes #2591. 

NOTE: No behavioral/functional spec change.

Per @tidoust's recommendation, this PR fixes wrong syntax around firing events in the Web Audio API spec.

To: @tidoust - can I get your quick look on this PR as well?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2592.html" title="Last updated on Jul 12, 2024, 3:01 PM UTC (d6f90d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2592/116612c...d6f90d0.html" title="Last updated on Jul 12, 2024, 3:01 PM UTC (d6f90d0)">Diff</a>