### PR TITLE
Clarify renderQuantumSize handling and privacy considerations in AudioContext

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1638,6 +1638,20 @@ Constructors</h4>
                     Note: If resampling is required, the latency of |context| may be
                     affected, possibly by a large amount.
 
+                1. Set the {{BaseAudioContext/[[render quantum size]]}} of |context|
+                    based on the value of the <code>contextOptions.{{AudioContextOptions/renderSizeHint}}</code>:
+
+                    1. If it has the default value of <code>"default"</code>, set the
+                        {{BaseAudioContext/[[render quantum size]]}} private slot to 128.
+
+                    1. Else, if it has the value of <code>"hardware"</code>, set the
+                        {{BaseAudioContext/[[render quantum size]]}} private slot to 0.
+
+                    1. Else, if an integer has been passed, a {{NotSupportedError}} MUST be
+                        thrown if the value is outside the range specified in
+                        [[#render-quantum-sizes]], otherwise set the {{BaseAudioContext/[[render quantum size]]}}
+                        private slot to the passed value.
+
             1. If |context| is <a>allowed to start</a>, send a
                 <a>control message</a> to start processing.
 
@@ -1680,6 +1694,9 @@ Constructors</h4>
             {{AudioContext}}.
 
         1. [=Queue a media element task=] to execute the following steps:
+
+            1. If the {{BaseAudioContext/[[render quantum size]]}} of the {{AudioContext}} is 0,
+                set it to the actual hardware render quantum size chosen during resource acquisition.
 
             1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}}
                 to "{{AudioContextState/running}}".
@@ -2067,13 +2084,16 @@ Methods</h4>
             5. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
                 queue a media element task</a> to execute the following steps:
 
+                1. If the {{BaseAudioContext/[[render quantum size]]}} of the {{AudioContext}} is 0,
+                    set it to the actual hardware render quantum size chosen during resource acquisition.
+
                 1. Resolve all promises from {{AudioContext/[[pending resume promises]]}} in order.
                 1. Clear {{AudioContext/[[pending resume promises]]}}. Additionally, remove those
                     promises from {{BaseAudioContext/[[pending promises]]}}.
 
-                2. Resolve <var>promise</var>.
+                1. Resolve <var>promise</var>.
 
-                3. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is not already "{{AudioContextState/running}}":
+                1. If the {{BaseAudioContext/state}} attribute of the {{AudioContext}} is not already "{{AudioContextState/running}}":
 
                     1. Set the {{BaseAudioContext/state}} attribute of the {{AudioContext}} to "{{AudioContextState/running}}".
 
@@ -13475,6 +13495,18 @@ Per the [[security-privacy-questionnaire#questions]]:
         audio output is not downsampled on output)&mdash;for example, if
         {{MediaDevices}} capabilities were read (with user intervention) and indicated
         a higher rate was supported.
+
+    Fingerprinting via the render quantum size of the {{AudioContext}}
+    is possible when the `"hardware"` hint is used, as it exposes
+    information about the user's default audio hardware buffer
+    size. To minimize this risk,
+    {{BaseAudioContext/renderQuantumSize}} returns 0 until the
+    {{AudioContext}} transitions to the `"running"` state.  Once the
+    {{AudioContext}} has transitioned to the `"running"` state the
+    actual render quantum size is returned. A running AudioContext can
+    be used to infer the user's audio hardware buffer size via
+    {{AudioWorklet}} timing, so this does not expose any new
+    information.
 
     Fingerprinting via the number of output channels for the
     {{AudioContext}} is possible as well.  We recommend that


### PR DESCRIPTION
Fixes #2663 and fixes #2659

Clarify setting the renderQuantumSize private slot in the AudioContext constructor, and during transitioning to running.  We initially set it to 0 during construction when `hardware` is used, and populate it during the transition.  A paragraph was also added to the privacy considerations section noting this mitigation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2026, 11:06 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmjwilson-google%2Fweb-audio-api%2F10a4c21b6b4b4af1ef51c501ae6aad43ac1c2b64%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "4187:25",
        "messageType": "warning",
        "text": "At least one <img> doesn't have its size set (<img bs-line-number=\"4187:25\" alt=\"Graphical representation of calling cancelAndHoldAtTime when linearRampToValueAtTime has been called at this time.\" src=\"images/cancel-linear.svg\" style=\"height:75%;width:75%\">), but given the type of input document, Bikeshed can't figure out what the size should be.\nEither set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute."
    },
    {
        "lineNum": "2573:9",
        "messageType": "fatal",
        "text": "Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block."
    },
    {
        "lineNum": "3686:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3686:9",
        "messageType": "fatal",
        "text": "Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3787:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3800:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3815:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3815:9",
        "messageType": "fatal",
        "text": "Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "261:36",
        "messageType": "link",
        "text": "Multiple possible 'audio' element refs.\nArbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:html; type:element; text:audio\nspec:epub-34; type:element; text:audio\n<{audio}>"
    },
    {
        "lineNum": "309:39",
        "messageType": "link",
        "text": "Multiple possible 'audio' element refs.\nArbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:html; type:element; text:audio\nspec:epub-34; type:element; text:audio\n<{audio}>"
    },
    {
        "lineNum": "633:5",
        "messageType": "link",
        "text": "Multiple possible 'audio' element refs.\nArbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:html; type:element; text:audio\nspec:epub-34; type:element; text:audio\n<{audio}>"
    },
    {
        "lineNum": "1213:9",
        "messageType": "link",
        "text": "Multiple possible 'audio' element refs.\nArbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:html; type:element; text:audio\nspec:epub-34; type:element; text:audio\n<{audio}>"
    },
    {
        "lineNum": "2908:15",
        "messageType": "link",
        "text": "Multiple possible 'audio' element refs.\nArbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:html; type:element; text:audio\nspec:epub-34; type:element; text:audio\n<{audio}>"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 4807:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 4807:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 5221:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 5221:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 5879:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 5879:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 5899:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 5899:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 6361:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 6361:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 6938:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 6938:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 7054:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 7054:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 7171:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 7171:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 7266:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 7266:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 7541:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 7541:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 7719:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 7719:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 8180:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 8180:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 8292:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 8292:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "8438:51",
        "messageType": "link",
        "text": "Multiple possible 'audio' element refs.\nArbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio\nTo auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:\nspec:html; type:element; text:audio\nspec:epub-34; type:element; text:audio\n<{audio}>"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 8574:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 8574:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 8864:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 8864:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 9123:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 9123:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 9899:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 9899:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 9968:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 9968:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 10081:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 10081:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "23:9 of file 'audionode.include' (included by a block on 10722:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-MODE]'.\n{{ChannelCountMode/[CC-MODE]}}"
    },
    {
        "lineNum": "27:9 of file 'audionode.include' (included by a block on 10722:1)",
        "messageType": "link",
        "text": "No 'idl' refs found for '[CC-INTERP]'.\n{{ChannelInterpretation/[CC-INTERP]}}"
    },
    {
        "lineNum": "13391:1",
        "messageType": "warning",
        "text": "W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20WebAudio/web-audio-api%232673.)._

</details>
