### PR TITLE
Add Implementation Report and populate Change Log for WD publication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,7 @@ Former Editor: Raymond Toy (until Oct 2018)
 Former Editor: Chris Wilson (Until Jan 2016)
 Former Editor: Chris Rogers (Until Aug 2013)
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/webaudio
+Implementation Report: https://wpt.fyi/results/webaudio?label=experimental&label=master&aligned
 Repository: WebAudio/web-audio-api
 Abstract: This specification describes a high-level Web <abbr title="Application Programming Interface">API</abbr>
     for processing and synthesizing audio in web applications.
@@ -13879,6 +13880,68 @@ class Vec3 {
 
 <h2 id="changes">
 Change Log</h2>
+
+<p>
+    Changes since the
+    <a href="https://www.w3.org/TR/2024/WD-webaudio-1.1-20241105/">First Public
+    Working Draft (05 November 2024)</a>:
+</p>
+
+<ul>
+    <li>
+        Added incremental/chunked offline rendering support via the optional
+        <code>chunkSize</code> parameter on
+        {{OfflineAudioContext/startRendering()}} and made
+        {{OfflineAudioContextOptions/length}} optional (<a
+        href="https://github.com/WebAudio/web-audio-api/pull/2675"
+        >PR #2675</a>).
+    </li>
+    <li>
+        Added the {{AudioContextState/"interrupted"}} state to
+        {{AudioContextState}} enum, specified algorithm steps for hardware
+        interruptions and resumption, and updated the {{AudioContext}}
+        constructor to fire an error event rather than throwing synchronously
+        for invalid sink IDs (<a
+        href="https://github.com/WebAudio/web-audio-api/pull/2633"
+        >PR #2633</a>).
+    </li>
+    <li>
+        Widened the required supported sample rate range to [3000, 768000] Hz
+        inclusive, and added a security/privacy note regarding covert channels
+        (<a href="https://github.com/WebAudio/web-audio-api/pull/2657"
+        >PR #2657</a>).
+    </li>
+    <li>
+        Defined supported range constraints for {{BaseAudioContext/[[render
+        quantum size]]}} and clarified {{AudioContextOptions/renderSizeHint}}
+        handling (<a
+        href="https://github.com/WebAudio/web-audio-api/pull/2667"
+        >PR #2667</a>).
+    </li>
+    <li>
+        Clarified monotonicity and precision requirements for
+        {{BaseAudioContext/currentTime}} (<a
+        href="https://github.com/WebAudio/web-audio-api/pull/2617"
+        >PR #2617</a>).
+    </li>
+    <li>
+        Separated Privacy Considerations and Security Considerations into
+        distinct sections per W3C publication policy (<a
+        href="https://github.com/WebAudio/web-audio-api/pull/2686"
+        >PR #2686</a>).
+    </li>
+    <li>
+        Updated the community Slack workspace registration link (<a
+        href="https://github.com/WebAudio/web-audio-api/pull/2679"
+        >PR #2679</a>).
+    </li>
+    <li>
+        Converted code examples to <code>&lt;xmp&gt;</code> blocks, modernized
+        JavaScript syntax across examples (replacing <code>var</code> with
+        <code>let</code>/<code>const</code>), resolved cross-specification
+        linking ambiguities, and improved diagram accessibility.
+    </li>
+</ul>
 
 <h2 id="acks">
 Acknowledgements</h2>

--- a/index.bs
+++ b/index.bs
@@ -13881,67 +13881,33 @@ class Vec3 {
 <h2 id="changes">
 Change Log</h2>
 
-<p>
-    Changes since the
-    <a href="https://www.w3.org/TR/2024/WD-webaudio-1.1-20241105/">First Public
-    Working Draft (05 November 2024)</a>:
-</p>
-
-<ul>
-    <li>
-        Added incremental/chunked offline rendering support via the optional
-        <code>chunkSize</code> parameter on
-        {{OfflineAudioContext/startRendering()}} and made
-        {{OfflineAudioContextOptions/length}} optional (<a
-        href="https://github.com/WebAudio/web-audio-api/pull/2675"
-        >PR #2675</a>).
-    </li>
-    <li>
-        Added the {{AudioContextState/"interrupted"}} state to
-        {{AudioContextState}} enum, specified algorithm steps for hardware
-        interruptions and resumption, and updated the {{AudioContext}}
-        constructor to fire an error event rather than throwing synchronously
-        for invalid sink IDs (<a
-        href="https://github.com/WebAudio/web-audio-api/pull/2633"
-        >PR #2633</a>).
-    </li>
-    <li>
-        Widened the required supported sample rate range to [3000, 768000] Hz
-        inclusive, and added a security/privacy note regarding covert channels
-        (<a href="https://github.com/WebAudio/web-audio-api/pull/2657"
-        >PR #2657</a>).
-    </li>
-    <li>
-        Defined supported range constraints for {{BaseAudioContext/[[render
-        quantum size]]}} and clarified {{AudioContextOptions/renderSizeHint}}
-        handling (<a
-        href="https://github.com/WebAudio/web-audio-api/pull/2667"
-        >PR #2667</a>).
-    </li>
-    <li>
-        Clarified monotonicity and precision requirements for
-        {{BaseAudioContext/currentTime}} (<a
-        href="https://github.com/WebAudio/web-audio-api/pull/2617"
-        >PR #2617</a>).
-    </li>
-    <li>
-        Separated Privacy Considerations and Security Considerations into
-        distinct sections per W3C publication policy (<a
-        href="https://github.com/WebAudio/web-audio-api/pull/2686"
-        >PR #2686</a>).
-    </li>
-    <li>
-        Updated the community Slack workspace registration link (<a
-        href="https://github.com/WebAudio/web-audio-api/pull/2679"
-        >PR #2679</a>).
-    </li>
-    <li>
-        Converted code examples to <code>&lt;xmp&gt;</code> blocks, modernized
-        JavaScript syntax across examples (replacing <code>var</code> with
-        <code>let</code>/<code>const</code>), resolved cross-specification
-        linking ambiguities, and improved diagram accessibility.
-    </li>
-</ul>
+<h3 id="changes-2024-11-05">
+  Since First Public Working Draft of 05 November 2024
+</h3>
+<!-- Last updated: 2026-08-27 -->
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2688">PR 2688</a>:
+   Speculative PR preview fix
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2686">PR 2686</a>:
+   Split Privacy Considerations and Security Considerations into separate
+   sections
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2679">PR 2679</a>:
+   Add Slack register link
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2676">PR 2676</a>:
+   Update expected-errs.txt format
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2675">PR 2675</a>:
+   OfflineAudioContext incremental/chunked rendering
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2667">PR 2667</a>:
+   Specify render quantum size range constraints and renderSizeHint handling
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2657">PR 2657</a>:
+   Require implementations support sample rate range [3000, 768000] Hz
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2656">PR 2656</a>:
+   Fix expected-errs.txt
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2654">PR 2654</a>:
+   Fix fundamental typo
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2633">PR 2633</a>:
+   Add interrupted state and error handling for sink ID
+ * <a href="https://github.com/WebAudio/web-audio-api/pull/2617">PR 2617</a>:
+   Revise wording for currentTime
 
 <h2 id="acks">
 Acknowledgements</h2>

--- a/index.bs
+++ b/index.bs
@@ -13885,29 +13885,53 @@ Change Log</h2>
   Since First Public Working Draft of 05 November 2024
 </h3>
 <!-- Last updated: 2026-08-27 -->
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2688">PR 2688</a>:
-   Speculative PR preview fix
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2686">PR 2686</a>:
-   Split Privacy Considerations and Security Considerations into separate
-   sections
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2679">PR 2679</a>:
-   Add Slack register link
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2676">PR 2676</a>:
-   Update expected-errs.txt format
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2675">PR 2675</a>:
-   OfflineAudioContext incremental/chunked rendering
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2667">PR 2667</a>:
-   Specify render quantum size range constraints and renderSizeHint handling
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2657">PR 2657</a>:
-   Require implementations support sample rate range [3000, 768000] Hz
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2656">PR 2656</a>:
-   Fix expected-errs.txt
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2654">PR 2654</a>:
-   Fix fundamental typo
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2633">PR 2633</a>:
-   Add interrupted state and error handling for sink ID
- * <a href="https://github.com/WebAudio/web-audio-api/pull/2617">PR 2617</a>:
-   Revise wording for currentTime
+<ul>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2688">PR 2688</a>:
+    Speculative PR preview fix
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2686">PR 2686</a>:
+    Split Privacy Considerations and Security Considerations into separate
+    sections
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2679">PR 2679</a>:
+    Add Slack register link
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2676">PR 2676</a>:
+    Update expected-errs.txt format
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2675">PR 2675</a>:
+    OfflineAudioContext incremental/chunked rendering
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2667">PR 2667</a>:
+    Specify render quantum size range constraints and renderSizeHint handling
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2657">PR 2657</a>:
+    Require implementations support sample rate range [3000, 768000] Hz
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2656">PR 2656</a>:
+    Fix expected-errs.txt
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2654">PR 2654</a>:
+    Fix fundamental typo
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2633">PR 2633</a>:
+    Add interrupted state and error handling for sink ID
+  </li>
+  <li>
+    <a href="https://github.com/WebAudio/web-audio-api/pull/2617">PR 2617</a>:
+    Revise wording for currentTime
+  </li>
+</ul>
 
 <h2 id="acks">
 Acknowledgements</h2>


### PR DESCRIPTION
- Add Implementation Report metadata pointing to WPT results.
- Populate Change Log with landed changes since First Public Working Draft (2024-11-05), linking to relevant pull requests.

Fixes #2692

cc @padenot


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/pull/2694.html" title="Last updated on Aug 27, 2026, 10:32 PM UTC (c864ef8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebAudio/web-audio-api/2694/bfc7143...c864ef8.html" title="Last updated on Aug 27, 2026, 10:32 PM UTC (c864ef8)">Diff</a>