### PR TITLE
Update expected-errs.txt format

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -18,116 +18,70 @@ Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
 To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
 spec:html; type:element; text:audio
 spec:epub-34; type:element; text:audio
-<{audio}>
 LINE: Multiple possible 'audio' element refs.
 Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
 To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
 spec:html; type:element; text:audio
 spec:epub-34; type:element; text:audio
-<{audio}>
 LINE: Multiple possible 'audio' element refs.
 Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
 To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
 spec:html; type:element; text:audio
 spec:epub-34; type:element; text:audio
-<{audio}>
 LINE: Multiple possible 'audio' element refs.
 Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
 To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
 spec:html; type:element; text:audio
 spec:epub-34; type:element; text:audio
-<{audio}>
 LINE: Multiple possible 'audio' element refs.
 Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
 To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
 spec:html; type:element; text:audio
 spec:epub-34; type:element; text:audio
-<{audio}>
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: Multiple possible 'audio' element refs.
 Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
 To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
 spec:html; type:element; text:audio
 spec:epub-34; type:element; text:audio
-<{audio}>
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: No 'idl' refs found for '[CC-MODE]'.
-{{ChannelCountMode/[CC-MODE]}}
 LINE: No 'idl' refs found for '[CC-INTERP]'.
-{{ChannelInterpretation/[CC-INTERP]}}
 LINE: W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one.
  ✔  Successfully generated, but fatal errors were suppressed


### PR DESCRIPTION
It seems like the format for the error messages has changed, resulting in failures when SpecGenerator tries to generate a preview for a CL.  Update to the new format.