### PR TITLE
Split privacy and security into separate sections

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -5,5 +5,4 @@ LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(
 LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
 LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: W3C policy requires Privacy Considerations and Security Considerations to be separate sections, but you appear to have them combined into one.
  ✔  Successfully generated, but fatal errors were suppressed

--- a/index.bs
+++ b/index.bs
@@ -13387,10 +13387,10 @@ time-constraints. It can also be caused by the audio DSP trying to do
 more work than is possible in real-time given the CPU's speed.
 
 
-<!-- Big Text: priv-sec -->
+<!-- Big Text: privacy -->
 
-<h2 id="priv-sec">
-Security and Privacy Considerations</h2>
+<h2 id="privacy-considerations">
+Privacy Considerations</h2>
 
 Per the [[security-privacy-questionnaire#questions]]:
 
@@ -13405,24 +13405,24 @@ Per the [[security-privacy-questionnaire#questions]]:
     fingerprinting analysis is done -->
 
 
-2. Does this specification deal with high-value data?
+1. Does this specification deal with high-value data?
 
     No. Credit card information and the like is not used in Web Audio.
     It is possible to use Web Audio to process or analyze voice data,
     which might be a privacy concern, but access to the user's
     microphone is permission-based via {{getUserMedia()}}.
 
-3. Does this specification introduce new state for an origin that
+1. Does this specification introduce new state for an origin that
     persists across browsing sessions?
 
     No. AudioWorklet does not persist across browsing sessions.
 
-4. Does this specification expose persistent, cross-origin state to
+1. Does this specification expose persistent, cross-origin state to
     the web?
 
     Yes, the supported audio sample rate(s) and the output device channel count are exposed. See {{AudioContext}}.
 
-5. Does this specification expose any other data to an origin that it
+1. Does this specification expose any other data to an origin that it
     doesn’t currently have access to?
 
     Yes. When giving various information on available
@@ -13515,18 +13515,12 @@ Per the [[security-privacy-questionnaire#questions]]:
     (stereo).  Stereo is by far the most common number of
     channels.
 
-6. Does this specification enable new script execution/loading
-    mechanisms?
-
-    No. It does use the [[HTML]] script execution method,
-    defined in that specification.
-
-7. Does this specification allow an origin access to a user’s
+1. Does this specification allow an origin access to a user’s
     location?
 
     No.
 
-8. Does this specification allow an origin access to sensors on a
+1. Does this specification allow an origin access to sensors on a
     user’s device?
 
     Not directly. Currently, audio input is not specified in this
@@ -13545,7 +13539,7 @@ Per the [[security-privacy-questionnaire#questions]]:
     enable communication between otherwise partitioned contexts in one 
     browser.
 
-9. Does this specification allow an origin access to aspects of a
+1. Does this specification allow an origin access to aspects of a
     user’s local computing environment?
 
 <!-- from f2f -->
@@ -13566,7 +13560,41 @@ Per the [[security-privacy-questionnaire#questions]]:
     requiring higher-end devices to use a lower rate would merely result in
     Web Audio being labelled as unsuitable for professional use.
 
-10. Does this specification allow an origin access to other devices?
+1.  Does this specification expose temporary identifiers to the web?
+
+    No.
+
+1.  Does this specification distinguish between behavior in first-party
+    and third-party contexts?
+
+    No.
+
+1.  How should this specification work in the context of a user agent’s
+    "incognito" mode?
+
+    Not differently.
+
+1.  Does this specification persist data to a user’s local device?
+
+    No.
+
+1.  Does this specification have a "Security Considerations" and
+    "Privacy Considerations" section?
+
+    Yes (you are reading it).
+
+<h2 id="security-considerations">
+Security Considerations</h2>
+
+Per the [[security-privacy-questionnaire#questions]]:
+
+1. Does this specification enable new script execution/loading
+    mechanisms?
+
+    No. It does use the [[HTML]] script execution method,
+    defined in that specification.
+
+1.  Does this specification allow an origin access to other devices?
 
     It typically does not allow access to other networked devices (an
     exception in a high-end recording studio might be Dante networked
@@ -13591,7 +13619,7 @@ Per the [[security-privacy-questionnaire#questions]]:
     20kHz to 24kHz band (but it is easier to avoid phase ripple
     errors in the passband).
 
-11. Does this specification allow an origin some measure of control
+1.  Does this specification allow an origin some measure of control
     over a user agent’s native UI?
 
     If the UI has audio components, such as a voice assistant or screenreader,
@@ -13600,30 +13628,7 @@ Per the [[security-privacy-questionnaire#questions]]:
     This possibility also exists with HTML, through
     the &lt;audio&gt; element.
 
-12. Does this specification expose temporary identifiers to the web?
-
-    No.
-
-13. Does this specification distinguish between behavior in first-party
-    and third-party contexts?
-
-    No.
-
-14. How should this specification work in the context of a user agent’s
-    "incognito" mode?
-
-    Not differently.
-
-15. Does this specification persist data to a user’s local device?
-
-    No.
-
-16. Does this specification have a "Security Considerations" and
-    "Privacy Considerations" section?
-
-    Yes (you are reading it).
-
-17. Does this specification allow downgrading default security
+1.  Does this specification allow downgrading default security
     characteristics?
 
     No.


### PR DESCRIPTION
Current W3C policy requires these to be separate sections.  Split them, without changing the content.

Note that this section is now out of sync with the questionnaire, but if desired I think that should be addressed in a separate change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 422 Unprocessable Entity :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 21, 2026, 10:33 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fmjwilson-google%2Fweb-audio-api%2F0536f7aae35075afb820d9357ffa796bba25ac34%2Findex.bs&force=1&md-warning=not%20ready)

**Error output:**

```json
[
    {
        "lineNum": "4581:9",
        "messageType": "warning",
        "text": "At least one <img> doesn't have its size set (<img bs-line-number=\"4581:9\" alt=\"AudioParam automation clipping to nominal\" src=\"images/audioparam-automation-clipping.png\">), but given the type of input document, Bikeshed can't figure out what the size should be.\nEither set 'width'/'height' manually, or opt out of auto-detection by setting the 'no-autosize' attribute."
    },
    {
        "lineNum": "2574:9",
        "messageType": "fatal",
        "text": "Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block."
    },
    {
        "lineNum": "3687:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3687:9",
        "messageType": "fatal",
        "text": "Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3788:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3801:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3816:9",
        "messageType": "fatal",
        "text": "Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": "3816:9",
        "messageType": "fatal",
        "text": "Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block."
    },
    {
        "lineNum": null,
        "messageType": "failure",
        "text": "Did not generate, due to errors exceeding the allowed error level."
    }
]
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20WebAudio/web-audio-api%232686.)._

</details>
