### PR TITLE
Add Slack register link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the problem is in the spec.
 
 If you need help on how to use WebAudio, ask on your favorite forum or consider visiting
-the [WebAudio Slack Channel](https://web-audio.slack.com/) or
+the [WebAudio Slack Channel](https://web-audio.slack.com/) (register [here](https://join.slack.com/t/web-audio/shared_invite/zt-3q3jencut-i1Z77wQrQCRo2hmZPTQkPA)) or
 [StackOverflow](https://stackoverflow.com/).
 
 If it's really an implementation bug, considering filing an issue for your browser at


### PR DESCRIPTION
Thanks to @halfbyte we have a new register link for the Slack channel. This PR is the follow-up to https://github.com/chrisguttandin/web-audio-api/commit/1203a54e3b979391db80a6790ed45e055684f9ea to add it back.