### PR TITLE
Use <xmp> for examples

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -388,7 +388,7 @@ containing a single {{AudioDestinationNode}}:
 
 Illustrating this simple routing, here's a simple example playing a single sound:
 
-<pre class="example" highlight="js">
+<xmp class="example" highlight="js">
 const context = new AudioContext();
 
 function playSound() {
@@ -397,7 +397,7 @@ function playSound() {
     source.connect(context.destination);
     source.start(0);
 }
-</pre>
+</xmp>
 
 Here's a more complex example with three sources and a convolution
 reverb send with a dynamics compressor at the final output stage:
@@ -409,7 +409,7 @@ reverb send with a dynamics compressor at the final output stage:
     </figcaption>
 </figure>
 
-<pre class="example" highlight="js" line-numbers>
+<xmp class="example" highlight="js" line-numbers>
 let context;
 let compressor;
 let reverb;
@@ -491,7 +491,7 @@ function setupRoutingGraph () {
     source2.start(0);
     source3.start(0);
 }
-</pre>
+</xmp>
 
 Modular routing also permits the output of
 {{AudioNode}}s to be routed to an
@@ -509,7 +509,7 @@ input signal.
     </figcaption>
 </figure>
 
-<pre class="example" highlight="js" line-numbers>
+<xmp class="example" highlight="js" line-numbers>
 function setupRoutingGraph() {
     const context = new AudioContext();
 
@@ -532,7 +532,7 @@ function setupRoutingGraph() {
     hfo.start(0);
     lfo.start(0);
 }
-</pre>
+</xmp>
 
 <h3 id="APIOverview">
 API Overview</h3>
@@ -719,14 +719,14 @@ from {{AudioContextState}}, and that are both initially set to <code>"suspended"
 `null` and a private slot <dfn attribute for="BaseAudioContext">[[render quantum
 size]]</dfn> that is an unsigned integer.
 
-<pre class="idl">
+<xmp class="idl">
 enum AudioContextState {
     "suspended",
     "running",
     "closed",
     "interrupted"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-for="AudioContextState" dfn-type="enum-value">
@@ -761,12 +761,12 @@ enum AudioContextState {
 </table>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
  enum AudioContextRenderSizeCategory {
     "default",
     "hardware"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-for="AudioContextRenderSizeCategory" dfn-type="enum-value">
@@ -1425,13 +1425,13 @@ output device that produces a signal directed at the user. In most
 use cases, only a single {{AudioContext}} is used per
 document.
 
-<pre class="idl">
+<xmp class="idl">
 enum AudioContextLatencyCategory {
         "balanced",
         "interactive",
         "playback"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="AudioContextLatencyCategory">
@@ -1460,11 +1460,11 @@ enum AudioContextLatencyCategory {
 </table>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
 enum AudioSinkType {
     "none"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
     <table class="simple" dfn-type=enum-value dfn-for="AudioSinkType">
@@ -1954,13 +1954,13 @@ Methods</h4>
             method can be used to get performance time estimation for the
             slightly later context's time value:
 
-            <pre highlight="js">
+            <xmp highlight="js">
                 function outputPerformanceTime(contextTime) {
                     const timestamp = context.getOutputTimestamp();
                     const elapsedTime = contextTime - timestamp.contextTime;
                     return timestamp.performanceTime + elapsedTime * 1000;
                 }
-            </pre>
+            </xmp>
 
             In the above example the accuracy of the estimation depends on
             how close the argument value is to the current output audio
@@ -2333,14 +2333,14 @@ This algorithm is used to validate the information provided to modify
 The {{AudioContextOptions}} dictionary is used to
 specify user-specified options for an {{AudioContext}}.
 
-<pre class="idl">
+<xmp class="idl">
     dictionary AudioContextOptions {
         (AudioContextLatencyCategory or double) latencyHint = "interactive";
         float sampleRate;
         (DOMString or AudioSinkOptions) sinkId;
         (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
     };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audiocontextoptions-members">
 Dictionary {{AudioContextOptions}} Members</h5>
@@ -2390,11 +2390,11 @@ Dictionary {{AudioContextOptions}} Members</h5>
 The {{AudioSinkOptions}} dictionary is used to specify options for
 {{AudioContext/sinkId}}.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioSinkOptions {
     required AudioSinkType type;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audiosinkoptions-members">
 Dictionary {{AudioSinkOptions}} Members</h5>
@@ -2411,12 +2411,12 @@ Dictionary {{AudioSinkOptions}} Members</h5>
 The {{AudioSinkInfo}} interface is used to get information on the current
 audio output device via {{AudioContext/sinkId}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioSinkInfo {
     readonly attribute AudioSinkType type;
 };
-</pre>
+</xmp>
 
 <h5 id="audiosinkinfo-attributes">
 Attributes</h5>
@@ -2430,12 +2430,12 @@ Attributes</h5>
 <h4 dictionary id="AudioTimestamp">
 {{AudioTimestamp}}</h4>
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioTimestamp {
     double contextTime;
     DOMHighResTimeStamp performanceTime;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audiotimestamp-members">
 Dictionary {{AudioTimestamp}} Members</h5>
@@ -2558,13 +2558,13 @@ Constructors</h4>
 
         The OfflineAudioContext is constructed as if
 
-        <pre highlight="js">
+        <xmp highlight="js">
             new OfflineAudioContext({
                     numberOfChannels: numberOfChannels,
                     length: length,
                     sampleRate: sampleRate
             })
-        </pre>
+        </xmp>
 
         were called instead.
 
@@ -2785,14 +2785,14 @@ Methods</h4>
 This specifies the options to use in constructing an
 {{OfflineAudioContext}}.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary OfflineAudioContextOptions {
     unsigned long numberOfChannels = 1;
     required unsigned long length;
     required float sampleRate;
     (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-offlineaudiocontextoptions-members">
 Dictionary {{OfflineAudioContextOptions}} Members</h5>
@@ -2823,13 +2823,13 @@ The {{OfflineAudioCompletionEvent}} Interface</h4>
 This is an {{Event}} object which is dispatched to
 {{OfflineAudioContext}} for legacy reasons.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface OfflineAudioCompletionEvent : Event {
     constructor (DOMString type, OfflineAudioCompletionEventInit eventInitDict);
     readonly attribute AudioBuffer renderedBuffer;
 };
-</pre>
+</xmp>
 
 <h5 id="OfflineAudioCompletionEvent-attributes">
 Attributes</h5>
@@ -2843,11 +2843,11 @@ Attributes</h5>
 <h5 dictionary id="OfflineAudioCompletionEventInit">
 {{OfflineAudioCompletionEventInit}}</h5>
 
-<pre class="idl">
+<xmp class="idl">
 dictionary OfflineAudioCompletionEventInit : EventInit {
     required AudioBuffer renderedBuffer;
 };
-</pre>
+</xmp>
 
 <h6 id="dictionary-offlineaudiocompletioneventinit-members">
 Dictionary {{OfflineAudioCompletionEventInit}} Members</h6>
@@ -2906,7 +2906,7 @@ An {{AudioBuffer}} may be used by one or more
         A [=data block=] holding the audio sample data.
 </dl>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioBuffer {
     constructor (AudioBufferOptions options);
@@ -2922,7 +2922,7 @@ interface AudioBuffer {
                              unsigned long channelNumber,
                              optional unsigned long bufferOffset = 0);
 };
-</pre>
+</xmp>
 
 <h4 id="AudioBuffer-constructors">
 Constructors</h4>
@@ -3134,13 +3134,13 @@ This specifies the options to use in constructing an
 {{AudioBuffer}}. The {{AudioBufferOptions/length}} and {{AudioBufferOptions/sampleRate}} members are
 required.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioBufferOptions {
     unsigned long numberOfChannels = 1;
     required unsigned long length;
     required float sampleRate;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audiobufferoptions-members">
 Dictionary {{AudioBufferOptions}} Members</h5>
@@ -3215,7 +3215,7 @@ The processing of inputs and the internal operations of an
 connected outputs, and regardless of whether these outputs ultimately
 reach an {{AudioContext}}'s {{AudioDestinationNode}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioNode : EventTarget {
     AudioNode connect (AudioNode destinationNode,
@@ -3238,7 +3238,7 @@ interface AudioNode : EventTarget {
     attribute ChannelCountMode channelCountMode;
     attribute ChannelInterpretation channelInterpretation;
 };
-</pre>
+</xmp>
 
 <h4 id="AudioNode-creation">
 AudioNode Creation</h4>
@@ -3315,13 +3315,13 @@ This means that it is possible to dispatch events to
 {{AudioNode}}s the same way that other {{EventTarget}}s
 accept events.
 
-<pre class="idl">
+<xmp class="idl">
 enum ChannelCountMode {
     "max",
     "clamped-max",
     "explicit"
 };
-</pre>
+</xmp>
 
 The {{ChannelCountMode}}, in conjuction with the node's
 {{AudioNode/channelCount}} and {{AudioNode/channelInterpretation}} values, is used to determine
@@ -3357,12 +3357,12 @@ mixing is to be done.
 </table>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
 enum ChannelInterpretation {
     "speakers",
     "discrete"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="ChannelInterpretation">
@@ -3641,16 +3641,16 @@ Methods</h4>
         <div class=example>
             For example:
 
-            <pre highlight="js">
+            <xmp highlight="js">
                 nodeA.connect(nodeB);
                 nodeA.connect(nodeB);
-            </pre>
+            </xmp>
 
             will have the same effect as
 
-            <pre highlight="js">
+            <xmp highlight="js">
                 nodeA.connect(nodeB);
-            </pre>
+            </xmp>
         </div>
 
         This method returns <code>destination</code>
@@ -3703,16 +3703,16 @@ Methods</h4>
         <div class=example>
             For example:
 
-            <pre highlight="js">
+            <xmp highlight="js">
                 nodeA.connect(param);
                 nodeA.connect(param);
-            </pre>
+            </xmp>
 
             will have the same effect as
 
-            <pre highlight="js">
+            <xmp highlight="js">
                 nodeA.connect(param);
-            </pre>
+            </xmp>
         </div>
 
         <pre class=argumentdef for="AudioNode/connect(destinationParam, output)">
@@ -3836,13 +3836,13 @@ This specifies the options that can be used in constructing all
 {{AudioNode}}s. All members are optional. However, the specific
 values used for each node depends on the actual node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioNodeOptions {
     unsigned long channelCount;
     ChannelCountMode channelCountMode;
     ChannelInterpretation channelInterpretation;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audionodeoptions-members">
 Dictionary {{AudioNodeOptions}} Members</h5>
@@ -3978,12 +3978,12 @@ The automation rate of an {{AudioParam}} can be selected setting the
 values.  However, some {{AudioParam}}s have constraints on whether the
 automation rate can be changed.
 
-<pre class="idl">
+<xmp class="idl">
 enum AutomationRate {
     "a-rate",
     "k-rate"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="AutomationRate">
@@ -4016,7 +4016,7 @@ enum AutomationRate {
 Each {{AudioParam}} has an internal slot <dfn attribute for=AudioParam>[[current value]]</dfn>,
 initially set to the {{AudioParam}}'s {{AudioParam/defaultValue}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioParam {
     attribute float value;
@@ -4028,13 +4028,13 @@ interface AudioParam {
     AudioParam linearRampToValueAtTime (float value, double endTime);
     AudioParam exponentialRampToValueAtTime (float value, double endTime);
     AudioParam setTargetAtTime (float target, double startTime, float timeConstant);
-    AudioParam setValueCurveAtTime (sequence&lt;float> values,
+    AudioParam setValueCurveAtTime (sequence<float> values,
                                     double startTime,
                                     double duration);
     AudioParam cancelScheduledValues (double cancelTime);
     AudioParam cancelAndHoldAtTime (double cancelTime);
 };
-</pre>
+</xmp>
 
 <h4 id="AudioParam-attributes">
 Attributes</h4>
@@ -4247,11 +4247,11 @@ Methods</h4>
         the {{AudioParam/exponentialRampToValueAtTime()/endTime!!argument}} parameter passed into this method)
         will be calculated as:
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             v(t) = V_0 \left(\frac{V_1}{V_0}\right)^\frac{t - T_0}{T_1 - T_0}
         $$
-        </pre>
+        </xmp>
 
         where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is
         the {{AudioParam/exponentialRampToValueAtTime()/value!!argument}} parameter passed into this method. If
@@ -4304,11 +4304,11 @@ Methods</h4>
         the {{AudioParam/linearRampToValueAtTime()/endTime!!argument}} parameter passed into this method)
         will be calculated as:
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             v(t) = V_0 + (V_1 - V_0) \frac{t - T_0}{T_1 - T_0}
         $$
-        </pre>
+        </xmp>
 
         where \(V_0\) is the value at the time \(T_0\) and \(V_1\) is
         the {{AudioParam/linearRampToValueAtTime()/value!!argument}} parameter passed into this method.
@@ -4357,11 +4357,11 @@ Methods</h4>
         During the time interval: \(T_0 \leq t\), where \(T_0\) is the
         {{AudioParam/setTargetAtTime()/startTime!!argument}} parameter:
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             v(t) = V_1 + (V_0 - V_1)\, e^{-\left(\frac{t - T_0}{\tau}\right)}
         $$
-        </pre>
+        </xmp>
 
         where \(V_0\) is the initial value (the {{[[current value]]}}
         attribute) at \(T_0\) (the {{AudioParam/setTargetAtTime()/startTime!!argument}} parameter),
@@ -4400,11 +4400,11 @@ Methods</h4>
         <code>LinearRampToValue</code> or <code>ExponentialRampToValue</code>,
         then, for \(T_0 \leq t &lt; T_1\):
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             v(t) = V
         $$
-        </pre>
+        </xmp>
 
         In other words, the value will remain constant during this time
         interval, allowing the creation of "step" functions.
@@ -4435,12 +4435,12 @@ Methods</h4>
         and \(N\) be the length of the {{AudioParam/setValueCurveAtTime()/values!!argument}} array. Then,
         during the time interval: \(T_0 \le t &lt; T_0 + T_D\), let
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             \begin{align*} k &amp;= \left\lfloor \frac{N - 1}{T_D}(t-T_0) \right\rfloor \\
             \end{align*}
         $$
-        </pre>
+        </xmp>
 
         Then \(v(t)\) is computed by linearly interpolating between
         \(V[k]\) and \(V[k+1]\),
@@ -4533,11 +4533,11 @@ the clamping done as specified above.
     For example, consider a node \(N\) has an AudioParam \(p\) with a
     nominal range of \([0, 1]\), and following automation sequence
 
-    <pre highlight="js">
+    <xmp highlight="js">
         N.p.setValueAtTime(0, 0);
         N.p.linearRampToValueAtTime(4, 1);
         N.p.linearRampToValueAtTime(0, 2);
-    </pre>
+    </xmp>
 
     The initial slope of the curve is 4, until it reaches the maximum
     value of 1, at which time, the output is held constant. Finally,
@@ -4569,10 +4569,10 @@ http://googlechrome.github.io/web-audio-samples/samples/audio/timeline.html -->
         An example of parameter automation.
     </figcaption>
 </figure>
-<pre class="example" highlight="js" line-numbers>
+<xmp class="example" highlight="js" line-numbers>
     const curveLength = 44100;
     const curve = new Float32Array(curveLength);
-    for (const i = 0; i &lt; curveLength; ++i)
+    for (const i = 0; i < curveLength; ++i)
         curve[i] = Math.sin(Math.PI * i / curveLength);
 
     const t0 = 0;
@@ -4601,7 +4601,7 @@ http://googlechrome.github.io/web-audio-samples/samples/audio/timeline.html -->
     param.exponentialRampToValueAtTime(0.75, t6);
     param.exponentialRampToValueAtTime(0.05, t7);
     param.setValueCurveAtTime(curve, t7, t8 - t7);
-</pre>
+</xmp>
 
 
 <!--
@@ -4638,14 +4638,14 @@ and less than the time it's set to stop.
 slot <dfn attribute for="AudioScheduledSourceNode">[[source started]]</dfn>, initially
 set to false.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioScheduledSourceNode : AudioNode {
     attribute EventHandler onended;
     undefined start(optional double when = 0);
     undefined stop(optional double when = 0);
 };
-</pre>
+</xmp>
 
 <h4 id="AudioScheduledSourceNode-attributes">
 Attributes</h4>
@@ -4789,7 +4789,7 @@ macros:
     tail-time: No
 </pre>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AnalyserNode : AudioNode {
     constructor (BaseAudioContext context, optional AnalyserOptions options = {});
@@ -4803,7 +4803,7 @@ interface AnalyserNode : AudioNode {
     attribute double maxDecibels;
     attribute double smoothingTimeConstant;
 };
-</pre>
+</xmp>
 
 <h4 id="AnalyserNode-constructors">
 Constructors</h4>
@@ -4904,14 +4904,14 @@ Methods</h4>
         data</a> as described in <a href="#fft-windowing-and-smoothing-over-time">FFT windowing and
         smoothing</a>. Then the byte value, \(b[k]\), is
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             b[k] = \left\lfloor
                     \frac{255}{\mbox{dB}_{max} - \mbox{dB}_{min}}
                     \left(Y[k] - \mbox{dB}_{min}\right)
                 \right\rfloor
         $$
-        </pre>
+        </xmp>
 
         where \(\mbox{dB}_{min}\) is {{AnalyserNode/minDecibels}}
         and \(\mbox{dB}_{max}\) is <code>{{AnalyserNode/maxDecibels}}</code>. If
@@ -4939,11 +4939,11 @@ Methods</h4>
         the following way. Let \(x[k]\) be the time-domain data. Then
         the byte value, \(b[k]\), is
 
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             b[k] = \left\lfloor 128(1 + x[k]) \right\rfloor.
         $$
-        </pre>
+        </xmp>
 
         If \(b[k]\) lies outside the range 0 to 255, \(b[k]\) is
         clipped to lie in that range.
@@ -5006,14 +5006,14 @@ This specifies the options to be used when constructing an
 specified, the normal default values are used to construct the
 node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AnalyserOptions : AudioNodeOptions {
     unsigned long fftSize = 2048;
     double maxDecibels = -30;
     double minDecibels = -100;
     double smoothingTimeConstant = 0.8;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-analyseroptions-members">
 Dictionary {{AnalyserOptions}} Members</h5>
@@ -5074,7 +5074,7 @@ In the following, let \(N\) be the value of the
     \(x[n]\) for \(n = 0, \ldots, N - 1\) be the time domain data. The
     Blackman window is defined by
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
     \begin{align*}
         \alpha &amp;= \mbox{0.16} \\ a_0 &amp;= \frac{1-\alpha}{2} \\
@@ -5083,15 +5083,15 @@ In the following, let \(N\) be the value of the
         w[n] &amp;= a_0 - a_1 \cos\frac{2\pi n}{N} + a_2 \cos\frac{4\pi n}{N}, \mbox{ for } n = 0, \ldots, N - 1
     \end{align*}
     $$
-    </pre>
+    </xmp>
 
     The windowed signal \(\hat{x}[n]\) is
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \hat{x}[n] = x[n] w[n], \mbox{ for } n = 0, \ldots, N - 1
     $$
-    </pre>
+    </xmp>
 </div>
 
 <div algorithm="apply fourier transform">
@@ -5101,11 +5101,11 @@ In the following, let \(N\) be the value of the
     \(\hat{x}[n]\) be the windowed time domain data computed above.
     Then
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         X[k] = \frac{1}{N} \sum_{n = 0}^{N - 1} \hat{x}[n]\, W^{-kn}_{N}
     $$
-    </pre>
+    </xmp>
 
     for \(k = 0, \dots, N/2-1\) where \(W_N = e^{2\pi i/N}\).
 </div>
@@ -5126,11 +5126,11 @@ In the following, let \(N\) be the value of the
 
     Then the smoothed value, \(\hat{X}[k]\), is computed by
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \hat{X}[k] = \tau\, \hat{X}_{-1}[k] + (1 - \tau)\, \left|X[k]\right|
     $$
-    </pre>
+    </xmp>
 
     * If \(\hat{X}[k]\) is <code>NaN</code>, positive infinity or negative infinity, set \(\hat{X}[k]\) = 0.
 
@@ -5141,11 +5141,11 @@ In the following, let \(N\) be the value of the
     <dfn id="conversion-to-db">Conversion to dB</dfn> consists of the
     following operation, where \(\hat{X}[k]\) is computed in <a>smoothing over time</a>:
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         Y[k] = 20\log_{10}\hat{X}[k]
     $$
-    </pre>
+    </xmp>
 
     for \(k = 0, \ldots, N-1\).
 
@@ -5229,9 +5229,9 @@ The {{AudioBufferSourceNode/playbackRate}} and
 <a>compound parameter</a>. They are used together to determine a
 <dfn>computedPlaybackRate</dfn> value:
 
-<pre highlight>
+<xmp highlight>
 computedPlaybackRate(t) = playbackRate(t) * pow(2, detune(t) / 1200)
-</pre>
+</xmp>
 
 The <a>nominal range</a> for this <a>compound parameter</a> is
 \((-\infty, \infty)\).
@@ -5239,7 +5239,7 @@ The <a>nominal range</a> for this <a>compound parameter</a> is
 {{AudioBufferSourceNode}}s are created with an internal boolean
 slot <dfn attribute for="AudioBufferSourceNode">[[buffer set]]</dfn>, initially set to false.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
     constructor (BaseAudioContext context,
@@ -5254,7 +5254,7 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
                      optional double offset,
                      optional double duration);
 };
-</pre>
+</xmp>
 
 <h4 id="AudioBufferSourceNode-constructors">
 Constructors</h4>
@@ -5435,7 +5435,7 @@ This specifies options for constructing a
 optional; if not specified, the normal default is used in
 constructing the node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioBufferSourceOptions {
     AudioBuffer? buffer;
     float detune = 0;
@@ -5444,7 +5444,7 @@ dictionary AudioBufferSourceOptions {
     double loopStart = 0;
     float playbackRate = 1;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audiobuffersourceoptions-members">
 Dictionary {{AudioBufferSourceOptions}} Members</h5>
@@ -5887,12 +5887,12 @@ value may not be changed; <span class="synchronous">a
 {{AudioNode/channelCount}} is changed to a
 different value</span>.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioDestinationNode : AudioNode {
     readonly attribute unsigned long maxChannelCount;
 };
-</pre>
+</xmp>
 
 <h4 id="AudioDestinationNode-attributes">
 Attributes</h4>
@@ -5943,7 +5943,7 @@ head is pointing. These two vectors are expected to be linearly
 independent. For normative requirements of how these values are to be
 interpreted, see the [[#Spatialization]] section.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioListener {
     readonly attribute AudioParam positionX;
@@ -5958,7 +5958,7 @@ interface AudioListener {
     undefined setPosition (float x, float y, float z);
     undefined setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
 };
-</pre>
+</xmp>
 
 <h4 id="AudioListener-attributes">
 Attributes</h4>
@@ -6228,7 +6228,7 @@ The audio data which is the result of the processing (or the
 synthesized data if there are no inputs) is then placed into the
 {{AudioProcessingEvent/outputBuffer}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface AudioProcessingEvent : Event {
     constructor (DOMString type, AudioProcessingEventInit eventInitDict);
@@ -6236,7 +6236,7 @@ interface AudioProcessingEvent : Event {
     readonly attribute AudioBuffer inputBuffer;
     readonly attribute AudioBuffer outputBuffer;
 };
-</pre>
+</xmp>
 
 <h4 id="AudioProcessingEvent-attributes">
 Attributes</h4>
@@ -6273,13 +6273,13 @@ Attributes</h4>
 <h4 dictionary id="AudioProcessingEventInit">
 {{AudioProcessingEventInit}}</h4>
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioProcessingEventInit : EventInit {
     required double playbackTime;
     required AudioBuffer inputBuffer;
     required AudioBuffer outputBuffer;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-audioprocessingeventinit-members">
 Dictionary {{AudioProcessingEventInit}} Members</h5>
@@ -6323,9 +6323,9 @@ and {{BiquadFilterNode/detune}} form
 a <a>compound parameter</a> and are both <a>a-rate</a>. They are used
 together to determine a <dfn>computedFrequency</dfn> value:
 
-<pre highlight>
+<xmp highlight>
     computedFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
-</pre>
+</xmp>
 
 The <a>nominal range</a> for this <a>compound parameter</a> is [0,
 <a>Nyquist frequency</a>].
@@ -6346,7 +6346,7 @@ macros:
 The number of channels of the output always equals the number of
 channels of the input.
 
-<pre class="idl">
+<xmp class="idl">
 enum BiquadFilterType {
     "lowpass",
     "highpass",
@@ -6357,7 +6357,7 @@ enum BiquadFilterType {
     "notch",
     "allpass"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="BiquadFilterType">
@@ -6497,7 +6497,7 @@ enum BiquadFilterType {
 
 All attributes of the {{BiquadFilterNode}} are <a>a-rate</a> {{AudioParam}}s.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface BiquadFilterNode : AudioNode {
     constructor (BaseAudioContext context, optional BiquadFilterOptions options = {});
@@ -6510,7 +6510,7 @@ interface BiquadFilterNode : AudioNode {
                                     Float32Array magResponse,
                                     Float32Array phaseResponse);
 };
-</pre>
+</xmp>
 
 <h4 id="BiquadFilterNode-constructors">
 Constructors</h4>
@@ -6662,7 +6662,7 @@ This specifies the options to be used when constructing a
 not specified, the normal default values are used to construct the
 node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary BiquadFilterOptions : AudioNodeOptions {
     BiquadFilterType type = "lowpass";
     float Q = 1;
@@ -6670,7 +6670,7 @@ dictionary BiquadFilterOptions : AudioNodeOptions {
     float frequency = 350;
     float gain = 0;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-biquadfilteroptions-members">
 Dictionary {{BiquadFilterOptions}} Members</h5>
@@ -6705,21 +6705,21 @@ filter types. They are inspired by formulas found in the
 
 The {{BiquadFilterNode}} processes audio with a transfer function of
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
  H(z) = \frac{\frac{b_0}{a_0} + \frac{b_1}{a_0}z^{-1} + \frac{b_2}{a_0}z^{-2}}
                                           {1+\frac{a_1}{a_0}z^{-1}+\frac{a_2}{a_0}z^{-2}}
 $$
-</pre>
+</xmp>
 
 which is equivalent to a time-domain equation of:
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
 a_0 y(n) + a_1 y(n-1) + a_2 y(n-2) =
     b_0 x(n) + b_1 x(n-1) + b_2 x(n-2)
 $$
-</pre>
+</xmp>
 
 
 The initial filter state is 0.
@@ -6746,7 +6746,7 @@ their computation, based on the <a>computedValue</a> of the
 
 * Finally let
     <!-- Should \alpha_S be simplified since S is always 1?-->
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
     \begin{align*}
         A &amp;= 10^{\frac{G}{40}} \\
@@ -6757,14 +6757,14 @@ their computation, based on the <a>computedValue</a> of the
         \alpha_S &amp;= \frac{\sin\omega_0}{2}\sqrt{\left(A+\frac{1}{A}\right)\left(\frac{1}{S}-1\right)+2}
     \end{align*}
     $$
-    </pre>
+    </xmp>
 
 The six coefficients (\(b_0, b_1, b_2, a_0, a_1, a_2\)) for each
 filter type, are:
 
 : "{{lowpass}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= \frac{1 - \cos\omega_0}{2} \\
@@ -6775,11 +6775,11 @@ filter type, are:
             a_2 &amp;= 1 - \alpha_{Q_{dB}}
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{highpass}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= \frac{1 + \cos\omega_0}{2} \\
@@ -6790,11 +6790,11 @@ filter type, are:
             a_2 &amp;= 1 - \alpha_{Q_{dB}}
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{bandpass}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= \alpha_Q \\
@@ -6805,11 +6805,11 @@ filter type, are:
             a_2 &amp;= 1 - \alpha_Q
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{notch}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= 1 \\
@@ -6820,11 +6820,11 @@ filter type, are:
             a_2 &amp;= 1 - \alpha_Q
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{allpass}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= 1 - \alpha_Q \\
@@ -6835,11 +6835,11 @@ filter type, are:
             a_2 &amp;= 1 - \alpha_Q
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{peaking}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= 1 + \alpha_Q\, A \\
@@ -6850,11 +6850,11 @@ filter type, are:
             a_2 &amp;= 1 - \frac{\alpha_Q}{A}
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{lowshelf}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= A \left[ (A+1) - (A-1) \cos\omega_0 + 2 \alpha_S \sqrt{A})\right] \\
@@ -6865,11 +6865,11 @@ filter type, are:
             a_2 &amp;= (A+1) + (A-1) \cos\omega_0 - 2 \alpha_S \sqrt{A})
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 : "{{highshelf}}"
 ::
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         \begin{align*}
             b_0 &amp;= A\left[ (A+1) + (A-1)\cos\omega_0 + 2\alpha_S\sqrt{A} )\right] \\
@@ -6880,7 +6880,7 @@ filter type, are:
             a_2 &amp;= (A+1) - (A-1)\cos\omega_0 - 2\alpha_S\sqrt{A}
         \end{align*}
     $$
-    </pre>
+    </xmp>
 
 
 <!--
@@ -6957,12 +6957,12 @@ output channels.
     </figure>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface ChannelMergerNode : AudioNode {
     constructor (BaseAudioContext context, optional ChannelMergerOptions options = {});
 };
-</pre>
+</xmp>
 
 <h4 id="ChannelMergerNode-constructors">
 Constructors</h4>
@@ -6984,11 +6984,11 @@ Constructors</h4>
 <h4 dictionary id="ChannelMergerOptions">
 {{ChannelMergerOptions}}</h4>
 
-<pre class="idl">
+<xmp class="idl">
 dictionary ChannelMergerOptions : AudioNodeOptions {
     unsigned long numberOfInputs = 6;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-channelmergeroptions-members">
 Dictionary {{ChannelMergerOptions}} Members</h5>
@@ -7070,12 +7070,12 @@ One application for {{ChannelSplitterNode}} is for doing
 "matrix mixing" where individual gain control of each channel is
 desired.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface ChannelSplitterNode : AudioNode {
     constructor (BaseAudioContext context, optional ChannelSplitterOptions options = {});
 };
-</pre>
+</xmp>
 
 <h4 id="ChannelSplitterNode-constructors">
 Constructors</h4>
@@ -7097,11 +7097,11 @@ Constructors</h4>
 <h4 dictionary id="ChannelSplitterOptions">
 {{ChannelSplitterOptions}}</h4>
 
-<pre class="idl">
+<xmp class="idl">
 dictionary ChannelSplitterOptions : AudioNodeOptions {
     unsigned long numberOfOutputs = 6;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-channelsplitteroptions-members">
 Dictionary {{ChannelSplitterOptions}} Members</h5>
@@ -7152,13 +7152,13 @@ macros:
     tail-time: No
 </pre>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface ConstantSourceNode : AudioScheduledSourceNode {
     constructor (BaseAudioContext context, optional ConstantSourceOptions options = {});
     readonly attribute AudioParam offset;
 };
-</pre>
+</xmp>
 
 <h4 id="ConstantSourceNode-constructors">
 Constructors</h4>
@@ -7205,11 +7205,11 @@ This specifies options for constructing a
 if not specified, the normal defaults are used for constructing the
 node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary ConstantSourceOptions {
     float offset = 1;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-constantsourceoptions-members">
 Dictionary {{ConstantSourceOptions}} Members</h5>
@@ -7258,14 +7258,14 @@ There are <a>channelCount constraints</a> and <a>channelCountMode
 constraints</a> for this node. These constraints ensure that the
 input to the node is either mono or stereo.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface ConvolverNode : AudioNode {
     constructor (BaseAudioContext context, optional ConvolverOptions options = {});
     attribute AudioBuffer? buffer;
     attribute boolean normalize;
 };
-</pre>
+</xmp>
 
 <h4 id="ConvolverNode-constructors">
 Constructors</h4>
@@ -7374,7 +7374,7 @@ Attributes</h4>
         {{ConvolverNode/buffer}} to calculate a <var>normalizationScale</var>
         given this algorithm:
 
-        <pre highlight="js" line-numbers>
+        <xmp highlight="js" line-numbers>
         function calculateNormalizationScale(buffer) {
             const GainCalibration = 0.00125;
             const GainCalibrationSampleRate = 44100;
@@ -7386,11 +7386,11 @@ Attributes</h4>
 
             let power = 0;
 
-            for (let i = 0; i &lt; numberOfChannels; i++) {
+            for (let i = 0; i < numberOfChannels; i++) {
                 let channelPower = 0;
                 const channelData = buffer.getChannelData(i);
 
-                for (let j = 0; j &lt; length; j++) {
+                for (let j = 0; j < length; j++) {
                     const sample = channelData[j];
                     channelPower += sample * sample;
                 }
@@ -7401,7 +7401,7 @@ Attributes</h4>
             power = Math.sqrt(power / (numberOfChannels * length));
 
             // Protect against accidental overload.
-            if (!isFinite(power) || isNaN(power) || power &lt; MinPower)
+            if (!isFinite(power) || isNaN(power) || power < MinPower)
                 power = MinPower;
 
             let scale = 1 / power;
@@ -7419,7 +7419,7 @@ Attributes</h4>
 
             return scale;
         }
-        </pre>
+        </xmp>
 
         During processing, the ConvolverNode will then take this
         calculated <var>normalizationScale</var> value and multiply it by
@@ -7439,12 +7439,12 @@ The specifies options for constructing a
 {{ConvolverNode}}. All members are optional; if not
 specified, the node is contructing using the normal defaults.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary ConvolverOptions : AudioNodeOptions {
     AudioBuffer? buffer;
     boolean disableNormalization = false;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-convolveroptions-members">
 Dictionary {{ConvolverOptions}} Members</h5>
@@ -7545,13 +7545,13 @@ layout.
 Note: By definition, a {{DelayNode}} introduces an audio processing
 latency equal to the amount of the delay.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface DelayNode : AudioNode {
     constructor (BaseAudioContext context, optional DelayOptions options = {});
     readonly attribute AudioParam delayTime;
 };
-</pre>
+</xmp>
 
 <h4 id="DelayNode-constructors">
 Constructors</h4>
@@ -7604,12 +7604,12 @@ This specifies options for constructing a
 {{DelayNode}}. All members are optional; if not
 given, the node is constructed using the normal defaults.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary DelayOptions : AudioNodeOptions {
     double maxDelayTime = 1;
     double delayTime = 0;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-delayoptions-members">
 Dictionary {{DelayOptions}} Members</h5>
@@ -7703,7 +7703,7 @@ macros:
     tail-time-notes:  This node has a <a>tail-time</a> such that this node continues to output non-silent audio with zero input due to the look-ahead delay.
 </pre>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface DynamicsCompressorNode : AudioNode {
     constructor (BaseAudioContext context,
@@ -7715,7 +7715,7 @@ interface DynamicsCompressorNode : AudioNode {
     readonly attribute AudioParam attack;
     readonly attribute AudioParam release;
 };
-</pre>
+</xmp>
 
 <h4 id="DynamicsCompressorNode-constructors">
 Constructors</h4>
@@ -7830,7 +7830,7 @@ This specifies the options to use in constructing a
 optional; if not specified the normal defaults are used in
 constructing the node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary DynamicsCompressorOptions : AudioNodeOptions {
     float attack = 0.003;
     float knee = 30;
@@ -7838,7 +7838,7 @@ dictionary DynamicsCompressorOptions : AudioNodeOptions {
     float release = 0.25;
     float threshold = -24;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-dynamicscompressoroptions-members">
 Dictionary {{DynamicsCompressorOptions}} Members</h5>
@@ -7915,14 +7915,14 @@ a new class, <dfn>EnvelopeFollower</dfn>, that instantiates a
 special object that behaves like an {{AudioNode}}, described
 below:
 
-<pre>
+<xmp>
     const delay = new DelayNode(context, {delayTime: 0.006});
     const gain = new GainNode(context);
     const compression = new EnvelopeFollower();
 
     input.connect(delay).connect(gain).connect(output);
     input.connect(compression).connect(gain.gain);
-</pre>
+</xmp>
 
 <figure>
     <img src="images/dynamicscompressor-internal-graph.svg" alt="Schema of
@@ -8165,13 +8165,13 @@ Each sample of each channel of the input data of the
 {{GainNode}} MUST be multiplied by the
 <a>computedValue</a> of the {{GainNode/gain}} {{AudioParam}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface GainNode : AudioNode {
     constructor (BaseAudioContext context, optional GainOptions options = {});
     readonly attribute AudioParam gain;
 };
-</pre>
+</xmp>
 
 <h4 id="GainNode-constructors">
 Constructors</h4>
@@ -8217,11 +8217,11 @@ This specifies options to use in constructing a
 {{GainNode}}. All members are optional; if not
 specified, the normal defaults are used in constructing the node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary GainOptions : AudioNodeOptions {
     float gain = 1.0;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-gainoptions-members">
 Dictionary {{GainOptions}} Members</h5>
@@ -8277,7 +8277,7 @@ macros:
 The number of channels of the output always equals the number of
 channels of the input.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface IIRFilterNode : AudioNode {
     constructor (BaseAudioContext context, IIRFilterOptions options);
@@ -8285,7 +8285,7 @@ interface IIRFilterNode : AudioNode {
                                     Float32Array magResponse,
                                     Float32Array phaseResponse);
 };
-</pre>
+</xmp>
 
 <h4 id="IIRFilterNode-constructors">
 Constructors</h4>
@@ -8363,11 +8363,11 @@ Let \(b_m\) be the <code>feedforward</code> coefficients and
 {{BaseAudioContext/createIIRFilter()}} or the {{IIRFilterOptions}} dictionary for the {{IIRFilterNode/IIRFilterNode()|constructor}}. Then the
 transfer function of the general IIR filter is given by
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
     H(z) = \frac{\sum_{m=0}^{M} b_m z^{-m}}{\sum_{n=0}^{N} a_n z^{-n}}
 $$
-</pre>
+</xmp>
 
 where \(M + 1\) is the length of the \(b\) array and \(N + 1\) is
 the length of the \(a\) array. The coefficient \(a_0\) MUST not be 0 (see {{BaseAudioContext/createIIRFilter()/feedback|feedback parameter}} for {{BaseAudioContext/createIIRFilter()}}).
@@ -8375,11 +8375,11 @@ At least one of \(b_m\) MUST be non-zero (see {{BaseAudioContext/createIIRFilter
 
 Equivalently, the time-domain equation is:
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
     \sum_{k=0}^{N} a_k y(n-k) = \sum_{k=0}^{M} b_k x(n-k)
 $$
-</pre>
+</xmp>
 
 The initial filter state is the all-zeroes state.
 
@@ -8448,19 +8448,19 @@ attribute changes, and other aspects of the
 {{HTMLMediaElement}} MUST behave as they normally would if
 <em>not</em> used with a {{MediaElementAudioSourceNode}}.
 
-<pre class="example" highlight="js">
+<xmp class="example" highlight="js">
     const mediaElement = document.getElementById('mediaElementID');
     const sourceNode = context.createMediaElementSource(mediaElement);
     sourceNode.connect(filterNode);
-</pre>
+</xmp>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface MediaElementAudioSourceNode : AudioNode {
     constructor (AudioContext context, MediaElementAudioSourceOptions options);
     [SameObject] readonly attribute HTMLMediaElement mediaElement;
 };
-</pre>
+</xmp>
 
 <h4 id="MediaElementAudioSourceNode-constructors">
 Constructors</h4>
@@ -8493,11 +8493,11 @@ Attributes</h4>
 This specifies the options to use in constructing a
 {{MediaElementAudioSourceNode}}.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary MediaElementAudioSourceOptions {
     required HTMLMediaElement mediaElement;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-mediaelementaudiosourceoptions-members">
 Dictionary {{MediaElementAudioSourceOptions}} Members</h5>
@@ -8557,13 +8557,13 @@ macros:
 
 The number of channels of the input is by default 2 (stereo).
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface MediaStreamAudioDestinationNode : AudioNode {
     constructor (AudioContext context, optional AudioNodeOptions options = {});
     readonly attribute MediaStream stream;
 };
-</pre>
+</xmp>
 
 <h4 id="MediaStreamAudioDestinationNode-constructors">
 Constructors</h4>
@@ -8618,13 +8618,13 @@ rate of the associated {{AudioContext}}, then the output of the
 {{MediaStreamTrack}} is resampled to match the context's
 {{BaseAudioContext/sampleRate|sample rate}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface MediaStreamAudioSourceNode : AudioNode {
     constructor (AudioContext context, MediaStreamAudioSourceOptions options);
     [SameObject] readonly attribute MediaStream mediaStream;
 };
-</pre>
+</xmp>
 
 <h4 id="MediaStreamAudioSourceNode-constructors">
 Constructors</h4>
@@ -8690,11 +8690,11 @@ Attributes</h4>
 
 This specifies the options for constructing a {{MediaStreamAudioSourceNode}}.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary MediaStreamAudioSourceOptions {
     required MediaStream mediaStream;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-mediastreamaudiosourceoptions-members">
 Dictionary {{MediaStreamAudioSourceOptions}} Members</h5>
@@ -8729,12 +8729,12 @@ rate of the associated {{AudioContext}}, then the output of the
 {{MediaStreamTrackAudioSourceOptions/mediaStreamTrack}} is resampled
 to match the context's {{BaseAudioContext/sampleRate|sample rate}}.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface MediaStreamTrackAudioSourceNode : AudioNode {
     constructor (AudioContext context, MediaStreamTrackAudioSourceOptions options);
 };
-</pre>
+</xmp>
 
 <h4 id="MediaStreamTrackAudioSourceNode-constructors">
 Constructors</h4>
@@ -8761,11 +8761,11 @@ This specifies the options for constructing a
 {{MediaStreamTrackAudioSourceNode}}. This is
 required.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary MediaStreamTrackAudioSourceOptions {
     required MediaStreamTrack mediaStreamTrack;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-mediastreamtrackaudiosourceoptions-members">
 Dictionary {{MediaStreamTrackAudioSourceOptions}} Members</h5>
@@ -8823,9 +8823,9 @@ Both {{OscillatorNode/frequency}} and {{OscillatorNode/detune}} are <a>a-rate</a
 parameters, and form a <a>compound parameter</a>. They are used
 together to determine a <dfn>computedOscFrequency</dfn> value:
 
-<pre>
+<xmp>
     computedOscFrequency(t) = frequency(t) * pow(2, detune(t) / 1200)
-</pre>
+</xmp>
 
 The OscillatorNode's instantaneous phase at each time is the definite
 time integral of <a>computedOscFrequency</a>, assuming a phase angle
@@ -8845,7 +8845,7 @@ macros:
     tail-time: No
 </pre>
 
-<pre class="idl">
+<xmp class="idl">
 enum OscillatorType {
     "sine",
     "square",
@@ -8853,7 +8853,7 @@ enum OscillatorType {
     "triangle",
     "custom"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="OscillatorType">
@@ -8869,7 +8869,7 @@ enum OscillatorType {
 </table>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface OscillatorNode : AudioScheduledSourceNode {
     constructor (BaseAudioContext context, optional OscillatorOptions options = {});
@@ -8878,7 +8878,7 @@ interface OscillatorNode : AudioScheduledSourceNode {
     readonly attribute AudioParam detune;
     undefined setPeriodicWave (PeriodicWave periodicWave);
 };
-</pre>
+</xmp>
 
 <h4 id="OscillatorNode-constructors">
 Constructors</h4>
@@ -8975,14 +8975,14 @@ This specifies the options to be used when constructing an
 optional; if not specified, the normal default values are used for
 constructing the oscillator.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary OscillatorOptions : AudioNodeOptions {
     OscillatorType type = "sine";
     float frequency = 440;
     float detune = 0;
     PeriodicWave periodicWave;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-oscillatoroptions-members">
 Dictionary {{OscillatorOptions}} Members</h5>
@@ -9029,24 +9029,24 @@ basic waveforms.
 ::
     The waveform for sine oscillator is:
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         x(t) = \sin t
     $$
-    </pre>
+    </xmp>
 
 : "{{OscillatorType/square}}"
 ::
     The waveform for the square wave oscillator is:
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         x(t) = \begin{cases}
-                     1 & \mbox{for } 0≤ t &lt; \pi \\
-                     -1 & \mbox{for } -\pi &lt; t &lt; 0.
+                     1 & \mbox{for } 0≤ t < \pi \\
+                     -1 & \mbox{for } -\pi < t < 0.
                      \end{cases}
     $$
-    </pre>
+    </xmp>
 
     This is extended to all \(t\) by using the fact that the
     waveform is an odd function with period \(2\pi\).
@@ -9055,11 +9055,11 @@ basic waveforms.
 ::
     The waveform for the sawtooth oscillator is the ramp:
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
-        x(t) = \frac{t}{\pi} \mbox{ for } -\pi &lt; t ≤ \pi;
+        x(t) = \frac{t}{\pi} \mbox{ for } -\pi < t ≤ \pi;
     $$
-    </pre>
+    </xmp>
 
     This is extended to all \(t\) by using the fact that the
     waveform is an odd function with period \(2\pi\).
@@ -9068,15 +9068,15 @@ basic waveforms.
 ::
     The waveform for the triangle oscillator is:
 
-    <pre nohighlight>
+    <xmp nohighlight>
     $$
         x(t) = \begin{cases}
                          \frac{2}{\pi} t & \mbox{for } 0 ≤ t ≤ \frac{\pi}{2} \\
                          1-\frac{2}{\pi} \left(t-\frac{\pi}{2}\right) & \mbox{for }
-                         \frac{\pi}{2} &lt; t ≤ \pi.
+                         \frac{\pi}{2} < t ≤ \pi.
                      \end{cases}
     $$
-    </pre>
+    </xmp>
 
     This is extended to all \(t\) by using the fact that the
     waveform is an odd function with period \(2\pi\).
@@ -9121,12 +9121,12 @@ The {{PanningModelType}} enum determines which
 spatialization algorithm will be used to position the audio in 3D
 space. The default is "{{PanningModelType/equalpower}}".
 
-<pre class="idl">
+<xmp class="idl">
 enum PanningModelType {
         "equalpower",
         "HRTF"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="PanningModelType">
@@ -9172,13 +9172,13 @@ value of the {{PannerNode/refDistance}} attribute; \(d_{max}\) be the
 value of the {{PannerNode/maxDistance}} attribute; and \(f\) be the
 value of the {{PannerNode/rolloffFactor}} attribute.
 
-<pre class="idl">
+<xmp class="idl">
 enum DistanceModelType {
     "linear",
     "inverse",
     "exponential"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="DistanceModelType">
@@ -9195,11 +9195,11 @@ enum DistanceModelType {
                 A linear distance model which calculates <em>distanceGain</em>
                 according to:
 
-                <pre nohighlight>
+                <xmp nohighlight>
                 $$
                     1 - f\ \frac{\max\left[\min\left(d, d'_{max}\right), d'_{ref}\right] - d'_{ref}}{d'_{max} - d'_{ref}}
                 $$
-                </pre>
+                </xmp>
 
                 where \(d'_{ref} = \min\left(d_{ref}, d_{max}\right)\) and \(d'_{max} =
                 \max\left(d_{ref}, d_{max}\right)\). In the case where \(d'_{ref} =
@@ -9215,11 +9215,11 @@ enum DistanceModelType {
                 An inverse distance model which calculates
                 <em>distanceGain</em> according to:
 
-                <pre nohighlight>
+                <xmp nohighlight>
                 $$
                     \frac{d_{ref}}{d_{ref} + f\ \left[\max\left(d, d_{ref}\right) - d_{ref}\right]}
                 $$
-                </pre>
+                </xmp>
 
                 That is, \(d\) is clamped to the interval \(\left[d_{ref},\,
                 \infty\right)\). If \(d_{ref} = 0\), the value of the inverse model
@@ -9231,11 +9231,11 @@ enum DistanceModelType {
                 An exponential distance model which calculates
                 <em>distanceGain</em> according to:
 
-                <pre nohighlight>
+                <xmp nohighlight>
                 $$
                     \left[\frac{\max\left(d, d_{ref}\right)}{d_{ref}}\right]^{-f}
                 $$
-                </pre>
+                </xmp>
 
                 That is, \(d\) is clamped to the interval \(\left[d_{ref},\,
                 \infty\right)\). If \(d_{ref} = 0\), the value of the exponential
@@ -9243,7 +9243,7 @@ enum DistanceModelType {
 </table>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface PannerNode : AudioNode {
     constructor (BaseAudioContext context, optional PannerOptions options = {});
@@ -9264,7 +9264,7 @@ interface PannerNode : AudioNode {
     undefined setPosition (float x, float y, float z);
     undefined setOrientation (float x, float y, float z);
 };
-</pre>
+</xmp>
 
 <h4 id="PannerNode-constructors">
 Constructors</h4>
@@ -9548,7 +9548,7 @@ This specifies options for constructing a
 {{PannerNode}}. All members are optional; if not
 specified, the normal default is used in constructing the node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary PannerOptions : AudioNodeOptions {
     PanningModelType panningModel = "equalpower";
     DistanceModelType distanceModel = "inverse";
@@ -9565,7 +9565,7 @@ dictionary PannerOptions : AudioNodeOptions {
     double coneOuterAngle = 360;
     double coneOuterGain = 0;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-pannernode-members">
 Dictionary {{PannerOptions}} Members</h5>
@@ -9632,12 +9632,12 @@ with an {{OscillatorNode}}.
 A <a>conforming implementation</a> MUST support {{PeriodicWave}}
 up to at least 8192 elements.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface PeriodicWave {
     constructor (BaseAudioContext context, optional PeriodicWaveOptions options = {});
 };
-</pre>
+</xmp>
 
 <h4 id="PeriodicWave-constructors">
 Constructors</h4>
@@ -9688,11 +9688,11 @@ Constructors</h4>
 The {{PeriodicWaveConstraints}} dictionary is used to
 specify how the waveform is [[#waveform-normalization|normalized]].
 
-<pre class="idl">
+<xmp class="idl">
 dictionary PeriodicWaveConstraints {
     boolean disableNormalization = false;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-periodicwaveconstraints-members">
 Dictionary {{PeriodicWaveConstraints}} Members</h5>
@@ -9758,11 +9758,11 @@ method takes two arrays to specify the Fourier coefficients of the
 arrays of length \(L\), respectively. Then the basic time-domain waveform,
 \(x(t)\), can be computed using:
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
     x(t) = \sum_{k=1}^{L-1} \left[a[k]\cos2\pi k t + b[k]\sin2\pi k t\right]
 $$
-</pre>
+</xmp>
 
 This is the basic (unnormalized) waveform.
 
@@ -9777,29 +9777,29 @@ maximum value is 1. The normalization is done as follows.
 
 Let
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
     \tilde{x}(n) = \sum_{k=1}^{L-1} \left(a[k]\cos\frac{2\pi k n}{N} + b[k]\sin\frac{2\pi k n}{N}\right)
 $$
-</pre>
+</xmp>
 
 where \(N\) is a power of two. (Note: \(\tilde{x}(n)\) can
 conveniently be computed using an inverse FFT.) The fixed
 normalization factor \(f\) is computed as follows.
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
     f = \max_{n = 0, \ldots, N - 1} |\tilde{x}(n)|
 $$
-</pre>
+</xmp>
 
 Thus, the actual normalized waveform \(\hat{x}(n)\) is:
 
-<pre nohighlight>
+<xmp nohighlight>
 $$
     \hat{x}(n) = \frac{\tilde{x}(n)}{f}
 $$
-</pre>
+</xmp>
 
 This fixed normalization factor MUST be applied to all generated
 waveforms.
@@ -9822,38 +9822,38 @@ for \(n \ge 1\) is specified below.
 <dl link-for="OscillatorType">
     : "{{sine}}"
     ::
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             b[n] = \begin{cases}
                              1 &amp; \mbox{for } n = 1 \\
                              0 &amp; \mbox{otherwise}
                          \end{cases}
         $$
-        </pre>
+        </xmp>
 
     : "{{square}}"
     ::
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             b[n] = \frac{2}{n\pi}\left[1 - (-1)^n\right]
         $$
-        </pre>
+        </xmp>
 
     : "{{sawtooth}}"
     ::
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             b[n] = (-1)^{n+1} \dfrac{2}{n\pi}
         $$
-        </pre>
+        </xmp>
 
     : "{{triangle}}"
     ::
-        <pre nohighlight>
+        <xmp nohighlight>
         $$
             b[n] = \frac{8\sin\dfrac{n\pi}{2}}{(\pi n)^2}
         $$
-        </pre>
+        </xmp>
 </dl>
 
 
@@ -9900,13 +9900,13 @@ determine the number of input and output channels. It is invalid for
 both {{numberOfInputChannels}} and {{numberOfOutputChannels}}
 to be zero.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface ScriptProcessorNode : AudioNode {
     attribute EventHandler onaudioprocess;
     readonly attribute long bufferSize;
 };
-</pre>
+</xmp>
 
 <h4 id="ScriptProcessorNode-attributes">
 Attributes</h4>
@@ -9959,13 +9959,13 @@ appropriately</a>.
 The output of this node is hard-coded to stereo (2 channels) and
 cannot be configured.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface StereoPannerNode : AudioNode {
     constructor (BaseAudioContext context, optional StereoPannerOptions options = {});
     readonly attribute AudioParam pan;
 };
-</pre>
+</xmp>
 
 <h4 id="StereoPannerNode-constructors">
 Constructors</h4>
@@ -10010,11 +10010,11 @@ This specifies the options to use in constructing a
 {{StereoPannerNode}}. All members are optional; if
 not specified, the normal default is used in constructing the node.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary StereoPannerOptions : AudioNodeOptions {
     float pan = 0;
 };
-</pre>
+</xmp>
 
 <h5 id="dictionary-stereopanneroptions-members">
 Dictionary {{StereoPannerOptions}} Members</h5>
@@ -10066,13 +10066,13 @@ macros:
 The number of channels of the output always equals the number of
 channels of the input.
 
-<pre class="idl">
+<xmp class="idl">
 enum OverSampleType {
     "none",
     "2x",
     "4x"
 };
-</pre>
+</xmp>
 
 <div class="enum-description">
 <table class="simple" dfn-type=enum-value dfn-for="OverSampleType">
@@ -10094,14 +10094,14 @@ enum OverSampleType {
 </table>
 </div>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window]
 interface WaveShaperNode : AudioNode {
     constructor (BaseAudioContext context, optional WaveShaperOptions options = {});
     attribute Float32Array? curve;
     attribute OverSampleType oversample;
 };
-</pre>
+</xmp>
 
 <h4 id="WaveShaperNode-constructors">
 Constructors</h4>
@@ -10163,7 +10163,7 @@ Attributes</h4>
                 {{WaveShaperNode/curve}}.
 
             1. Let
-                <pre nohighlight>
+                <xmp nohighlight>
                 $$
                     \begin{align*}
                     v &= \frac{N-1}{2}(x + 1) \\
@@ -10171,9 +10171,9 @@ Attributes</h4>
                     f &= v - k
                     \end{align*}
                 $$
-                </pre>
+                </xmp>
             1. Then
-                <pre nohighlight>
+                <xmp nohighlight>
                 $$
                     \begin{align*}
                     y &=
@@ -10184,7 +10184,7 @@ Attributes</h4>
                         \end{cases}
                     \end{align*}
                 $$
-                </pre>
+                </xmp>
         </div>
 
         <span class="synchronous">A {{InvalidStateError}} MUST be thrown if this
@@ -10288,12 +10288,12 @@ Dictionary {{WaveShaperOptions}} Members</h5>
 <h3 interface lt="AudioWorklet" id="AudioWorklet">
 The {{AudioWorklet}} Interface</h3>
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window, SecureContext]
 interface AudioWorklet : Worklet {
   readonly attribute MessagePort port;
 };
-</pre>
+</xmp>
 
 <h4 id="AudioWorklet-attributes">Attributes</h4>
 
@@ -10362,7 +10362,7 @@ instances created from the constructor.
     to complete prior to the resolution of the promise returned by
     {{addModule()}} on a context's {{BaseAudioContext/audioWorklet}}.
 
-<pre class="example" highlight="js" title="Registering an AudioWorkletProcessor class definition">
+<xmp class="example" highlight="js" title="Registering an AudioWorkletProcessor class definition">
 // bypass-processor.js script file, runs on AudioWorkletGlobalScope
 class BypassProcessor extends AudioWorkletProcessor {
     process (inputs, outputs) {
@@ -10377,15 +10377,15 @@ class BypassProcessor extends AudioWorkletProcessor {
 };
 
 registerProcessor('bypass-processor', BypassProcessor);
-</pre>
+</xmp>
 
-<pre class="example" highlight="js" title="Importing a script and creating AudioWorkletNode">
+<xmp class="example" highlight="js" title="Importing a script and creating AudioWorkletNode">
 // The main global scope
 const context = new AudioContext();
-context.audioWorklet.addModule('bypass-processor.js').then(() =&gt; {
+context.audioWorklet.addModule('bypass-processor.js').then(() => {
     const bypassNode = new AudioWorkletNode(context, 'bypass-processor');
 });
-</pre>
+</xmp>
 
 At the instantiation of {{AudioWorkletNode}} in the main global
 scope, the counterpart {{AudioWorkletProcessor}} will also be
@@ -10443,7 +10443,7 @@ Note: An {{AudioWorkletGlobalScope}} is associated with a single
 for that context. This prevents data races from occurring in global
 scope code running within concurrent threads.
 
-<pre class="idl">
+<xmp class="idl">
 callback AudioWorkletProcessorConstructor = AudioWorkletProcessor (object options);
 
 [Global=(Worklet, AudioWorklet), Exposed=AudioWorklet]
@@ -10456,7 +10456,7 @@ interface AudioWorkletGlobalScope : WorkletGlobalScope {
     readonly attribute unsigned long renderQuantumSize;
     readonly attribute MessagePort port;
 };
-</pre>
+</xmp>
 
 <h5 id="AudioWorkletGlobalScope-attributes">
 Attributes</h5>
@@ -10722,7 +10722,7 @@ This interface has "entries", "forEach", "get", "has", "keys",
 "values", @@iterator methods and a "size" getter brought by
 <code>readonly maplike</code>.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window, SecureContext]
 interface AudioWorkletNode : AudioNode {
     constructor (BaseAudioContext context, DOMString name,
@@ -10731,7 +10731,7 @@ interface AudioWorkletNode : AudioNode {
     readonly attribute MessagePort port;
     attribute EventHandler onprocessorerror;
 };
-</pre>
+</xmp>
 
 <h5 id="AudioWorkletNode-constructors">
 Constructors</h5>
@@ -11235,7 +11235,7 @@ The {{AudioParamDescriptor}} dictionary is used to
 specify properties for an {{AudioParam}} object
 that is used in an {{AudioWorkletNode}}.
 
-<pre class="idl">
+<xmp class="idl">
 dictionary AudioParamDescriptor {
     required DOMString name;
     float defaultValue = 0;
@@ -11243,7 +11243,7 @@ dictionary AudioParamDescriptor {
     float maxValue = 3.4028235e38;
     AutomationRate automationRate = "a-rate";
 };
-</pre>
+</xmp>
 
 <h6 id="dictionary-audioparamdescriptor-members">
 Dictionary {{AudioParamDescriptor}} Members</h6>
@@ -11438,7 +11438,7 @@ communication (asynchronous) between
 {{AudioWorkletNode}} and
 {{AudioWorkletProcessor}}. This node does not use any output.
 
-<pre line-numbers class="example" highlight="js" title="VUMeterNode - Global Scope (vumeternode.js)">
+<xmp line-numbers class="example" highlight="js" title="VUMeterNode - Global Scope (vumeternode.js)">
 /* vumeter-node.js: Main global scope */
 
 export default class VUMeterNode extends AudioWorkletNode {
@@ -11478,7 +11478,7 @@ export default class VUMeterNode extends AudioWorkletNode {
         // every |this._updateIntervalInMS| milliseconds.
     }
 };
-</pre>
+</xmp>
 
 <xmp line-numbers class="example" highlight="js" title="VUMeterNode - AudioWorkletGlobalScope (vumeterprocessor.js)">
 /* vumeter-processor.js: AudioWorkletGlobalScope */
@@ -11595,7 +11595,7 @@ Underruns are defined in terms of [=underrun frames=] and [=underrun events=]:
     The duration of the [=underrun event=] is the total duration of
     the sequence of [=underrun frames=]s.
 
-<pre class="idl">
+<xmp class="idl">
 [Exposed=Window, SecureContext]
 interface AudioPlaybackStats {
     readonly attribute double underrunDuration;
@@ -11607,7 +11607,7 @@ interface AudioPlaybackStats {
     undefined resetLatency();
     [Default] object toJSON();
 };
-</pre>
+</xmp>
 
 Each {{AudioContext}} possesses exactly one {{AudioPlaybackStats}}.
 
@@ -12497,7 +12497,7 @@ the graph and deleted. The streaming source has a global reference
 and will remain connected until it is explicitly disconnected. Here's
 how it might look in JavaScript:
 
-<pre line-numbers class="example" highlight="js">
+<xmp line-numbers class="example" highlight="js">
 let context = 0;
 let compressor = 0;
 let gainNode1 = 0;
@@ -12539,7 +12539,7 @@ function playSound() {
         // Play 0.75 seconds from now (to play immediately pass in 0)
         oneShotSound.start(context.currentTime + 0.75);
 }
-</pre>
+</xmp>
 
 <h2 id="channel-up-mixing-and-down-mixing">
 Channel Up-Mixing and Down-Mixing</h2>
@@ -12671,20 +12671,20 @@ count is a superset of the input channel count of the input render quantums.
 <h3 id="UpMix-sub">
 Up Mixing Speaker Layouts</h3>
 
-<pre>
+<xmp>
 Mono up-mix:
 
-    1 -&gt; 2 : up-mix from mono to stereo
+    1 -> 2 : up-mix from mono to stereo
         output.L = input;
         output.R = input;
 
-    1 -&gt; 4 : up-mix from mono to quad
+    1 -> 4 : up-mix from mono to quad
         output.L = input;
         output.R = input;
         output.SL = 0;
         output.SR = 0;
 
-    1 -&gt; 5.1 : up-mix from mono to 5.1
+    1 -> 5.1 : up-mix from mono to 5.1
         output.L = 0;
         output.R = 0;
         output.C = input; // put in center channel
@@ -12694,13 +12694,13 @@ Mono up-mix:
 
 Stereo up-mix:
 
-    2 -&gt; 4 : up-mix from stereo to quad
+    2 -> 4 : up-mix from stereo to quad
         output.L = input.L;
         output.R = input.R;
         output.SL = 0;
         output.SR = 0;
 
-    2 -&gt; 5.1 : up-mix from stereo to 5.1
+    2 -> 5.1 : up-mix from stereo to 5.1
         output.L = input.L;
         output.R = input.R;
         output.C = 0;
@@ -12710,14 +12710,14 @@ Stereo up-mix:
 
 Quad up-mix:
 
-    4 -&gt; 5.1 : up-mix from quad to 5.1
+    4 -> 5.1 : up-mix from quad to 5.1
         output.L = input.L;
         output.R = input.R;
         output.C = 0;
         output.LFE = 0;
         output.SL = input.SL;
         output.SR = input.SR;
-</pre>
+</xmp>
 
 <h3 id="down-mix">
 Down Mixing Speaker Layouts</h3>
@@ -12725,41 +12725,41 @@ Down Mixing Speaker Layouts</h3>
 A down-mix will be necessary, for example, if processing 5.1 source
 material, but playing back stereo.
 
-<pre>
+<xmp>
 Mono down-mix:
 
-    2 -&gt; 1 : stereo to mono
+    2 -> 1 : stereo to mono
         output = 0.5 * (input.L + input.R);
 
-    4 -&gt; 1 : quad to mono
+    4 -> 1 : quad to mono
         output = 0.25 * (input.L + input.R + input.SL + input.SR);
 
-    5.1 -&gt; 1 : 5.1 to mono
+    5.1 -> 1 : 5.1 to mono
         output = sqrt(0.5) * (input.L + input.R) + input.C + 0.5 * (input.SL + input.SR)
 
 Stereo down-mix:
 
-    4 -&gt; 2 : quad to stereo
+    4 -> 2 : quad to stereo
         output.L = 0.5 * (input.L + input.SL);
         output.R = 0.5 * (input.R + input.SR);
 
-    5.1 -&gt; 2 : 5.1 to stereo
+    5.1 -> 2 : 5.1 to stereo
         output.L = L + sqrt(0.5) * (input.C + input.SL)
         output.R = R + sqrt(0.5) * (input.C + input.SR)
 
 Quad down-mix:
 
-    5.1 -&gt; 4 : 5.1 to quad
+    5.1 -> 4 : 5.1 to quad
         output.L = L + sqrt(0.5) * input.C
         output.R = R + sqrt(0.5) * input.C
         output.SL = input.SL
         output.SR = input.SR
-</pre>
+</xmp>
 
 <h3 id="ChannelRules-section">
 Channel Rules Examples</h3>
 
-<pre line-numbers class="example" highlight="js">
+<xmp line-numbers class="example" highlight="js">
     // Set gain node to explicit 2-channels (stereo).
     gain.channelCount = 2;
     gain.channelCountMode = "explicit";
@@ -12785,7 +12785,7 @@ Channel Rules Examples</h3>
     gain.channelCount = 1;
     gain.channelCountMode = "explicit";
     gain.channelInterpretation = "speakers";
-</pre>
+</xmp>
 
 <h2 id="audio-signal-values">
 Audio Signal Values</h2>
@@ -12959,75 +12959,75 @@ the appropriate rate as specified by the
         2. The <var>azimuth</var> value is first contained to be within
             the range [-90, 90] according to:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             // First, clamp azimuth to allowed range of [-180, 180].
             azimuth = max(-180, azimuth);
             azimuth = min(180, azimuth);
 
             // Then wrap to range [-90, 90].
-            if (azimuth &lt; -90)
+            if (azimuth < -90)
                 azimuth = -180 - azimuth;
-            else if (azimuth &gt; 90)
+            else if (azimuth > 90)
                 azimuth = 180 - azimuth;
-            </pre>
+            </xmp>
 
         3. A normalized value <em>x</em> is calculated from
             <var>azimuth</var> for a mono input as:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             x = (azimuth + 90) / 180;
-            </pre>
+            </xmp>
 
             Or for a stereo input as:
 
-            <pre highlight="js">
-            if (azimuth &lt;= 0) { // -90 -&gt; 0
+            <xmp highlight="js">
+            if (azimuth <= 0) { // -90 -> 0
                 // Transform the azimuth value from [-90, 0] degrees into the range [-90, 90].
                 x = (azimuth + 90) / 90;
-            } else { // 0 -&gt; 90
+            } else { // 0 -> 90
                 // Transform the azimuth value from [0, 90] degrees into the range [-90, 90].
                 x = azimuth / 90;
             }
-            </pre>
+            </xmp>
 
         4. Left and right gain values are calculated as:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             gainL = cos(x * Math.PI / 2);
             gainR = sin(x * Math.PI / 2);
-            </pre>
+            </xmp>
 
         5. For mono input, the stereo output is calculated as:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             outputL = input * gainL;
             outputR = input * gainR;
-            </pre>
+            </xmp>
 
             Else for stereo input, the output is calculated as:
 
-            <pre highlight="js">
-            if (azimuth &lt;= 0) {
+            <xmp highlight="js">
+            if (azimuth <= 0) {
                 outputL = inputL + inputR * gainL;
                 outputR = inputR * gainR;
             } else {
                 outputL = inputL * gainL;
                 outputR = inputR + inputL * gainR;
             }
-            </pre>
+            </xmp>
         6. Apply the distance gain and cone gain where the
             computation of the distance is described in
             [[#Spatialization-distance-effects|Distance
             Effects]] and the cone gain is described in
             [[#Spatialization-sound-cones|Sound Cones]]:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             let distance = distance();
             let distanceGain = distanceModel(distance);
             let totalGain = coneGain() * distanceGain();
             outputL = totalGain * outputL;
             outputR = totalGain * outputR;
-            </pre>
+            </xmp>
 
 </div>
 
@@ -13063,52 +13063,52 @@ StereoPannerNode Panning</h4>
 
         2. Clamp <var>pan</var> to [-1, 1].
 
-            <pre highlight="js">
+            <xmp highlight="js">
             pan = max(-1, pan);
             pan = min(1, pan);
-            </pre>
+            </xmp>
 
         3. Calculate <em>x</em> by normalizing <var>pan</var> value to
             [0, 1]. For mono input:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             x = (pan + 1) / 2;
-            </pre>
+            </xmp>
 
             For stereo input:
 
-            <pre highlight="js">
-            if (pan &lt;= 0)
+            <xmp highlight="js">
+            if (pan <= 0)
                 x = pan + 1;
             else
                 x = pan;
-            </pre>
+            </xmp>
 
         4. Left and right gain values are calculated as:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             gainL = cos(x * Math.PI / 2);
             gainR = sin(x * Math.PI / 2);
-            </pre>
+            </xmp>
 
         5. For mono input, the stereo output is calculated as:
 
-            <pre highlight="js">
+            <xmp highlight="js">
             outputL = input * gainL;
             outputR = input * gainR;
-            </pre>
+            </xmp>
 
             Else for stereo input, the output is calculated as:
 
-            <pre highlight="js">
-            if (pan &lt;= 0) {
+            <xmp highlight="js">
+            if (pan <= 0) {
                 outputL = inputL + inputR * gainL;
                 outputR = inputR * gainR;
             } else {
                 outputL = inputL * gainL;
                 outputR = inputR + inputL * gainR;
             }
-            </pre>
+            </xmp>
 </div>
 
 <h3 id="Spatialization-distance-effects">
@@ -13581,7 +13581,7 @@ Common Definitions for Specification Code</h2>
 This section describes common functions and classes employed by
 JavaScript code used within this specification.
 
-<pre highlight="js" line-numbers>
+<xmp highlight="js" line-numbers>
 // Three dimensional vector class.
 class Vec3 {
     // Construct from 3 coordinates.
@@ -13627,7 +13627,7 @@ class Vec3 {
         return scale(1 / m);
     }
 }
-</pre>
+</xmp>
 
 <h2 id="changes">
 Change Log</h2>


### PR DESCRIPTION
This is more comfortable to write e.g. comparisons (< instead of `&lt;`
in the code).

This fixes https://github.com/WebAudio/web-audio-api/issues/2429.

I found that while inspecting ready for editing issues.