### PR TITLE
Editorial: add missing indentation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2002,7 +2002,7 @@ Methods</h4>
                         {{BaseAudioContext/statechange}} at the {{AudioContext}}.
                 
                 1. Reject the promise with {{InvalidStateError}}, abort these
-                steps, returning <var>promise</var>.
+                    steps, returning <var>promise</var>.
 
             1. If the context is not <a>allowed to start</a>, append
                 <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}


### PR DESCRIPTION
This PR adds a missing indentation that causes Bikeshed compile errors. This indentation should have been added in #2611