### PR TITLE
Add AudioPlayoutStats interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11760,6 +11760,11 @@ covert channel between two cooperating sites.
 One site could transmit information by intentionally causing audio glitches
 (by causing very high CPU usage, for example) while the other site
 could detect these glitches.
+
+Note: This covert channel depends on specific system characteristics.
+It typically requires a shared linearization point (such as an OS or browser
+audio mixer) and callbacks that are effectively synchronous from that point,
+without intermediate buffering that would flatten load spikes.
 <h5 id="AudioPlaybackStats-mitigations">Mitigations</h5>
 To inhibit the usage of such a covert channel, the API implements these
 mitigations.


### PR DESCRIPTION
Integrates the [Playout Statistics API for WebAudio spec](https://wicg.github.io/audio-context-playout-stats/) into the WebAudio spec.

The following changes are made between the version incubated in WICG and this PR:
* "fallback"/"fallbackFrames" terminology is replaced with "underrun".
* Duration types are changed from DOMHighResTimestamp to double.
* Time units are changed from milliseconds to seconds.

Related issue: https://github.com/WebAudio/web-audio-api/issues/2642


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Hernqvist/web-audio-api/pull/2645.html" title="Last updated on Nov 12, 2025, 2:48 PM UTC (0b3e022)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2645/7f58ac7...Hernqvist:0b3e022.html" title="Last updated on Nov 12, 2025, 2:48 PM UTC (0b3e022)">Diff</a>