### PR TITLE
Consider interrupted case on error handling section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -12109,7 +12109,8 @@ Running a <a>control message</a> to end an {{AudioContext}} |context|
 The {{AudioContext}} |audioContext| performs the following steps on <a>rendering thread</a> in the
     event of an audio system resource error.
 
-1. If the |audioContext|'s {{[[rendering thread state]]}} is <code>running</code>:
+1. If the |audioContext|'s {{[[rendering thread state]]}} is <code>running</code>
+    or <code>interrupted</code>:
 
     1. Attempt to <a>release system resources</a>.
 


### PR DESCRIPTION
This PR defines what should be done if an error occurs while an AudioContext is `interrupted`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gabrielsanbrito/web-audio-api/pull/2633.html" title="Last updated on Apr 11, 2025, 10:53 PM UTC (84f0211)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2633/a73cd1b...gabrielsanbrito:84f0211.html" title="Last updated on Apr 11, 2025, 10:53 PM UTC (84f0211)">Diff</a>