### PR TITLE
Fix various bikeshed errors

### DIFF
--- a/audionode.include
+++ b/audionode.include
@@ -20,11 +20,11 @@
 			<td>[CC-NOTES?]
 		<tr>
 			<td>{{AudioNode/channelCountMode}}
-			<td>"{{ChannelCountMode/[CC-MODE]}}"
+			<td>"<code>[CC-MODE]</code>"
 			<td>[CC-MODE-NOTES?]
 		<tr>
 			<td>{{AudioNode/channelInterpretation}}
-			<td>"{{ChannelInterpretation/[CC-INTERP]}}"
+			<td>"<code>[CC-INTERP]</code>"
 			<td>[CC-INTERP-NOTES?]
 		<tr>
 			<td><a>tail-time</a>

--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -1,11 +1,3 @@
-LINE: Couldn't determine width and height of this image: 'images/cancel-linear.svg'
-LINE: Couldn't determine width and height of this image: 'images/cancel-setTarget.svg'
-LINE: Couldn't determine width and height of this image: 'images/cancel-setValueCurve.svg'
-LINE: Couldn't determine width and height of this image: 'images/channel-merger.svg'
-LINE: Couldn't determine width and height of this image: 'images/compression-curve.svg'
-LINE: Couldn't determine width and height of this image: 'images/dynamicscompressor-internal-graph.svg'
-LINE: Couldn't determine width and height of this image: 'images/panner-coord.svg'
-LINE: Couldn't determine width and height of this image: 'images/cone-diagram.svg'
 LINE: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block.
 LINE: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
@@ -13,75 +5,5 @@ LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(
 LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Multiple possible 'audio' element refs.
-Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
-To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
-spec:html; type:element; text:audio
-spec:epub-34; type:element; text:audio
-LINE: Multiple possible 'audio' element refs.
-Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
-To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
-spec:html; type:element; text:audio
-spec:epub-34; type:element; text:audio
-LINE: Multiple possible 'audio' element refs.
-Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
-To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
-spec:html; type:element; text:audio
-spec:epub-34; type:element; text:audio
-LINE: Multiple possible 'audio' element refs.
-Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
-To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
-spec:html; type:element; text:audio
-spec:epub-34; type:element; text:audio
-LINE: Multiple possible 'audio' element refs.
-Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
-To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
-spec:html; type:element; text:audio
-spec:epub-34; type:element; text:audio
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: Multiple possible 'audio' element refs.
-Arbitrarily chose https://html.spec.whatwg.org/multipage/media.html#audio
-To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
-spec:html; type:element; text:audio
-spec:epub-34; type:element; text:audio
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
-LINE: No 'idl' refs found for '[CC-MODE]'.
-LINE: No 'idl' refs found for '[CC-INTERP]'.
 LINE: W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one.
  ✔  Successfully generated, but fatal errors were suppressed

--- a/index.bs
+++ b/index.bs
@@ -53,6 +53,7 @@ url: https://www.w3.org/TR/mediacapture-streams/#dom-mediadevices-getusermedia; 
 <pre class=link-defaults>
 spec:webidl; type:interface; text:object
 spec:webidl; type:interface; text:Promise
+spec:html; type:element; text:audio
 </pre>
 <script>
 // Handles the loading task for MathJax library.
@@ -4184,7 +4185,7 @@ Methods</h4>
                         ramp ending at time \(t_c\) with an end value that
                         would be the value of the original ramp at time
                         \(t_c\).
-                        <img alt="Graphical representation of calling cancelAndHoldAtTime when linearRampToValueAtTime has been called at this time." src="images/cancel-linear.svg" style="height:75%;width:75%">
+                        <img alt="Graphical representation of calling cancelAndHoldAtTime when linearRampToValueAtTime has been called at this time." src="images/cancel-linear.svg" style="height:75%;width:75%" no-autosize>
 
                     2. Go to step 5.
 
@@ -4196,7 +4197,7 @@ Methods</h4>
                         event at time \(t_c\) with the value that the
                         <code>setTarget</code> would have at time
                         \(t_c\).
-                        <img alt="Graphical representation of calling cancelAndHoldAtTime when setTargetAtTime has been called at this time" src="images/cancel-setTarget.svg" style="height:75%;width:75%">
+                        <img alt="Graphical representation of calling cancelAndHoldAtTime when setTargetAtTime has been called at this time" src="images/cancel-setTarget.svg" style="height:75%;width:75%" no-autosize>
 
                     2. Go to step 5.
 
@@ -4215,7 +4216,7 @@ Methods</h4>
                             a different duration. (That would cause sampling of
                             the value curve in a slightly different way,
                             producing different results.)
-                            <img alt="Graphical representation of calling cancelAndHoldAtTime when setValueCurve has been called at this time" src="images/cancel-setValueCurve.svg" style="height:75%;width:75%">
+                            <img alt="Graphical representation of calling cancelAndHoldAtTime when setValueCurve has been called at this time" src="images/cancel-setValueCurve.svg" style="height:75%;width:75%" no-autosize>
 
                         2. Go to step 5.
 
@@ -6977,7 +6978,7 @@ output channels.
     simply combines channels in the order that they are input.
 
     <figure>
-        <img alt="channel merger" src="images/channel-merger.svg">
+        <img alt="channel merger" src="images/channel-merger.svg" no-autosize>
         <figcaption>
             A diagram of ChannelMerger
         </figcaption>
@@ -7923,7 +7924,7 @@ has the following characteristics:
 Graphically, such a curve would look something like this:
 
 <figure>
-    <img alt="Graphical representation of a compression curve" src="images/compression-curve.svg" style="width: 50%">
+    <img alt="Graphical representation of a compression curve" src="images/compression-curve.svg" style="width: 50%" no-autosize>
     <figcaption>
         A typical compression curve, showing the knee portion (soft or
         hard) as well as the threshold.
@@ -7953,7 +7954,7 @@ below:
 
 <figure>
     <img src="images/dynamicscompressor-internal-graph.svg" alt="Schema of
-    the internal graph used by the DynamicCompressorNode">
+    the internal graph used by the DynamicCompressorNode" no-autosize>
     <figcaption>
         The graph of internal {{AudioNode}}s used as part of the
         {{DynamicsCompressorNode}} processing algorithm.
@@ -12892,7 +12893,7 @@ below, with the default values shown.  The locations for the
 positions so we can see things better.
 
 <figure>
-    <img alt="panner-coord" src="images/panner-coord.svg">
+    <img alt="panner-coord" src="images/panner-coord.svg" no-autosize>
     <figcaption>
         Diagram of the coordinate system with AudioListener
         and PannerNode attributes shown.
@@ -13209,7 +13210,7 @@ is, the inner cone extends 25 deg on each side of the direction
 vector.  Similarly, the outer cone is 60 deg on each side.
 
 <figure>
-    <img alt="cone-diagram" src="images/cone-diagram.svg">
+    <img alt="cone-diagram" src="images/cone-diagram.svg" no-autosize>
     <figcaption>
         Cone angles for a source in relationship to the source orientation and the listeners position and orientation.
     </figcaption>


### PR DESCRIPTION
This pull request fixes the following errors:
* Ambiguous audio reference
* Failed ref lookup for CC-MODE and CC-INTERP
* Image size


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 11, 2026, 10:42 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmjwilson-google%2Fweb-audio-api%2F5c37fce550a950106ad44bb8d4e187b6835274bd%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "4581:9",
        "messageType": "warning",
        "text": "At least one <img> doesn't have its size set (<img bs-line-number=\"4581:9\" alt=\"AudioParam automation clipping to nominal\" src=\"images/audioparam-automation-clipping.png\">), but given the type of input document, Bikeshed can't figure out what the size should be.\nEither set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute."
    },
    {
        "lineNum": "2574:9",
        "messageType": "fatal",
        "text": "Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block."
    },
    {
        "lineNum": "3687:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3687:9",
        "messageType": "fatal",
        "text": "Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3788:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3801:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3816:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3816:9",
        "messageType": "fatal",
        "text": "Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "13392:1",
        "messageType": "warning",
        "text": "W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20WebAudio/web-audio-api%232678.)._

</details>
