### PR TITLE
Use HTML table for overloaded methods to resolve Bikeshed fatal errors

### DIFF
--- a/expected-errs.txt
+++ b/expected-errs.txt
@@ -1,8 +1,0 @@
-LINE: Can't find the 'contextOptions' argument of method 'OfflineAudioContext/constructor(numberOfChannels, length, sampleRate)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'input' argument of method 'AudioNode/connect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'destinationNode' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
-LINE: Can't find the 'input' argument of method 'AudioNode/disconnect(destinationParam, output)' in the argumentdef block.
- ✔  Successfully generated, but fatal errors were suppressed

--- a/index.bs
+++ b/index.bs
@@ -2596,9 +2596,32 @@ Constructors</h4>
                 |serializedRenderingSidePort|.
         </div>
 
-        <pre class=argumentdef for="OfflineAudioContext/constructor(contextOptions)">
-        contextOptions: The initial parameters needed to construct this context.
-        </pre>
+        <table class="data">
+            <caption>Arguments for the
+                {{OfflineAudioContext/constructor(contextOptions)}} method.
+            </caption>
+            <thead>
+                <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th style="text-align:center">Nullable</th>
+                    <th style="text-align:center">Optional</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><dfn argument
+                        for="OfflineAudioContext/constructor(contextOptions)">
+                        contextOptions</dfn></td>
+                    <td>{{OfflineAudioContextOptions}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The initial parameters needed to construct this
+                        context.</td>
+                </tr>
+            </tbody>
+        </table>
 
     : <dfn>OfflineAudioContext(numberOfChannels, length, sampleRate)</dfn>
     ::
@@ -3838,11 +3861,79 @@ Methods</h4>
         This method returns <code>destination</code>
         {{AudioNode}} object.
 
-        <pre class=argumentdef for="AudioNode/connect(destinationNode, output, input)">
-            destinationNode: The <code>destination</code> parameter is the {{AudioNode}} to connect to. <span class="synchronous">If the <code>destination</code> parameter is an {{AudioNode}} that has been created using another {{AudioContext}}, an {{InvalidAccessError}} MUST be thrown</span>. That is, {{AudioNode}}s cannot be shared between {{AudioContext}}s. Multiple {{AudioNode}}s can be connected to the same {{AudioNode}}, this is described in [[#channel-up-mixing-and-down-mixing|Channel Upmixing and down mixing]] section.
-            output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to connect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span> It is possible to connect an {{AudioNode}} output to more than one input with multiple calls to connect(). Thus, "fan-out" is supported.
-            input:  The <code>input</code> parameter is an index describing which input of the destination {{AudioNode}} to connect to. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span> It is possible to connect an {{AudioNode}} to another {{AudioNode}} which creates a <dfn dfn for>cycle</dfn>: an {{AudioNode}} may connect to another {{AudioNode}}, which in turn connects back to the input or {{AudioParam}} of the first {{AudioNode}}.
-        </pre>
+        <table class="data">
+            <caption>Arguments for the
+                {{AudioNode/connect(destinationNode, output, input)}} method.
+            </caption>
+            <thead>
+                <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th style="text-align:center">Nullable</th>
+                    <th style="text-align:center">Optional</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><dfn argument
+                        for="AudioNode/connect(destinationNode, output, input)">
+                        destinationNode</dfn></td>
+                    <td>{{AudioNode}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>destination</code> parameter is the
+                        {{AudioNode}} to connect to. <span class="synchronous">
+                        If the <code>destination</code> parameter is an
+                        {{AudioNode}} that has been created using another
+                        {{AudioContext}}, an {{InvalidAccessError}} MUST be
+                        thrown</span>. That is, {{AudioNode}}s cannot be
+                        shared between {{AudioContext}}s. Multiple
+                        {{AudioNode}}s can be connected to the same
+                        {{AudioNode}}, this is described in
+                        [[#channel-up-mixing-and-down-mixing|Channel Upmixing
+                        and down mixing]] section.</td>
+                </tr>
+                <tr>
+                    <td><dfn argument
+                        for="AudioNode/connect(destinationNode, output, input)">
+                        output</dfn></td>
+                    <td>{{unsigned long}}</td>
+                    <td style="text-align:center"><span
+                        class="no">✘</span></td>
+                    <td style="text-align:center"><span
+                        class="yes">✔</span></td>
+                    <td>The <code>output</code> parameter is an index
+                        describing which output of the {{AudioNode}} from which
+                        to connect. <span class="synchronous">If this parameter
+                        is out-of-bounds, an {{IndexSizeError}} exception MUST
+                        be thrown.</span> It is possible to connect an
+                        {{AudioNode}} output to more than one input with
+                        multiple calls to connect(). Thus, "fan-out" is
+                        supported.</td>
+                </tr>
+                <tr>
+                    <td><dfn argument
+                        for="AudioNode/connect(destinationNode, output, input)">
+                        input</dfn></td>
+                    <td>{{unsigned long}}</td>
+                    <td style="text-align:center"><span
+                        class="no">✘</span></td>
+                    <td style="text-align:center"><span
+                        class="yes">✔</span></td>
+                    <td>The <code>input</code> parameter is an index describing
+                        which input of the destination {{AudioNode}} to connect
+                        to. <span class="synchronous">If this parameter is
+                        out-of-bounds, an {{IndexSizeError}} exception MUST be
+                        thrown.</span> It is possible to connect an
+                        {{AudioNode}} to another {{AudioNode}} which creates a
+                        <dfn dfn for>cycle</dfn>: an {{AudioNode}} may connect
+                        to another {{AudioNode}}, which in turn connects back
+                        to the input or {{AudioParam}} of the first
+                        {{AudioNode}}.</td>
+                </tr>
+            </tbody>
+        </table>
 
         <div>
             <em>Return type:</em> {{AudioNode}}
@@ -3939,9 +4030,37 @@ Methods</h4>
         that go to a specific destination
         {{AudioNode}}.
 
-        <pre class=argumentdef for="AudioNode/disconnect(destinationNode)">
-            destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. It disconnects all outgoing connections to the given <code>destinationNode</code>. <span class="synchronous">If there is no connection to the <code>destinationNode</code>, an {{InvalidAccessError}} exception MUST be thrown.</span>
-        </pre>
+        <table class="data">
+            <caption>Arguments for the
+                {{AudioNode/disconnect(destinationNode)}} method.
+            </caption>
+            <thead>
+                <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th style="text-align:center">Nullable</th>
+                    <th style="text-align:center">Optional</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><dfn argument
+                        for="AudioNode/disconnect(destinationNode)">
+                        destinationNode</dfn></td>
+                    <td>{{AudioNode}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>destinationNode</code> parameter is the
+                        {{AudioNode}} to disconnect. It disconnects all outgoing
+                        connections to the given <code>destinationNode</code>.
+                        <span class="synchronous">If there is no connection to
+                        the <code>destinationNode</code>, an
+                        {{InvalidAccessError}} exception MUST be thrown.</span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
         <div>
             <em>Return type:</em> {{undefined}}
         </div>
@@ -3952,10 +4071,49 @@ Methods</h4>
         {{AudioNode}} from any and all inputs of some
         destination {{AudioNode}}.
 
-        <pre class=argumentdef for="AudioNode/disconnect(destinationNode, output)">
-            destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationNode</code> from the given output, an {{InvalidAccessError}} exception MUST be thrown.</span>
-            output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to disconnect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
-        </pre>
+        <table class="data">
+            <caption>Arguments for the
+                {{AudioNode/disconnect(destinationNode, output)}} method.
+            </caption>
+            <thead>
+                <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th style="text-align:center">Nullable</th>
+                    <th style="text-align:center">Optional</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><dfn argument
+                        for="AudioNode/disconnect(destinationNode, output)">
+                        destinationNode</dfn></td>
+                    <td>{{AudioNode}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>destinationNode</code> parameter is the
+                        {{AudioNode}} to disconnect. <span class="synchronous">
+                        If there is no connection to the
+                        <code>destinationNode</code> from the given output, an
+                        {{InvalidAccessError}} exception MUST be thrown.</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td><dfn argument
+                        for="AudioNode/disconnect(destinationNode, output)">
+                        output</dfn></td>
+                    <td>{{unsigned long}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>output</code> parameter is an index
+                        describing which output of the {{AudioNode}} from which
+                        to disconnect. <span class="synchronous">If this
+                        parameter is out-of-bounds, an {{IndexSizeError}}
+                        exception MUST be thrown.</span></td>
+                </tr>
+            </tbody>
+        </table>
 
         <div>
             <em>Return type:</em> {{undefined}}
@@ -3967,11 +4125,62 @@ Methods</h4>
         {{AudioNode}} from a specific input of some
         destination {{AudioNode}}.
 
-        <pre class=argumentdef for="AudioNode/disconnect(destinationNode, output, input)">
-            destinationNode: The <code>destinationNode</code> parameter is the {{AudioNode}} to disconnect. <span class="synchronous">If there is no connection to the <code>destinationNode</code> from the given output to the given input, an {{InvalidAccessError}} exception MUST be thrown.</span>
-            output: The <code>output</code> parameter is an index describing which output of the {{AudioNode}} from which to disconnect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
-            input: The <code>input</code> parameter is an index describing which input of the destination {{AudioNode}} to disconnect. <span class="synchronous">If this parameter is out-of-bounds, an {{IndexSizeError}} exception MUST be thrown.</span>
-        </pre>
+        <table class="data">
+            <caption>Arguments for the
+                {{AudioNode/disconnect(destinationNode, output, input)}} method.
+            </caption>
+            <thead>
+                <tr>
+                    <th>Parameter</th>
+                    <th>Type</th>
+                    <th style="text-align:center">Nullable</th>
+                    <th style="text-align:center">Optional</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><dfn argument for=
+                        "AudioNode/disconnect(destinationNode, output, input)">
+                        destinationNode</dfn></td>
+                    <td>{{AudioNode}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>destinationNode</code> parameter is the
+                        {{AudioNode}} to disconnect. <span class="synchronous">
+                        If there is no connection to the
+                        <code>destinationNode</code> from the given output to
+                        the given input, an {{InvalidAccessError}} exception
+                        MUST be thrown.</span></td>
+                </tr>
+                <tr>
+                    <td><dfn argument for=
+                        "AudioNode/disconnect(destinationNode, output, input)">
+                        output</dfn></td>
+                    <td>{{unsigned long}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>output</code> parameter is an index
+                        describing which output of the {{AudioNode}} from which
+                        to disconnect. <span class="synchronous">If this
+                        parameter is out-of-bounds, an {{IndexSizeError}}
+                        exception MUST be thrown.</span></td>
+                </tr>
+                <tr>
+                    <td><dfn argument for=
+                        "AudioNode/disconnect(destinationNode, output, input)">
+                        input</dfn></td>
+                    <td>{{unsigned long}}</td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td style="text-align:center"><span class="no">✘</span></td>
+                    <td>The <code>input</code> parameter is an index describing
+                        which input of the destination {{AudioNode}} to
+                        disconnect. <span class="synchronous">If this parameter
+                        is out-of-bounds, an {{IndexSizeError}} exception MUST
+                        be thrown.</span></td>
+                </tr>
+            </tbody>
+        </table>
 
         <div>
             <em>Return type:</em> {{undefined}}


### PR DESCRIPTION
Bikeshed currently fails with fatal errors on method overloads when using the `<pre class=argumentdef>` syntax (speced/bikeshed#1192).

This replaces the argumentdef blocks for earlier overloads of:
- `OfflineAudioContext constructor(contextOptions)`
- `AudioNode.connect(destinationNode, output, input)`
- `AudioNode.disconnect(destinationNode)`
- `AudioNode.disconnect(destinationNode, output)`
- `AudioNode.disconnect(destinationNode, output, input)`

with explicit HTML `<table class="data">` definitions. This produces identical output while bypassing Bikeshed's `argumentdef` overload bug, clearing all fatal errors and allowing clean TR autopublishing.

Also clears expected-errs.txt as the build is now 100% error-free.