### PR TITLE
Editorial: Removing algorithm section for buffer length calculation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2708,12 +2708,6 @@ Methods</h4>
                     </ol>
                 </ol>
 
-                <li>Let <var>bufferLength</var> be a number initialized to the
-                result of
-                <a lt="calculate the buffer length for offline rendering">
-                calculating the buffer length for offline rendering</a> given
-                the requested <code>chunkSize</code>.
-
                 <li> If <var>bufferLength</var> is not a multiple of
                 <a>render quantum size</a>, round it up to the next multiple of
                 the <a>render quantum size</a>.
@@ -2741,31 +2735,6 @@ Methods</h4>
                 <li>Append <var>promise</var> to {{BaseAudioContext/[[pending promises]]}}.
 
                 <li>Return <var>promise</var>.
-            </ol>
-        </div>
-
-        <div algorithm="calculate buffer length for offline rendering">
-            To <dfn dfn for>calculate the buffer length for offline rendering
-            </dfn> given a requested <var>chunkSize</var>, the following steps
-            MUST be performed on the <a>control thread</a>:
-            <ol>
-                <li> If the {{OfflineAudioContext}}'s
-                {{OfflineAudioContext/length}} is <code>null</code>:
-                <ol> 
-                    <li> If <var>chunkSize</var> is <code>null</code>, return
-                    the <a>render quantum size</a>.
-                    <li> Otherwise, return <var>chunkSize</var>.
-                </ol>
-                <li> Otherwise, if the {{OfflineAudioContext}}'s 
-                {{OfflineAudioContext/length}} is not <code>null</code>:
-                <ol>
-                    <li> If <var>chunkSize</var> is not <code>null</code> and
-                    {{[[committed frames]]}} + <var>chunkSize</var> is less than
-                    the {{OfflineAudioContext}}'s
-                    {{OfflineAudioContext/length}}, return <var>chunkSize</var>.
-                    <li> Otherwise, return
-                    {{OfflineAudioContext/length}} - {{[[committed frames]]}}.
-                </ol>
             </ol>
         </div>
 


### PR DESCRIPTION
This PR removes the buffer length calculation algorithm for `OfflineAudioContext.startRendering()` and let the steps be inlined within the `startRendering` algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gabrielsanbrito/web-audio-api/pull/2691.html" title="Last updated on Aug 6, 2026, 4:41 PM UTC (a4140e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2691/bfc7143...gabrielsanbrito:a4140e8.html" title="Last updated on Aug 6, 2026, 4:41 PM UTC (a4140e8)">Diff</a>