### PR TITLE
Fix decodeAudioData algorithm logic

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1237,14 +1237,14 @@ Methods</h4>
 
             2. Let <var>promise</var> be a new Promise.
 
-            3. If {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} 
-                is [=BufferSource/detached=], execute the following steps:
+            3. If {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}}
+                is not [=BufferSource/detached=], execute the following steps:
 
                 1. Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
                 2. [=ArrayBuffer/Detach=]
                     the {{BaseAudioContext/decodeAudioData(audioData, successCallback, errorCallback)/audioData!!argument}} {{ArrayBuffer}}.
-                    If this operations throws, jump to the step 3. 
+                    If this operation throws, jump to step 4.1. 
 
                 3. Queue a decoding operation to be performed on another thread.
 


### PR DESCRIPTION
Per WG resolution 2025-05-15:
- Step 3 condition now correctly says "is not detached" instead of "is detached"
- Step 3.2 now correctly jumps to step 4.1 (error handling) if the ArrayBuffer detach operation throws

Also fixed "this operations" -> "this operation" typo while I was there.

This fixes #2637 and fixes #2646.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2665.html" title="Last updated on Jan 16, 2026, 2:35 PM UTC (2e6b677)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2665/4b11c58...2e6b677.html" title="Last updated on Jan 16, 2026, 2:35 PM UTC (2e6b677)">Diff</a>