### PR TITLE
Use a regular Event for AudioContext.onerror

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2196,7 +2196,7 @@ Attributes</h4>
     <ins cite=#2567>
     : <dfn>onerror</dfn>
     ::
-        An [=event handler=] for the {{ErrorEvent}} dispatched from an {{AudioContext}}. The event
+        An [=event handler=] for the {{Event}} dispatched from an {{AudioContext}}. The event
             type of this handler is <dfn event for=AudioContext>error</dfn> and the user agent can
             dispatch this event in the following cases:
 
@@ -12941,7 +12941,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
 
     1. [=Queue a media element task=] to execute the following steps:
 
-        1. [=Fire an event=] named {{AudioContext/error}} at |audioContext| using {{ErrorEvent}}.
+        1. [=Fire an event=] named {{AudioContext/error}} at |audioContext|.
 
         1. Set the |audioContext|'s {{[[suspended by user]]}} to <code>false</code>.
 
@@ -12958,7 +12958,7 @@ The {{AudioContext}} |audioContext| performs the following steps on <a>rendering
 
     1. [=Queue a media element task=]to execute the following steps:
 
-        1. [=Fire an event=] named {{AudioContext/error}} at |audioContext| using {{ErrorEvent}}.
+        1. [=Fire an event=] named {{AudioContext/error}} at |audioContext|.
 
 Note: An example of system audio resource errors would be when an external or wireless audio device
     becoming disconnected during the active rendering of the {{AudioContext}}.


### PR DESCRIPTION
Fixes #2590.

cc @domenic - there are other places where `ErrorEvent` is used without necessary information, but this PR is focused on fixing problems with `AudioContext.onerror`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2593.html" title="Last updated on Jul 15, 2024, 2:13 PM UTC (b9430f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2593/6301a49...b9430f0.html" title="Last updated on Jul 15, 2024, 2:13 PM UTC (b9430f0)">Diff</a>