### PR TITLE
Speculative pr-preview fix

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -2,6 +2,6 @@
     "src_file": "index.bs",
     "type": "bikeshed",
     "params": {
-        "force": 1
+        "die-on": "nothing"
     }
 }


### PR DESCRIPTION
In https://github.com/tobie/pr-preview/pull/172, spec-generator migrated from using the api.csswg.org/bikeshed service to the w3.org/publications/spec-generator for generating Bikeshed documents. The HTTP APIs very similar but not the same. The Web Audio CI relies on setting the `force` param to 1, which is not part of the API surface of the new service. 

The same functionality can be achieved in the new service by setting the `die-on` parameter to `"nothing"`. More info [here](https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator).

Manually validated by:
1. pr-preview fails in https://github.com/WebAudio/web-audio-api/pull/2675
2. The generated URL is https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fgabrielsanbrito%2Fweb-audio-api%2F857f48a208522456fd05522a02424b73ce858e7b%2Findex.bs&force=1&md-warning=not%20ready
3. If we switch "force=1" for "die-on=nothing" it works: https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fgabrielsanbrito%2Fweb-audio-api%2F857f48a208522456fd05522a02424b73ce858e7b%2Findex.bs&die-on=nothing&md-warning=not%20ready