### PR TITLE
OfflineAudioContext Incremental Rendering

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -2,6 +2,6 @@
     "src_file": "index.bs",
     "type": "bikeshed",
     "params": {
-        "force": 1
+        "die-on": "nothing"
     }
 }

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -2,6 +2,6 @@
     "src_file": "index.bs",
     "type": "bikeshed",
     "params": {
-        "die-on": "nothing"
+        "force": 1
     }
 }

--- a/index.bs
+++ b/index.bs
@@ -2668,9 +2668,12 @@ Methods</h4>
             occasion.
 
             <ol>
+                <li>Let <var>nFrames</var> be a number initialized to the value
+                of the length of {{[[rendered buffer]]}}.
+                
                 <li>Given the current connections and scheduled changes, start
-                rendering {{[[rendered buffer/length]]}} sample-frames of audio into
-                {{[[rendered buffer]]}}
+                rendering <var>nFrames</var> sample-frames of audio into
+                {{[[rendered buffer]]}}.
 
                 <li>For every <a>render quantum</a>, check and
                 {{OfflineAudioContext/suspend()|suspend}}

--- a/index.bs
+++ b/index.bs
@@ -2608,10 +2608,11 @@ Attributes</h4>
 <dl dfn-type=attribute dfn-for="OfflineAudioContext">
     : <dfn>length</dfn>
     ::
-        The total size of the audio render in sample-frames. This is the same as the
-        value of the <code>length</code> parameter for the constructor.
+        The total size of the audio render in sample-frames. This is the same
+        as the value of the <code>length</code> parameter for the constructor.
 
-        For undefined-length rendering, this attribute SHOULD be set to <code>null</code>.
+        For undefined-length rendering, this attribute SHOULD be set to
+        <code>null</code>.
 
     : <dfn>oncomplete</dfn>
     ::
@@ -2648,16 +2649,28 @@ Methods</h4>
 
                 <li>Let <var>promise</var> be a new promise.
 
-                <lI>Let <var>bufferLength</var> be a number initialized to the value of {{OfflineAudioContext/length}}.
+                <lI>Let <var>bufferLength</var> be a number initialized to the
+                value of {{OfflineAudioContext/length}}.
 
                 <ol>
-                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} is provided:
+                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    is provided:
                     <ol>
-                        <li> Let <var>renderedFrames</var> be the number of sample-frames already rendered by the {{OfflineAudioContext}}.
-                        <li> If <var>renderedFrames</var> + {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} is less than or equal to {{OfflineAudioContext/length}}, set <var>bufferLength</var> to {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
-                        <li> Otherwise, set <var>bufferLength</var> to {{OfflineAudioContext/length}} - <var>renderedFrames</var>.
+                        <li> Let <var>renderedFrames</var> be the number of
+                        sample-frames already rendered by the
+                        {{OfflineAudioContext}}.
+                        <li> If <var>renderedFrames</var> +
+                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        is less than or equal to {{OfflineAudioContext/length}},
+                        set <var>bufferLength</var> to
+                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                        <li> Otherwise, set <var>bufferLength</var> to
+                        {{OfflineAudioContext/length}} -
+                        <var>renderedFrames</var>.
                     </ol>
-                    <li> Otherwise, if {{OfflineAudioContext/length}} is <code>null</code>, set <var>bufferLength</var> to the <a>render quantum size</a>.
+                    <li> Otherwise, if {{OfflineAudioContext/length}} is
+                    <code>null</code>, set <var>bufferLength</var> to the
+                    <a>render quantum size</a>.
                 </ol>
 
                 <li>Create a new {{AudioBuffer}}, with a number of
@@ -2688,8 +2701,8 @@ Methods</h4>
             occasion.
 
             <ol>
-                <li>Let <var>numberOfFrames</var> be a number initialized to the value
-                of the length of {{[[rendered buffer]]}}.
+                <li>Let <var>numberOfFrames</var> be a number initialized to
+                the value of the length of {{[[rendered buffer]]}}.
                 
                 <li>Given the current connections and scheduled changes, start
                 rendering <var>numberOfFrames</var> sample-frames of audio into
@@ -2710,11 +2723,12 @@ Methods</h4>
                         <li>Resolve the <var ignore>promise</var> created by {{startRendering()}}
                         with {{[[rendered buffer]]}}.
 
-                        <li>If {{OfflineAudioContext/length}} is not <code>null</code>, 
-                        [=Queue a media element task=] to [=fire an event=] named
-                        {{OfflineAudioContext/complete}} at the {{OfflineAudioContext}} using
-                        {{OfflineAudioCompletionEvent}} whose `renderedBuffer` property is set to
-                        {{[[rendered buffer]]}}.
+                        <li>If {{OfflineAudioContext/length}} is not
+                        <code>null</code>, [=Queue a media element task=] to
+                        [=fire an event=] named {{OfflineAudioContext/complete}}
+                        at the {{OfflineAudioContext}} using
+                        {{OfflineAudioCompletionEvent}} whose `renderedBuffer`
+                        property is set to {{[[rendered buffer]]}}.
 
                     </ol>
 
@@ -2822,35 +2836,37 @@ Methods</h4>
     : <dfn>close()</dfn>
     ::
         Closes the {{OfflineAudioContext}}. This will not automatically release
-        all {{AudioContext}}-created objects, but will suspend the
-        progression of the {{AudioContext}}'s
-        {{BaseAudioContext/currentTime}}, and stop
+        all {{AudioContext}}-created objects, but will suspend the progression
+        of the {{AudioContext}}'s {{BaseAudioContext/currentTime}}, and stop
         processing audio data.
 
         <div algorithm="OfflineAudioContext.close()">
             <span class="synchronous">When close is called, execute these steps:</span>
 
-            1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
+            1. If [=this=]'s [=relevant global object=]'s
+                [=associated Document=] is not [=fully active=] then return
+                [=a promise rejected with=] "{{InvalidStateError}}"
+                {{DOMException}}.
 
             1. Let <var>promise</var> be a new Promise.
 
             1. If the {{[[control thread state]]}} flag on the
-                {{OfflineAudioContext}} is <code>closed</code> reject the promise
-                with {{InvalidStateError}}, abort these steps,
+                {{OfflineAudioContext}} is <code>closed</code> reject the
+                promise with {{InvalidStateError}}, abort these steps,
                 returning <var>promise</var>.
 
-            1. Set the {{[[control thread state]]}} flag on the {{OfflineAudioContext}} to
-                <code>closed</code>.
+            1. Set the {{[[control thread state]]}} flag on the
+                {{OfflineAudioContext}} to <code>closed</code>.
 
-            1. <a>Queue a control message</a> to close the {{OfflineAudioContext}}.
+            1. <a>Queue a control message</a> to close the
+                {{OfflineAudioContext}}.
 
             1. Return <em>promise</em>.
         </div>
 
         <div algorithm="run a control message to close an OfflineAudioContext">
-            Running a <a>control message</a> to close an
-            {{OfflineAudioContext}} means running these steps on the
-            <a>rendering thread</a>:
+            Running a <a>control message</a> to close an {{OfflineAudioContext}}
+            means running these steps on the <a>rendering thread</a>:
 
             1. Set the {{[[rendering thread state]]}} to <code>suspended</code>.
                 <div class="note">
@@ -2867,12 +2883,18 @@ Methods</h4>
                 queue a media element task</a> to execute the following steps:
 
                 1. Resolve <em>promise</em>.
-                1. If the {{BaseAudioContext/state}} attribute of the {{OfflineAudioContext}} is not already "{{AudioContextState/closed}}":
-                    1. Set the {{BaseAudioContext/state}} attribute of the {{OfflineAudioContext}} to "{{AudioContextState/closed}}".
+                1. If the {{BaseAudioContext/state}} attribute of the
+                    {{OfflineAudioContext}} is not already
+                    "{{AudioContextState/closed}}":
+                        1. Set the {{BaseAudioContext/state}} attribute of the
+                            {{OfflineAudioContext}} to 
+                            "{{AudioContextState/closed}}".
 
                     1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
-                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire
-                        an event</a> named {{BaseAudioContext/statechange}} at the {{OfflineAudioContext}}.
+                        queue a media element task</a> to
+                        <a spec="dom" lt="fire an event">fire an event</a> named
+                        {{BaseAudioContext/statechange}} at the
+                        {{OfflineAudioContext}}.
         </div>
 
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -2500,7 +2500,7 @@ returned promise with the rendered result as an
 interface OfflineAudioContext : BaseAudioContext {
     constructor(OfflineAudioContextOptions contextOptions);
     constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
-    Promise<AudioBuffer> startRendering(unsigned long chunkSize);
+    Promise<AudioBuffer> startRendering(optional unsigned long chunkSize);
     Promise<undefined> resume();
     Promise<undefined> suspend(double suspendTime);
     Promise<undefined> close();
@@ -2611,7 +2611,7 @@ Attributes</h4>
         The total size of the audio render in sample-frames. This is the same as the
         value of the <code>length</code> parameter for the constructor.
 
-        For undefined-length rendering, this attribute SHOULD be set to positive infinity.
+        For undefined-length rendering, this attribute SHOULD be set to <code>null</code>.
 
     : <dfn>oncomplete</dfn>
     ::
@@ -2654,10 +2654,10 @@ Methods</h4>
                     <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} is provided:
                     <ol>
                         <li> Let <var>renderedFrames</var> be the number of sample-frames already rendered by the {{OfflineAudioContext}}.
-                        <li> If <var>renderedFrames</var> + {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} <= {{OfflineAudioContext/length}}, set <var>bufferLength</var> to {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                        <li> If <var>renderedFrames</var> + {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} is less than or equal to {{OfflineAudioContext/length}}, set <var>bufferLength</var> to {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
                         <li> Otherwise, set <var>bufferLength</var> to {{OfflineAudioContext/length}} - <var>renderedFrames</var>.
                     </ol>
-                    <li> Otherwise, if {{OfflineAudioContext/length}} is positive infinity, set <var>bufferLength</var> to the <a>render quantum size</a>.
+                    <li> Otherwise, if {{OfflineAudioContext/length}} is <code>null</code>, set <var>bufferLength</var> to the <a>render quantum size</a>.
                 </ol>
 
                 <li>Create a new {{AudioBuffer}}, with a number of
@@ -2688,11 +2688,11 @@ Methods</h4>
             occasion.
 
             <ol>
-                <li>Let <var>nFrames</var> be a number initialized to the value
+                <li>Let <var>numberOfFrames</var> be a number initialized to the value
                 of the length of {{[[rendered buffer]]}}.
                 
                 <li>Given the current connections and scheduled changes, start
-                rendering <var>nFrames</var> sample-frames of audio into
+                rendering <var>numberOfFrames</var> sample-frames of audio into
                 {{[[rendered buffer]]}}.
 
                 <li>For every <a>render quantum</a>, check and
@@ -2710,7 +2710,7 @@ Methods</h4>
                         <li>Resolve the <var ignore>promise</var> created by {{startRendering()}}
                         with {{[[rendered buffer]]}}.
 
-                        <li>If {{OfflineAudioContext/length}} is not positive infinity, 
+                        <li>If {{OfflineAudioContext/length}} is not <code>null</code>, 
                         [=Queue a media element task=] to [=fire an event=] named
                         {{OfflineAudioContext/complete}} at the {{OfflineAudioContext}} using
                         {{OfflineAudioCompletionEvent}} whose `renderedBuffer` property is set to
@@ -2722,7 +2722,7 @@ Methods</h4>
         </div>
 
         <pre class=argumentdef for="OfflineAudioContext/startRendering()">
-            chunkSize: The size of the desired {{AudioBuffer}}.
+            chunkSize: The number of sample-frames to render during this call.
         </pre>
         <div>
             <em>Return type:</em> {{Promise}}&lt;{{AudioBuffer}}&gt;
@@ -2821,7 +2821,7 @@ Methods</h4>
     
     : <dfn>close()</dfn>
     ::
-        Closes the {{AudioContext}}. This will not automatically release
+        Closes the {{OfflineAudioContext}}. This will not automatically release
         all {{AudioContext}}-created objects, but will suspend the
         progression of the {{AudioContext}}'s
         {{BaseAudioContext/currentTime}}, and stop

--- a/index.bs
+++ b/index.bs
@@ -2480,9 +2480,10 @@ returned promise with the rendered result as an
 interface OfflineAudioContext : BaseAudioContext {
     constructor(OfflineAudioContextOptions contextOptions);
     constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
-    Promise<AudioBuffer> startRendering();
+    Promise<AudioBuffer> startRendering(unsigned long chunkSize);
     Promise<undefined> resume();
     Promise<undefined> suspend(double suspendTime);
+    Promise<undefined> close();
     readonly attribute unsigned long length;
     attribute EventHandler oncomplete;
 };
@@ -2576,7 +2577,7 @@ Constructors</h4>
 
         <pre class=argumentdef for="OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)">
         numberOfChannels: Determines how many channels the buffer will have. See {{BaseAudioContext/createBuffer()}} for the supported number of channels.
-        length: Determines the size of the buffer in sample-frames.
+        length: Determines the total size of the audio render in sample-frames.
         sampleRate: Describes the sample-rate of the [=linear PCM=] audio data in the buffer in sample-frames per second. See [[#sample-rates]] for the required supported range.
         </pre>
 </dl>
@@ -2587,8 +2588,10 @@ Attributes</h4>
 <dl dfn-type=attribute dfn-for="OfflineAudioContext">
     : <dfn>length</dfn>
     ::
-        The size of the buffer in sample-frames. This is the same as the
+        The total size of the audio render in sample-frames. This is the same as the
         value of the <code>length</code> parameter for the constructor.
+
+        For undefined-length rendering, this attribute SHOULD be set to positive infinity.
 
     : <dfn>oncomplete</dfn>
     ::
@@ -2601,7 +2604,7 @@ Attributes</h4>
 Methods</h4>
 
 <dl dfn-type=method dfn-for="OfflineAudioContext">
-    : <dfn>startRendering()</dfn>
+    : <dfn>startRendering(chunkSize)</dfn>
     ::
         Given the current connections and scheduled changes, starts
         rendering audio.
@@ -2620,21 +2623,29 @@ Methods</h4>
             <ol>
                 <li>If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
 
-                <li>If the {{[[rendering started]]}} slot on the
-                {{OfflineAudioContext}} is <em>true</em>, return a rejected
-                promise with {{InvalidStateError}}, and abort these
-                steps.
-
                 <li>Set the {{[[rendering started]]}} slot of the
                 {{OfflineAudioContext}} to <em>true</em>.
 
                 <li>Let <var>promise</var> be a new promise.
 
+                <lI>Let <var>bufferLength</var> be a number initialized to the value of {{OfflineAudioContext/length}}.
+
+                <ol>
+                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} is provided:
+                    <ol>
+                        <li> Let <var>renderedFrames</var> be the number of sample-frames already rendered by the {{OfflineAudioContext}}.
+                        <li> If <var>renderedFrames</var> + {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}} <= {{OfflineAudioContext/length}}, set <var>bufferLength</var> to {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                        <li> Otherwise, set <var>bufferLength</var> to {{OfflineAudioContext/length}} - <var>renderedFrames</var>.
+                    </ol>
+                    <li> Otherwise, if {{OfflineAudioContext/length}} is positive infinity, set <var>bufferLength</var> to the <a>render quantum size</a>.
+                </ol>
+
                 <li>Create a new {{AudioBuffer}}, with a number of
-                channels, length and sample rate equal respectively to the
-                <code>numberOfChannels</code>, <code>length</code> and
+                channels and sample rate equal respectively to the
+                <code>numberOfChannels</code> and
                 <code>sampleRate</code> values passed to this instance's
-                constructor in the <code>contextOptions</code> parameter.
+                constructor in the <code>contextOptions</code> parameter;
+                and length equal to <var>bufferLength</var>.
                 Assign this buffer to an internal slot
                 <dfn attribute for="OfflineAudioContext">[[rendered buffer]]</dfn> in the {{OfflineAudioContext}}.
 
@@ -2658,7 +2669,7 @@ Methods</h4>
 
             <ol>
                 <li>Given the current connections and scheduled changes, start
-                rendering <code>length</code> sample-frames of audio into
+                rendering {{[[rendered buffer/length]]}} sample-frames of audio into
                 {{[[rendered buffer]]}}
 
                 <li>For every <a>render quantum</a>, check and
@@ -2676,7 +2687,8 @@ Methods</h4>
                         <li>Resolve the <var ignore>promise</var> created by {{startRendering()}}
                         with {{[[rendered buffer]]}}.
 
-                        <li>[=Queue a media element task=] to [=fire an event=] named
+                        <li>If {{OfflineAudioContext/length}} is not positive infinity, 
+                        [=Queue a media element task=] to [=fire an event=] named
                         {{OfflineAudioContext/complete}} at the {{OfflineAudioContext}} using
                         {{OfflineAudioCompletionEvent}} whose `renderedBuffer` property is set to
                         {{[[rendered buffer]]}}.
@@ -2686,9 +2698,9 @@ Methods</h4>
             </ol>
         </div>
 
-        <div>
-            <em>No parameters.</em>
-        </div>
+        <pre class=argumentdef for="OfflineAudioContext/startRendering()">
+            chunkSize: The size of the desired {{AudioBuffer}}.
+        </pre>
         <div>
             <em>Return type:</em> {{Promise}}&lt;{{AudioBuffer}}&gt;
         </div>
@@ -2783,6 +2795,63 @@ Methods</h4>
         <div>
             <em>Return type:</em> {{Promise}}&lt;{{undefined}}&gt;
         </div>
+    
+    : <dfn>close()</dfn>
+    ::
+        Closes the {{AudioContext}}. This will not automatically release
+        all {{AudioContext}}-created objects, but will suspend the
+        progression of the {{AudioContext}}'s
+        {{BaseAudioContext/currentTime}}, and stop
+        processing audio data.
+
+        <div algorithm="OfflineAudioContext.close()">
+            <span class="synchronous">When close is called, execute these steps:</span>
+
+            1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
+
+            1. Let <var>promise</var> be a new Promise.
+
+            1. If the {{[[control thread state]]}} flag on the
+                {{OfflineAudioContext}} is <code>closed</code> reject the promise
+                with {{InvalidStateError}}, abort these steps,
+                returning <var>promise</var>.
+
+            1. Set the {{[[control thread state]]}} flag on the {{OfflineAudioContext}} to
+                <code>closed</code>.
+
+            1. <a>Queue a control message</a> to close the {{OfflineAudioContext}}.
+
+            1. Return <em>promise</em>.
+        </div>
+
+        <div algorithm="run a control message to close an OfflineAudioContext">
+            Running a <a>control message</a> to close an
+            {{OfflineAudioContext}} means running these steps on the
+            <a>rendering thread</a>:
+
+            1. Set the {{[[rendering thread state]]}} to <code>suspended</code>.
+                <div class="note">
+                    This will stop rendering.
+                </div>
+
+            1. If this <a>control message</a> is being run in a reaction to the
+                document being unloaded, abort this algorithm.
+                <div class="note">
+                    There is no need to notify the control thread in this case.
+                </div>
+
+            1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                queue a media element task</a> to execute the following steps:
+
+                1. Resolve <em>promise</em>.
+                1. If the {{BaseAudioContext/state}} attribute of the {{OfflineAudioContext}} is not already "{{AudioContextState/closed}}":
+                    1. Set the {{BaseAudioContext/state}} attribute of the {{OfflineAudioContext}} to "{{AudioContextState/closed}}".
+
+                    1. <a href="https://html.spec.whatwg.org/multipage/media.html#queue-a-media-element-task">
+                        queue a media element task</a> to <a spec="dom" lt="fire an event">fire
+                        an event</a> named {{BaseAudioContext/statechange}} at the {{OfflineAudioContext}}.
+        </div>
+
 </dl>
 
 <h4 dictionary id="OfflineAudioContextOptions">

--- a/index.bs
+++ b/index.bs
@@ -2673,87 +2673,34 @@ Methods</h4>
                 steps.
 
                 <li> If {{[[committed frames]]}} is greater than or equal to
-                {{OfflineAudioContext/length}}, reject <var>promise</var> with
+                {{OfflineAudioContext}}'s {{OfflineAudioContext/length}}, reject <var>promise</var> with
                 {{InvalidStateError}} and abort these steps.
 
                 <lI>Let <var>bufferLength</var> be a number initialized to the
                 value of the {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
 
                 <ol>
-                    <li> If the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is not <code>null</code>:
-                        <ol>
-                            <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                            is <code>null</code> or if {{[[committed frames]]}} +
-                                {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                                is greater than the {{OfflineAudioContext}}'s
-                                {{OfflineAudioContext/length}}, set <var>bufferLength</var> to
-                            {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
-                        </ol>
-                    <li> Otherwise, if the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is <code>null</code>:
-                        <ol> 
-                            <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                            is <code>null</code>, set <var>bufferLength</var> to
-                            <a>render quantum size</a>.
-                        </ol>
-                </ol>
-
-                <ol>
-                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                    is not <code>null</code>:
-                    <ol>
-                        <li> If the {{OfflineAudioContext}}'s
-                        {{OfflineAudioContext/length}} is not <code>null</code>:
-                        <ol>
-                            <li>If {{[[committed frames]]}} +
-                            {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                            is less than or equal to the {{OfflineAudioContext}}'s
-                            {{OfflineAudioContext/length}}, set <var>bufferLength</var> to
-                            {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
-                            <li> Otherwise, set <var>bufferLength</var> to
-                            {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
-                        </ol>
-                        <li>Otherwise, set <var>bufferLength</var> to
-                            {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
+                    <li> If the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is <code>null</code>:
+                    <ol> 
+                        <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        is <code>null</code>, set <var>bufferLength</var> to
+                        <a>render quantum size</a>.
                     </ol>
-                    <li> Otherwise, if the {{OfflineAudioContext}}'s
-                    {{OfflineAudioContext/length}} is <code>null</code>, set
-                     <var>bufferLength</var> to <a>render quantum size</a>.
-                </ol>
-
+                    <li> Otherwise, if the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is not <code>null</code>:
                     <ol>
-                        <li> If {{[[committed frames]]}} +
+                        <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        is not <code>null</code> and {{[[committed frames]]}} +
                         {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                        is less than or equal to the {{OfflineAudioContext}}'s
-                        {{OfflineAudioContext/length}}, set 
-                        <var>bufferLength</var> to
+                        is less than the {{OfflineAudioContext}}'s
+                        {{OfflineAudioContext/length}}, set <var>bufferLength</var> to
                         {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
                         <li> Otherwise, set <var>bufferLength</var> to
-                        {{OfflineAudioContext/length}} -
-                        {{[[committed frames]]}}.
+                        {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
                     </ol>
-                    <li> Otherwise, if the {{OfflineAudioContext}}'s
-                    {{OfflineAudioContext/length}} is <code>null</code>, set
-                     <var>bufferLength</var> to <a>render quantum size</a>.
                 </ol>
 
-                <ol>
-                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                    is provided:
-                    <ol>
-                        <li> If {{[[committed frames]]}} +
-                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                        is less than or equal to the {{OfflineAudioContext}}'s
-                        {{OfflineAudioContext/length}}, set 
-                        <var>bufferLength</var> to
-                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
-                        <li> Otherwise, set <var>bufferLength</var> to
-                        {{OfflineAudioContext/length}} -
-                        {{[[committed frames]]}}.
-                    </ol>
-                    <li> Otherwise, if the {{OfflineAudioContext}}'s
-                    {{OfflineAudioContext/length}} is <code>null</code>, set
-                     <var>bufferLength</var> to <a>render quantum size</a>.
-                </ol>
+                <lI>Let <var>bufferLength</var> be a number initialized to the
+                result of <a lt="calculate the buffer length for offline rendering">calculating the buffer length for offline rendering</a> given the requested <var>chunkSize</var>.
 
                 <li> If <var>bufferLength</var> is not a multiple of
                 <a>render quantum size</a>, round it up to the next multiple of
@@ -2782,6 +2729,30 @@ Methods</h4>
                 <li>Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
                 <li>Return <var>promise</var>.
+            </ol>
+        </div>
+
+        <div algorithm="calculate buffer length for offline rendering">
+            To <dfn dfn for>calculate the buffer length for offline rendering</dfn> given a requested <var>chunkSize</var>, the following steps MUST be performed on the <a>control thread</a>:
+            <ol>
+                <li> If the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is <code>null</code>:
+                <ol> 
+                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    is <code>null</code>, return <a>render quantum size</a>.
+                    <li> Otherwise, return
+                    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                </ol>
+                <li> Otherwise, if the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is not <code>null</code>:
+                <ol>
+                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    is not <code>null</code> and {{[[committed frames]]}} +
+                    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    is less than the {{OfflineAudioContext}}'s
+                    {{OfflineAudioContext/length}}, return
+                    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                    <li> Otherwise, return
+                    {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
+                </ol>
             </ol>
         </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2500,14 +2500,37 @@ returned promise with the rendered result as an
 interface OfflineAudioContext : BaseAudioContext {
     constructor(OfflineAudioContextOptions contextOptions);
     constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
-    Promise<AudioBuffer> startRendering(optional unsigned long chunkSize);
+    Promise<AudioBuffer> startRendering(optional unsigned long chunkSize? = null);
     Promise<undefined> resume();
     Promise<undefined> suspend(double suspendTime);
     Promise<undefined> close();
-    readonly attribute unsigned long length;
+    readonly attribute unsigned long? length;
     attribute EventHandler oncomplete;
 };
 </xmp>
+
+{{OfflineAudioContext}} has the following internal slots:
+<dl dfn-type=attribute dfn-for="OfflineAudioContext">
+    : <dfn>[[rendering started]]</dfn>
+    ::
+        A boolean flag representing whether the rendering has started. The
+        initial value is <code>false</code>.
+
+    : <dfn>[[rendered buffers]]</dfn>
+    ::
+        An ordered list of {{AudioBuffers}} that are being rendered. The initial
+        value is an empty list.
+
+    : <dfn>[[committed frames]]</dfn>
+    ::
+        Tracks the number of frames that the {{OfflineAudioContext}} has
+        committed to render. The initial value is <code>0</code>.
+
+    : <dfn>[[rendered frames]]</dfn>
+    ::
+        Tracks the number of frames that have been rendered. The initial value
+        is <code>0</code>.
+</dl>
 
 <h4 id="OfflineAudioContext-constructors">
 Constructors</h4>
@@ -2634,9 +2657,7 @@ Methods</h4>
         is via its promise return value, the instance will also fire an
         event named <code>complete</code> for legacy reasons.
 
-        <div algorithm="OfflineAudioContext.startRendering()">
-            Let <dfn attribute for="OfflineAudioContext">[[rendering started]]</dfn> be an internal slot of this {{OfflineAudioContext}}.  Initialize this slot to <em>false</em>.
-
+        <div algorithm="OfflineAudioContext.startRendering(chunkSize)">
             <span class="synchronous">When <code>startRendering</code> is
             called, the following steps MUST be performed on the <a>control
             thread</a>:</span>
@@ -2644,50 +2665,119 @@ Methods</h4>
             <ol>
                 <li>If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=fully active=] then return [=a promise rejected with=] "{{InvalidStateError}}" {{DOMException}}.
 
-                <li>Set the {{[[rendering started]]}} slot of the
-                {{OfflineAudioContext}} to <em>true</em>.
-
                 <li>Let <var>promise</var> be a new promise.
 
+                <li> If the {{[[control thread state]]}} on the
+                {{OfflineAudioContext}} is {{AudioContextState/closed}}, reject
+                <var>promise</var> with {{InvalidStateError}} and abort these
+                steps.
+
+                <li> If {{[[committed frames]]}} is greater than or equal to
+                {{OfflineAudioContext/length}}, reject <var>promise</var> with
+                {{InvalidStateError}} and abort these steps.
+
                 <lI>Let <var>bufferLength</var> be a number initialized to the
-                value of {{OfflineAudioContext/length}}.
+                value of the {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+
+                <ol>
+                    <li> If the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is not <code>null</code>:
+                        <ol>
+                            <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                            is <code>null</code> or if {{[[committed frames]]}} +
+                                {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                                is greater than the {{OfflineAudioContext}}'s
+                                {{OfflineAudioContext/length}}, set <var>bufferLength</var> to
+                            {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
+                        </ol>
+                    <li> Otherwise, if the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is <code>null</code>:
+                        <ol> 
+                            <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                            is <code>null</code>, set <var>bufferLength</var> to
+                            <a>render quantum size</a>.
+                        </ol>
+                </ol>
+
+                <ol>
+                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    is not <code>null</code>:
+                    <ol>
+                        <li> If the {{OfflineAudioContext}}'s
+                        {{OfflineAudioContext/length}} is not <code>null</code>:
+                        <ol>
+                            <li>If {{[[committed frames]]}} +
+                            {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                            is less than or equal to the {{OfflineAudioContext}}'s
+                            {{OfflineAudioContext/length}}, set <var>bufferLength</var> to
+                            {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                            <li> Otherwise, set <var>bufferLength</var> to
+                            {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
+                        </ol>
+                        <li>Otherwise, set <var>bufferLength</var> to
+                            {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
+                    </ol>
+                    <li> Otherwise, if the {{OfflineAudioContext}}'s
+                    {{OfflineAudioContext/length}} is <code>null</code>, set
+                     <var>bufferLength</var> to <a>render quantum size</a>.
+                </ol>
+
+                    <ol>
+                        <li> If {{[[committed frames]]}} +
+                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        is less than or equal to the {{OfflineAudioContext}}'s
+                        {{OfflineAudioContext/length}}, set 
+                        <var>bufferLength</var> to
+                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                        <li> Otherwise, set <var>bufferLength</var> to
+                        {{OfflineAudioContext/length}} -
+                        {{[[committed frames]]}}.
+                    </ol>
+                    <li> Otherwise, if the {{OfflineAudioContext}}'s
+                    {{OfflineAudioContext/length}} is <code>null</code>, set
+                     <var>bufferLength</var> to <a>render quantum size</a>.
+                </ol>
 
                 <ol>
                     <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                     is provided:
                     <ol>
-                        <li> Let <var>renderedFrames</var> be the number of
-                        sample-frames already rendered by the
-                        {{OfflineAudioContext}}.
-                        <li> If <var>renderedFrames</var> +
+                        <li> If {{[[committed frames]]}} +
                         {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                        is less than or equal to {{OfflineAudioContext/length}},
-                        set <var>bufferLength</var> to
+                        is less than or equal to the {{OfflineAudioContext}}'s
+                        {{OfflineAudioContext/length}}, set 
+                        <var>bufferLength</var> to
                         {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
                         <li> Otherwise, set <var>bufferLength</var> to
                         {{OfflineAudioContext/length}} -
-                        <var>renderedFrames</var>.
+                        {{[[committed frames]]}}.
                     </ol>
-                    <li> Otherwise, if {{OfflineAudioContext/length}} is
-                    <code>null</code>, set <var>bufferLength</var> to the
-                    <a>render quantum size</a>.
+                    <li> Otherwise, if the {{OfflineAudioContext}}'s
+                    {{OfflineAudioContext/length}} is <code>null</code>, set
+                     <var>bufferLength</var> to <a>render quantum size</a>.
                 </ol>
 
-                <li>Create a new {{AudioBuffer}}, with a number of
+                <li> If <var>bufferLength</var> is not a multiple of
+                <a>render quantum size</a>, round it up to the next multiple of
+                the <a>render quantum size</a>.
+
+                <li>Create a new {{AudioBuffer}} <var>buffer</var>, with a number of
                 channels and sample rate equal respectively to the
                 <code>numberOfChannels</code> and
                 <code>sampleRate</code> values passed to this instance's
                 constructor in the <code>contextOptions</code> parameter;
                 and length equal to <var>bufferLength</var>.
-                Assign this buffer to an internal slot
-                <dfn attribute for="OfflineAudioContext">[[rendered buffer]]</dfn> in the {{OfflineAudioContext}}.
 
                 <li>If an exception was thrown during the preceding
-                {{AudioBuffer}} constructor call, reject
-                <var>promise</var> with this exception.
+                {{AudioBuffer}} constructor call, reject <var>promise</var> with
+                this exception and return <var>promise</var>.
 
-                <li>Otherwise, in the case that the buffer was successfully
-                constructed, <a>begin offline rendering</a>.
+                <li>Set {{[[rendering started]]}} to <em>true</em>.
+
+                <li>Set {{[[committed frames]]}} to the sum of
+                {{[[committed frames]]}} and the <var>buffer</var>'s
+                {{AudioBuffer/length}}.
+
+                <li>Append <var>buffer</var> to {{[[rendered buffers]]}} and
+                <a>begin offline rendering</a> for <var>buffer</var>.
 
                 <li>Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
@@ -2696,17 +2786,15 @@ Methods</h4>
         </div>
 
         <div algorithm="begin offline rendering">
-            To <dfn dfn for>begin offline rendering</dfn>, the following steps MUST
+            To <dfn dfn for>begin offline rendering</dfn> for an {{AudioBuffer}} <var>buffer</var>, the following steps MUST
             happen on a <a>rendering thread</a> that is created for the
             occasion.
 
             <ol>
-                <li>Let <var>numberOfFrames</var> be a number initialized to
-                the value of the length of {{[[rendered buffer]]}}.
                 
                 <li>Given the current connections and scheduled changes, start
-                rendering <var>numberOfFrames</var> sample-frames of audio into
-                {{[[rendered buffer]]}}.
+                rendering <var>buffer</var>'s {{AudioBuffer/length}}
+                sample-frames of audio into <var>buffer</var>.
 
                 <li>For every <a>render quantum</a>, check and
                 {{OfflineAudioContext/suspend()|suspend}}
@@ -2721,21 +2809,35 @@ Methods</h4>
 
                     <ol>
                         <li>Resolve the <var ignore>promise</var> created by {{startRendering()}}
-                        with {{[[rendered buffer]]}}.
+                        with <var>buffer</var>.
+
+                        <li>Remove the <var ignore>promise</var> from
+                        {{BaseAudioContext/[[pending promises]]}}.
+
+                        <li>Remove <var>buffer</var> from {{[[rendered buffers]]}}.
+
+                        <li>Set {{[[rendered frames]]}} to the sum of
+                        {{[[rendered frames]]}} and the {{AudioBuffer/length}}
+                        of <var>buffer</var>.
+
+                        <li> if {{[[rendered frames]]}} is greater than or equal
+                        to {{OfflineAudioContext/length}},
+                        <a>Queue a control message</a> to close the
+                        {{OfflineAudioContext}}.
 
                         <li>If {{OfflineAudioContext/length}} is not
                         <code>null</code>, [=Queue a media element task=] to
                         [=fire an event=] named {{OfflineAudioContext/complete}}
                         at the {{OfflineAudioContext}} using
                         {{OfflineAudioCompletionEvent}} whose `renderedBuffer`
-                        property is set to {{[[rendered buffer]]}}.
+                        property is set to <var>buffer</var>.
 
                     </ol>
 
             </ol>
         </div>
 
-        <pre class=argumentdef for="OfflineAudioContext/startRendering()">
+        <pre class=argumentdef for="OfflineAudioContext/startRendering(chunkSize)">
             chunkSize: The number of sample-frames to render during this call.
         </pre>
         <div>
@@ -2908,7 +3010,7 @@ This specifies the options to use in constructing an
 <xmp class="idl">
 dictionary OfflineAudioContextOptions {
     unsigned long numberOfChannels = 1;
-    required unsigned long length;
+    optional unsigned long length? = null;
     required float sampleRate;
     (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
 };

--- a/index.bs
+++ b/index.bs
@@ -2500,7 +2500,7 @@ returned promise with the rendered result as an
 interface OfflineAudioContext : BaseAudioContext {
     constructor(OfflineAudioContextOptions contextOptions);
     constructor(unsigned long numberOfChannels, unsigned long length, float sampleRate);
-    Promise<AudioBuffer> startRendering(optional unsigned long chunkSize? = null);
+    Promise<AudioBuffer> startRendering(optional unsigned long? chunkSize = null);
     Promise<undefined> resume();
     Promise<undefined> suspend(double suspendTime);
     Promise<undefined> close();
@@ -2518,7 +2518,7 @@ interface OfflineAudioContext : BaseAudioContext {
 
     : <dfn>[[rendered buffers]]</dfn>
     ::
-        An ordered list of {{AudioBuffers}} that are being rendered. The initial
+        An ordered list of {{AudioBuffer}}s that are being rendered. The initial
         value is an empty list.
 
     : <dfn>[[committed frames]]</dfn>
@@ -2674,27 +2674,27 @@ Methods</h4>
 
                 <li> If {{[[committed frames]]}} is greater than or equal to
                 {{OfflineAudioContext}}'s {{OfflineAudioContext/length}}, reject
-		<var>promise</var> with {{InvalidStateError}} and abort these
-		steps.
+                <var>promise</var> with {{InvalidStateError}} and abort these
+                steps.
 
-                <lI>Let <var>bufferLength</var> be a number initialized to the
+                <li>Let <var>bufferLength</var> be a number initialized to the
                 value of the
-		{{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
 
                 <ol>
                     <li> If the {{OfflineAudioContext}}'s
-		    {{OfflineAudioContext/length}} is <code>null</code>:
+                    {{OfflineAudioContext/length}} is <code>null</code>:
                     <ol> 
                         <li> If
-			{{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                         is <code>null</code>, set <var>bufferLength</var> to
                         <a>render quantum size</a>.
                     </ol>
                     <li> Otherwise, if the {{OfflineAudioContext}}'s
-		    {{OfflineAudioContext/length}} is not <code>null</code>:
+                    {{OfflineAudioContext/length}} is not <code>null</code>:
                     <ol>
                         <li> If
-			{{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                         is not <code>null</code> and {{[[committed frames]]}} +
                         {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                         is less than the {{OfflineAudioContext}}'s
@@ -2705,11 +2705,11 @@ Methods</h4>
                     </ol>
                 </ol>
 
-                <lI>Let <var>bufferLength</var> be a number initialized to the
+                <li>Let <var>bufferLength</var> be a number initialized to the
                 result of
-		<a lt="calculate the buffer length for offline rendering">
-		calculating the buffer length for offline rendering</a> given
-		the requested <var>chunkSize</var>.
+                <a lt="calculate the buffer length for offline rendering">
+                calculating the buffer length for offline rendering</a> given
+                the requested <code>chunkSize</code>.
 
                 <li> If <var>bufferLength</var> is not a multiple of
                 <a>render quantum size</a>, round it up to the next multiple of
@@ -2743,28 +2743,23 @@ Methods</h4>
 
         <div algorithm="calculate buffer length for offline rendering">
             To <dfn dfn for>calculate the buffer length for offline rendering
-	    </dfn> given a requested <var>chunkSize</var>, the following steps
-	    MUST be performed on the <a>control thread</a>:
+            </dfn> given a requested <var>chunkSize</var>, the following steps
+            MUST be performed on the <a>control thread</a>:
             <ol>
                 <li> If the {{OfflineAudioContext}}'s
-		{{OfflineAudioContext/length}} is <code>null</code>:
+                {{OfflineAudioContext/length}} is <code>null</code>:
                 <ol> 
-                    <li> If
-		    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                    is <code>null</code>, return the <a>render quantum size</a>.
-                    <li> Otherwise, return
-                    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                    <li> If <var>chunkSize</var> is <code>null</code>, return
+                    the <a>render quantum size</a>.
+                    <li> Otherwise, return <var>chunkSize</var>.
                 </ol>
                 <li> Otherwise, if the {{OfflineAudioContext}}'s 
-		{{OfflineAudioContext/length}} is not <code>null</code>:
+                {{OfflineAudioContext/length}} is not <code>null</code>:
                 <ol>
-                    <li> If
-		    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                    is not <code>null</code> and {{[[committed frames]]}} +
-                    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                    is less than the {{OfflineAudioContext}}'s
-                    {{OfflineAudioContext/length}}, return
-                    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                    <li> If <var>chunkSize</var> is not <code>null</code> and
+                    {{[[committed frames]]}} + <var>chunkSize</var> is less than
+                    the {{OfflineAudioContext}}'s
+                    {{OfflineAudioContext/length}}, return <var>chunkSize</var>.
                     <li> Otherwise, return
                     {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
                 </ol>
@@ -2773,8 +2768,8 @@ Methods</h4>
 
         <div algorithm="begin offline rendering">
             To <dfn dfn for>begin offline rendering</dfn> for an {{AudioBuffer}}
-	    <var>buffer</var>, the following steps MUST happen on a <a>rendering
-	    thread</a> that is created for the occasion.
+            <var>buffer</var>, the following steps MUST happen on a <a>rendering
+            thread</a> that is created for the occasion.
 
             <ol>
                 
@@ -2996,7 +2991,7 @@ This specifies the options to use in constructing an
 <xmp class="idl">
 dictionary OfflineAudioContextOptions {
     unsigned long numberOfChannels = 1;
-    optional unsigned long length? = null;
+    unsigned long? length = null;
     required float sampleRate;
     (AudioContextRenderSizeCategory or unsigned long) renderSizeHint = "default";
 };

--- a/index.bs
+++ b/index.bs
@@ -2673,22 +2673,28 @@ Methods</h4>
                 steps.
 
                 <li> If {{[[committed frames]]}} is greater than or equal to
-                {{OfflineAudioContext}}'s {{OfflineAudioContext/length}}, reject <var>promise</var> with
-                {{InvalidStateError}} and abort these steps.
+                {{OfflineAudioContext}}'s {{OfflineAudioContext/length}}, reject
+		<var>promise</var> with {{InvalidStateError}} and abort these
+		steps.
 
                 <lI>Let <var>bufferLength</var> be a number initialized to the
-                value of the {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
+                value of the
+		{{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
 
                 <ol>
-                    <li> If the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is <code>null</code>:
+                    <li> If the {{OfflineAudioContext}}'s
+		    {{OfflineAudioContext/length}} is <code>null</code>:
                     <ol> 
-                        <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        <li> If
+			{{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                         is <code>null</code>, set <var>bufferLength</var> to
                         <a>render quantum size</a>.
                     </ol>
-                    <li> Otherwise, if the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is not <code>null</code>:
+                    <li> Otherwise, if the {{OfflineAudioContext}}'s
+		    {{OfflineAudioContext/length}} is not <code>null</code>:
                     <ol>
-                        <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                        <li> If
+			{{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                         is not <code>null</code> and {{[[committed frames]]}} +
                         {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                         is less than the {{OfflineAudioContext}}'s
@@ -2700,7 +2706,10 @@ Methods</h4>
                 </ol>
 
                 <lI>Let <var>bufferLength</var> be a number initialized to the
-                result of <a lt="calculate the buffer length for offline rendering">calculating the buffer length for offline rendering</a> given the requested <var>chunkSize</var>.
+                result of
+		<a lt="calculate the buffer length for offline rendering">
+		calculating the buffer length for offline rendering</a> given
+		the requested <var>chunkSize</var>.
 
                 <li> If <var>bufferLength</var> is not a multiple of
                 <a>render quantum size</a>, round it up to the next multiple of
@@ -2733,18 +2742,24 @@ Methods</h4>
         </div>
 
         <div algorithm="calculate buffer length for offline rendering">
-            To <dfn dfn for>calculate the buffer length for offline rendering</dfn> given a requested <var>chunkSize</var>, the following steps MUST be performed on the <a>control thread</a>:
+            To <dfn dfn for>calculate the buffer length for offline rendering
+	    </dfn> given a requested <var>chunkSize</var>, the following steps
+	    MUST be performed on the <a>control thread</a>:
             <ol>
-                <li> If the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is <code>null</code>:
+                <li> If the {{OfflineAudioContext}}'s
+		{{OfflineAudioContext/length}} is <code>null</code>:
                 <ol> 
-                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
-                    is <code>null</code>, return <a>render quantum size</a>.
+                    <li> If
+		    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    is <code>null</code>, return the <a>render quantum size</a>.
                     <li> Otherwise, return
                     {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}.
                 </ol>
-                <li> Otherwise, if the {{OfflineAudioContext}}'s {{OfflineAudioContext/length}} is not <code>null</code>:
+                <li> Otherwise, if the {{OfflineAudioContext}}'s 
+		{{OfflineAudioContext/length}} is not <code>null</code>:
                 <ol>
-                    <li> If {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
+                    <li> If
+		    {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                     is not <code>null</code> and {{[[committed frames]]}} +
                     {{OfflineAudioContext/startRendering(chunkSize)/chunkSize}}
                     is less than the {{OfflineAudioContext}}'s
@@ -2757,9 +2772,9 @@ Methods</h4>
         </div>
 
         <div algorithm="begin offline rendering">
-            To <dfn dfn for>begin offline rendering</dfn> for an {{AudioBuffer}} <var>buffer</var>, the following steps MUST
-            happen on a <a>rendering thread</a> that is created for the
-            occasion.
+            To <dfn dfn for>begin offline rendering</dfn> for an {{AudioBuffer}}
+	    <var>buffer</var>, the following steps MUST happen on a <a>rendering
+	    thread</a> that is created for the occasion.
 
             <ol>
                 

--- a/index.bs
+++ b/index.bs
@@ -2673,7 +2673,9 @@ Methods</h4>
                 <var>promise</var> with {{InvalidStateError}} and abort these
                 steps.
 
-                <li> If {{[[committed frames]]}} is greater than or equal to
+                <li> If the {{OfflineAudioContext}}'s
+                {{OfflineAudioContext/length}} is not <code>null</code> and
+                {{[[committed frames]]}} is greater than or equal to
                 {{OfflineAudioContext}}'s {{OfflineAudioContext/length}}, reject
                 <var>promise</var> with {{InvalidStateError}} and abort these
                 steps.
@@ -2802,17 +2804,22 @@ Methods</h4>
                         {{[[rendered frames]]}} and the {{AudioBuffer/length}}
                         of <var>buffer</var>.
 
-                        <li> if {{[[rendered frames]]}} is greater than or equal
-                        to {{OfflineAudioContext/length}},
-                        <a>Queue a control message</a> to close the
-                        {{OfflineAudioContext}}.
+                        <li> If {{OfflineAudioContext/length}} is not <code>null</code>:
 
-                        <li>If {{OfflineAudioContext/length}} is not
-                        <code>null</code>, [=Queue a media element task=] to
-                        [=fire an event=] named {{OfflineAudioContext/complete}}
-                        at the {{OfflineAudioContext}} using
-                        {{OfflineAudioCompletionEvent}} whose `renderedBuffer`
-                        property is set to <var>buffer</var>.
+                        <ol>
+                            <li> If {{[[rendered frames]]}} is greater than or
+                            equal to {{OfflineAudioContext/length}},
+                            <a>Queue a control message</a> to close the
+                            {{OfflineAudioContext}}.
+
+                            <li> [=Queue a media element task=] to
+                            [=fire an event=] named
+                            {{OfflineAudioContext/complete}} at the
+                            {{OfflineAudioContext}} using
+                            {{OfflineAudioCompletionEvent}} whose
+                            `renderedBuffer` property is set to
+                            <var>buffer</var>.
+                        </ol>
 
                     </ol>
 


### PR DESCRIPTION
This PR proposes changes to the Web Audio spec to enable rendering audio from `OfflineAudioContexts` in chunks.

Github issue: https://github.com/WebAudio/web-audio-api/issues/2445
Feature explainer: https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/OfflineAudioContext/explainer.md


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gabrielsanbrito/web-audio-api/pull/2675.html" title="Last updated on Aug 6, 2026, 2:39 AM UTC (257a31c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2675/ad5d2ed...gabrielsanbrito:257a31c.html" title="Last updated on Aug 6, 2026, 2:39 AM UTC (257a31c)">Diff</a>