### PR TITLE
Fix typo (udio -> audio)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12927,7 +12927,7 @@ buffer</a> and the value(s) of the {{AudioParam}}(s) of this
     Handling an error from System Audio Resources on the {{AudioContext}}</h3>
 
 The {{AudioContext}} |audioContext| performs the following steps on <a>rendering thread</a> in the
-    event of an udio system resource error.
+    event of an audio system resource error.
 
 1. If the |audioContext|'s {{[[rendering thread state]]}} is <code>running</code>:
 


### PR DESCRIPTION
Hopefully this is straightforward and doesn't require change markup.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mjwilson-google/web-audio-api/pull/2594.html" title="Last updated on Jul 19, 2024, 11:00 PM UTC (a5a7653)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2594/88a3f35...mjwilson-google:a5a7653.html" title="Last updated on Jul 19, 2024, 11:00 PM UTC (a5a7653)">Diff</a>