### PR TITLE
docs: fix CONTRIBUTING typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to contribute
 
-This repository containes the current Web Audio API _standard document_, developed by the Audio Working Group at the W3C. There are _multiple implementations_ of the Web Audio API standard.
+This repository contains the current Web Audio API _standard document_, developed by the Audio Working Group at the W3C. There are _multiple implementations_ of the Web Audio API standard.
 
 If you're about to open an issue about a bug in a particular implementation, please file a ticket in the corresponding implementation bug tracker instead:
 
@@ -8,7 +8,7 @@ If you're about to open an issue about a bug in a particular implementation, ple
 - Blink (Chrome, Chromium, Electron apps, etc.): https://new.crbug.com/ (Google account needed).
 - Gecko (Firefox): https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&component=Web%20Audio (GitHub or Mozilla Bugzilla account needed).
 
-Testing the same Web Audio API code in multiple implementations can be a quick way to check if an implementation has a bug. However, it has happened that different implementation have the same bug, so it's best to read the [standard document](https://webaudio.github.io/web-audio-api/), and to check what _should_ happen.
+Testing the same Web Audio API code in multiple implementations can be a quick way to check if an implementation has a bug. However, it has happened that different implementations have the same bug, so it's best to read the [standard document](https://webaudio.github.io/web-audio-api/), and to check what _should_ happen.
 
 Feature requests are welcome, but a quick search in the [opened and closed issues](https://github.com/WebAudio/web-audio-api/issues) is welcome to avoid duplicates.
 
@@ -23,7 +23,7 @@ To use it via the HTTP API, run:
 curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 -F output=err -o err && cat err | sed -E 's/\\033\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' | diff -u - expected-errs.txt
 ```
 
-and preview your changes by doing: 
+and preview your changes by doing:
 ```
 curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html
 ```


### PR DESCRIPTION
## Summary

- Fix typos in CONTRIBUTING.md.
- Remove trailing whitespace from the Bikeshed preview instruction line.

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] Manually reviewed the `CONTRIBUTING.md` diff